### PR TITLE
Implement connection status indicator

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -177,12 +177,14 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             connected,
             ...restProps
         } = props;
-        const { theme } = state;
+        const { theme, hadConnection } = state;
 
-        const { disableToggleButton } = config.settings;
+        const { disableToggleButton, enableConnectionStatusIndicator } = config.settings;
 
         if (!this.props.config.active)
             return null;
+
+        const showDisconnectOverlay =  enableConnectionStatusIndicator && !connected && hadConnection;
 
         return (
             <>
@@ -200,7 +202,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                                             ? this.renderRegularLayout()
                                             : this.renderFullscreenMessageLayout()
                                         }
-                                        {!connected && this.state.hadConnection && <DisconnectOverlay />}
+                                        {showDisconnectOverlay && <DisconnectOverlay />}
                                     </WebchatRoot>
                                 )}
                                 {!disableToggleButton && (

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -28,6 +28,7 @@ import FAB from './presentational/FAB';
 import WebchatWrapper from './presentational/WebchatWrapper';
 import ChatIcon from '../assets/baseline-chat-24px.svg';
 import CloseIcon from '../assets/baseline-close-24px.svg';
+import DisconnectOverlay from './presentational/DisconnectOverlay';
 
 export interface WebchatUIProps {
     messages: IMessage[];
@@ -53,6 +54,8 @@ export interface WebchatUIProps {
 
     webchatRootProps?: React.ComponentProps<typeof WebchatRoot>;
     webchatToggleProps?: React.ComponentProps<typeof FAB>;
+
+    connected: boolean;
 }
 
 interface WebchatUIState {
@@ -162,6 +165,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             onToggle,
             webchatRootProps,
             webchatToggleProps,
+            connected,
             ...restProps
         } = props;
         const { theme } = state;
@@ -187,6 +191,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                                             ? this.renderRegularLayout()
                                             : this.renderFullscreenMessageLayout()
                                         }
+                                        {!connected && <DisconnectOverlay />}
                                     </WebchatRoot>
                                 )}
                                 {!disableToggleButton && (

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -62,6 +62,8 @@ interface WebchatUIState {
     theme: IWebchatTheme;
     messagePlugins: MessagePlugin[];
     inputPlugins: InputPlugin[];
+    /* Initially false, true from the point of first connection */
+    hadConnection: boolean; 
 }
 
 const styleCache = createCache({
@@ -85,7 +87,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
     state = {
         theme: createWebchatTheme(),
         messagePlugins: [],
-        inputPlugins: []
+        inputPlugins: [],
+        hadConnection: false
     };
 
     history: React.RefObject<ChatScroller>;
@@ -116,10 +119,16 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         });
     }
 
-    componentDidUpdate(prevProps: WebchatUIProps) {
+    componentDidUpdate(prevProps: WebchatUIProps, prevState: WebchatUIState) {
         if (this.props.config.settings.colorScheme !== prevProps.config.settings.colorScheme) {
             this.setState({
                 theme: createWebchatTheme({ primaryColor: this.props.config.settings.colorScheme })
+            })
+        }
+
+        if (!prevState.hadConnection && this.props.connected) {
+            this.setState({
+                hadConnection: true
             })
         }
     }
@@ -191,7 +200,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                                             ? this.renderRegularLayout()
                                             : this.renderFullscreenMessageLayout()
                                         }
-                                        {!connected && <DisconnectOverlay />}
+                                        {!connected && this.state.hadConnection && <DisconnectOverlay />}
                                     </WebchatRoot>
                                 )}
                                 {!disableToggleButton && (

--- a/src/webchat-ui/components/presentational/DisconnectOverlay.tsx
+++ b/src/webchat-ui/components/presentational/DisconnectOverlay.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { styled } from "../../style";
+import tinycolor from 'tinycolor2';
+
+const Wrapper = styled.div(({ theme }) => ({
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: '100%',
+    height: '100%',
+
+    padding: theme.blockSize,
+    boxSizing: 'border-box',
+    backgroundColor: 'hsla(0, 0%, 0%, .33)',
+
+    zIndex: 2,
+}));
+
+const Dialog = styled.div(({ theme }) => ({
+    padding: theme.unitSize * 2,
+    borderRadius: theme.unitSize,
+
+    backgroundColor: '#fafafa',
+    color: theme.greyContrastColor,
+
+    boxShadow: theme.shadow,
+}));
+
+export default () => {
+    return (
+        <Wrapper>
+            <Dialog>
+                <span>Connection lost. Trying to reconnect...</span>
+            </Dialog>
+        </Wrapper>
+    )
+}
+

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -8,19 +8,20 @@ import { MessagePlugin } from '../../common/interfaces/message-plugin';
 import { IMessage } from '../../common/interfaces/message';
 import { getPluginsForMessage, isFullscreenPlugin } from '../../plugins/helper';
 
-type FromState = Pick<WebchatUIProps, 'messages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config'>;
+type FromState = Pick<WebchatUIProps, 'messages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config' | 'connected'>;
 type FromDispatch = Pick<WebchatUIProps, 'onSendMessage' | 'onSetInputMode' | 'onSetFullscreenMessage' | 'onDismissFullscreenMessage' | 'onClose' | 'onToggle' >;
 export type FromProps = Pick<WebchatUIProps, 'messagePlugins' | 'inputPlugins' | 'webchatRootProps' | 'webchatToggleProps'>;
 type Merge = FromState & FromDispatch & FromProps & Pick<WebchatUIProps, 'fullscreenMessage'>;
 
 export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Merge, StoreState>(
-    ({ messages, ui: { open, typing, inputMode, fullscreenMessage }, config }) => ({
+    ({ messages, connection: { connected }, ui: { open, typing, inputMode, fullscreenMessage }, config }) => ({
         messages,
         open,
         typingIndicator: typing,
         inputMode,
         fullscreenMessage,
-        config
+        config,
+        connected
     }),
     dispatch => ({
         onSendMessage: (text, data, options) => dispatch(sendMessage({ text, data }, options)),

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -17,6 +17,7 @@ const getInitialState = (): ConfigState => ({
         enableSTT: false,
         enableTTS: false,
         enableTypingIndicator: false,
+        enableConnectionStatusIndicator: false,
         getStartedButtonText: '',
         getStartedPayload: '',
         getStartedText: '',

--- a/src/webchat/store/connection/connection-handler.ts
+++ b/src/webchat/store/connection/connection-handler.ts
@@ -1,0 +1,8 @@
+import { Store } from "redux";
+import { WebchatClient } from "@cognigy/webchat-client";
+import { setConnected } from "./connection-reducer";
+
+export const registerConnectionHandler = (store: Store, client: WebchatClient) => {
+    client.on('socket/connect', () => { store.dispatch(setConnected(true)) });
+    client.on('socket/disconnect', () => { store.dispatch(setConnected(false)) });
+}

--- a/src/webchat/store/connection/connection-middleware.ts
+++ b/src/webchat/store/connection/connection-middleware.ts
@@ -26,9 +26,6 @@ export const createConnectionMiddleware = (client: WebchatClient): Middleware<{}
                     .then(() => {
                         // set options
                         store.dispatch(setOptions(client.socketOptions));
-
-                        // set connection status
-                        store.dispatch(setConnected(true));
                     })
             }
             break;

--- a/src/webchat/store/store.ts
+++ b/src/webchat/store/store.ts
@@ -8,8 +8,9 @@ import { reducer } from './reducer';
 import { registerTypingHandler } from './typing/typing-handler';
 import { createConnectionMiddleware } from './connection/connection-middleware';
 import { createConfigMiddleware } from './config/config-middleware';
-import { IWebchatConfig, IWebchatSettings } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
+import { IWebchatSettings } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 import { createAnalyticsMiddleware } from './analytics/analytics-middleware';
+import { registerConnectionHandler } from './connection/connection-handler';
 
 
 export type StoreState = StateType<typeof reducer>;
@@ -30,6 +31,7 @@ export const createWebchatStore = (client: WebchatClient, defaultSettings?: IWeb
 
     registerMessageHandler(store, client);
     registerTypingHandler(store, client);
+    registerConnectionHandler(store, client);
 
     return store;
 }


### PR DESCRIPTION
It is now optionally possible to set up an overlay that will show when the webchat lost its connection.

You can enable it by passing it as a setting like this:

```javascript
initWebchat('...', {
  settings: {
    enableConnectionStatusIndicator: true
  }
});
```