### PR TITLE
Establish socket connection lazy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -989,9 +989,9 @@
             }
         },
         "@cognigy/webchat-client": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/@cognigy/webchat-client/-/webchat-client-4.0.4.tgz",
-            "integrity": "sha512-5vtLiyoN55vEq0DMTqoGZdkwuI+NL7CZqOxfO5MnBa+yY82UmdXxWEu0edHGm8VUdYd8hJpvK8FKmOb9v1SzSQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@cognigy/webchat-client/-/webchat-client-4.1.0.tgz",
+            "integrity": "sha512-jwOHbBgIbik/cBctqskdnVsNYrXvUuPBWtr2DG70kKsnU2hYGguffk6PkAE0awkTixx2hAwAns7ixTLLiN3rUA==",
             "requires": {
                 "@cognigy/socket-client": "4.0.0",
                 "detect-browser": "^4.5.1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "webchat": "webpack --config webpack.production.js"
     },
     "dependencies": {
-        "@cognigy/webchat-client": "4.0.4",
+        "@cognigy/webchat-client": "^4.1.0",
         "@emotion/cache": "^10.0.0",
         "@emotion/core": "^10.0.6",
         "@emotion/provider": "^0.11.2",

--- a/src/webchat-embed/index.tsx
+++ b/src/webchat-embed/index.tsx
@@ -81,11 +81,6 @@ const initWebchat = async (webchatConfigUrl: string, options?: InitWebchatOption
     while (!cognigyWebchat) {
         await new Promise(resolve => setTimeout(resolve, 500));
     }
-
-    await (cognigyWebchat as Webchat).connect();
-
-    // @ts-ignore
-    // window.cognigyWebchat.open();
     if (callback) {
         return callback(cognigyWebchat)
     }

--- a/src/webchat/store/config/config-middleware.ts
+++ b/src/webchat/store/config/config-middleware.ts
@@ -1,0 +1,43 @@
+import { WebchatClient } from "@cognigy/webchat-client";
+import { Middleware } from "redux";
+import { StoreState } from "../store";
+import { setConfig } from "./config-reducer";
+import { IWebchatSettings } from "@cognigy/webchat-client/lib/interfaces/webchat-config";
+
+export interface ISendMessageOptions {
+    /* overrides the displayed text within a chat bubble. useful for e.g. buttons */
+    label: string;
+}
+
+const LOAD_CONFIG = 'LOAD_CONFIG';
+export const loadConfig = () => ({
+    type: LOAD_CONFIG as 'LOAD_CONFIG'
+});
+export type LoadConfigAction = ReturnType<typeof loadConfig>;
+
+// forwards messages to the socket
+export const createConfigMiddleware = (client: WebchatClient, defaultSettings?: IWebchatSettings): Middleware<{}, StoreState> => store => next => (action: LoadConfigAction) => {
+    switch (action.type) {
+        case 'LOAD_CONFIG': {
+            if (!client.webchatConfig) {
+                client.loadWebchatConfig()
+                    .then(() => {
+                        // set the webchat settings (overridable by embed default settings)
+                        const settings = {
+                            ...client.webchatConfig.settings,
+                            ...defaultSettings
+                        }
+                        
+                        store.dispatch(setConfig({
+                            ...client.webchatConfig,
+                            settings
+                        }));
+                    })
+            }
+
+            break;
+        }
+    }
+
+    return next(action);
+}

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -44,7 +44,6 @@ export const config: Reducer<ConfigState, SetConfigAction> = (state = getInitial
 
     switch (action.type) {
         case 'SET_CONFIG': {
-
             return {
                 ...state,
                 ...action.config,

--- a/src/webchat/store/connection/connection-middleware.ts
+++ b/src/webchat/store/connection/connection-middleware.ts
@@ -1,0 +1,59 @@
+import { Middleware } from "redux";
+import { StoreState } from "../store";
+import { WebchatClient } from '@cognigy/webchat-client';
+import { setConnected } from "./connection-reducer";
+import { SetOpenAction, ToggleOpenAction } from "../ui/ui-reducer";
+import { SendMessageAction } from "../messages/message-middleware";
+import { setOptions } from "../options/options-reducer";
+
+export interface ISendMessageOptions {
+    /* overrides the displayed text within a chat bubble. useful for e.g. buttons */
+    label: string;
+}
+
+const CONNECT = 'CONNECT'
+export const connect = () => ({
+    type: CONNECT as 'CONNECT'
+});
+export type ConnectAction = ReturnType<typeof connect>;
+
+// forwards messages to the socket
+export const createConnectionMiddleware = (client: WebchatClient): Middleware<{}, StoreState> => store => next => (action: SetOpenAction | ToggleOpenAction | ConnectAction | SendMessageAction) => {
+    switch (action.type) {
+        case 'CONNECT': {
+            if (!client.connected) {
+                client.connect()
+                    .then(() => {
+                        // set options
+                        store.dispatch(setOptions(client.socketOptions));
+
+                        // set connection status
+                        store.dispatch(setConnected(true));
+                    })
+            }
+            break;
+        }
+
+        case 'SET_OPEN': {
+            if (action.open) {
+                if (!client.connected) {
+                    store.dispatch(connect())
+                }
+            }
+            break;
+        }
+
+        case 'TOGGLE_OPEN': {
+            if (!store.getState().ui.open) {
+                store.dispatch(connect())
+            }
+            break;
+        }
+
+        case 'SEND_MESSAGE': {
+            store.dispatch(connect())
+        }
+    }
+
+    return next(action);
+}

--- a/src/webchat/store/connection/connection-reducer.ts
+++ b/src/webchat/store/connection/connection-reducer.ts
@@ -1,0 +1,28 @@
+import { Reducer } from "redux";
+
+export interface ConnectionState {
+    connected: boolean;
+}
+
+const initialState: ConnectionState = {
+    connected: false
+}
+
+export const SET_CONNECTED = 'SET_CONNECTED'
+export const setConnected = (connected: boolean) => ({
+    type: SET_CONNECTED as 'SET_CONNECTED',
+    connected
+});
+export type SetConnectedAction = ReturnType<typeof setConnected>;
+
+export const connection: Reducer<ConnectionState, SetConnectedAction> = (state = initialState, action) => {
+    switch (action.type) {
+        case 'SET_CONNECTED': {
+            return {
+                connected: action.connected
+            }
+        }
+    }
+
+    return state;
+} 

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -46,7 +46,6 @@ export const createMessageMiddleware = (client: WebchatClient): Middleware<{}, S
                 const isInjectBehavior = config.settings.startBehavior === 'injection';
 
                 if (isInjectBehavior) {
-                    store.dispatch(connect());
                     const text = config.settings.getStartedPayload;
                     const label = config.settings.getStartedText;
                     

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -6,6 +6,7 @@ import { addMessage } from "./message-reducer";
 import { Omit } from "react-redux";
 import { setFullscreenMessage } from "../ui/ui-reducer";
 import { SetConfigAction } from "../config/config-reducer";
+import { connect } from "../connection/connection-middleware";
 
 export interface ISendMessageOptions {
     /* overrides the displayed text within a chat bubble. useful for e.g. buttons */
@@ -41,10 +42,11 @@ export const createMessageMiddleware = (client: WebchatClient): Middleware<{}, S
         case 'SET_CONFIG': {
             const config = action.config;
 
-            if (config) {
+            if (config && store.getState().messages.length === 0) {
                 const isInjectBehavior = config.settings.startBehavior === 'injection';
 
                 if (isInjectBehavior) {
+                    store.dispatch(connect());
                     const text = config.settings.getStartedPayload;
                     const label = config.settings.getStartedText;
                     

--- a/src/webchat/store/reducer.ts
+++ b/src/webchat/store/reducer.ts
@@ -3,13 +3,15 @@ import { options } from "./options/options-reducer";
 import { messages } from "./messages/message-reducer";
 import { ui } from "./ui/ui-reducer";
 import { config } from "./config/config-reducer";
+import { connection } from "./connection/connection-reducer";
 import { StoreState } from "./store";
 
 const rootReducer = combineReducers({
     messages,
     options,
     config,
-    ui
+    ui,
+    connection
 });
 
 const RESET_STATE = 'RESET_STATE';

--- a/src/webchat/store/store.ts
+++ b/src/webchat/store/store.ts
@@ -6,17 +6,22 @@ import { registerMessageHandler } from './messages/message-handler';
 import { optionsMiddleware } from './options/options-middleware';
 import { reducer } from './reducer';
 import { registerTypingHandler } from './typing/typing-handler';
+import { createConnectionMiddleware } from './connection/connection-middleware';
+import { createConfigMiddleware } from './config/config-middleware';
+import { IWebchatConfig, IWebchatSettings } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 
 
 export type StoreState = StateType<typeof reducer>;
 
 // creates a store and connects it to a webchat client
-export const createWebchatStore = (client: WebchatClient) => {
+export const createWebchatStore = (client: WebchatClient, defaultSettings?: IWebchatSettings) => {
 
     const store = createStore(
         reducer,
         applyMiddleware(
+            createConnectionMiddleware(client),
             createMessageMiddleware(client),
+            createConfigMiddleware(client, defaultSettings),
             optionsMiddleware,
         )
     );


### PR DESCRIPTION
The socket connection should be established if one of the following event occurs:
- the webchat is opened
- the webchat sends a message (also via webchat.sendMessage api)