### PR TITLE
fix empty url links in messenger galleries

### DIFF
--- a/src/plugins/messenger/index.tsx
+++ b/src/plugins/messenger/index.tsx
@@ -32,7 +32,7 @@ const isFullscreenMessengerGenericPayload = rawMessage => {
     const { message } = messengerPayload;
     if (!message)
         return false;
-    
+
     const { attachment } = message;
     if (!attachment)
         return false;
@@ -68,7 +68,7 @@ const messengerPlugin: MessagePluginFactory = ({ React, styled }) => {
                     }
 
                     // @ts-ignore
-                    if (action.type === 'web_url') {
+                    if (action.type === 'web_url' && action.url) {
                         // @ts-ignore
                         window.open(action.url, '_blank');
                     }


### PR DESCRIPTION
Added a check whether a url is empty before opening a new page.
Fixes an issue when configuring a gallery template without `default_action` set (only affected the "webchat" tab, not the "messenger" tab).