### PR TITLE
force websocket for IE11 and Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -989,11 +989,12 @@
             }
         },
         "@cognigy/webchat-client": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@cognigy/webchat-client/-/webchat-client-4.0.3.tgz",
-            "integrity": "sha512-21sk6OoSV34C29AQV8d8is6wrJWUhsDKanGvep70CWgWkPPABywC3/pC1PHLh5ZEMpHk6+sOu2nnIVe57YT3xg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@cognigy/webchat-client/-/webchat-client-4.0.4.tgz",
+            "integrity": "sha512-5vtLiyoN55vEq0DMTqoGZdkwuI+NL7CZqOxfO5MnBa+yY82UmdXxWEu0edHGm8VUdYd8hJpvK8FKmOb9v1SzSQ==",
             "requires": {
-                "@cognigy/socket-client": "4.0.0"
+                "@cognigy/socket-client": "4.0.0",
+                "detect-browser": "^4.5.1"
             }
         },
         "@emotion/cache": {
@@ -3174,6 +3175,11 @@
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
             "dev": true
+        },
+        "detect-browser": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-4.5.1.tgz",
+            "integrity": "sha512-cGXvbxvDws+ZjzR3AI+2IcKQR3Tj85PaUn42u6A/DWOEYda5fgvkS/NrQp2lD4LZ/IE2nLE/0kV//qekOyxJ2Q=="
         },
         "detect-file": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "webchat": "webpack --config webpack.production.js"
     },
     "dependencies": {
-        "@cognigy/webchat-client": "^4.0.3",
+        "@cognigy/webchat-client": "4.0.4",
         "@emotion/cache": "^10.0.0",
         "@emotion/core": "^10.0.6",
         "@emotion/provider": "^0.11.2",


### PR DESCRIPTION
For IE11 and Safari, the `forceWebsockets` option should be enabled by default. I put this into the `4.0.4` version of `@cognigy/socket-client`