### PR TITLE
Fix IE11 not breaking line when displaying multiple quick replies

### DIFF
--- a/src/plugins/messenger/MessengerPreview/components/MessengerQuickReply.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerQuickReply.tsx
@@ -3,8 +3,6 @@ import { MessagePluginFactoryProps } from '../../../../common/interfaces/message
 export const getMessengerQuickReply = ({ React, styled }: MessagePluginFactoryProps) => {
 
     const MessengerQuickReply = styled.button(({ theme }) => ({
-        display: 'flex',
-        alignItems: 'center',
         backgroundColor: 'transparent',
         border: `1px solid ${theme.primaryColor}`,
         borderRadius: theme.unitSize * 5,

--- a/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
@@ -19,13 +19,12 @@ export const getMessengerTextWithQuickReplies = ({ React, styled }: MessagePlugi
     }));
 
     const QuickReplies = styled.div({
-        display: 'flex',
+        textAlign: 'center',
 
         margin: -5,
         marginTop: 3,
         flexWrap: 'wrap',
 
-        justifyContent: 'center',
 
         '&>*': {
             margin: 5


### PR DESCRIPTION
do not use flexbox layout for quick replies (so ie11 does not struggle)