### PR TITLE
Feature/5221 messenger image aspect ratios

### DIFF
--- a/src/plugins/messenger/MessengerPreview/MessengerPreview.tsx
+++ b/src/plugins/messenger/MessengerPreview/MessengerPreview.tsx
@@ -77,6 +77,7 @@ export const getMessengerPreview = ({ React, styled }: MessagePluginFactoryProps
                                     {...divProps}
                                     payload={payload as IFBMListTemplatePayload}
                                     onAction={onAction}
+                                    config={config}
                                 />
                             );
                         }
@@ -87,6 +88,7 @@ export const getMessengerPreview = ({ React, styled }: MessagePluginFactoryProps
                                     {...divProps}
                                     payload={payload as IFBMMediaTemplatePayload}
                                     onAction={onAction}
+                                    config={config}
                                 />
                             );
                         }

--- a/src/plugins/messenger/MessengerPreview/components/FlexImage.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/FlexImage.tsx
@@ -1,0 +1,10 @@
+import { MessagePluginFactoryProps } from "../../../../common/interfaces/message-plugin";
+
+export const getFlexImage = ({ React, styled }: MessagePluginFactoryProps) => {
+    const FlexImage = styled.img({
+        display: 'block',
+        width: '100%'
+    })
+
+    return FlexImage;
+}

--- a/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
@@ -12,6 +12,7 @@ import { Carousel } from 'react-responsive-carousel';
 import './carousel.css';
 import { element } from 'prop-types';
 import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
+import { getFlexImage } from '../FlexImage';
 
 export interface IMessengerGenericTemplateProps extends IWithFBMActionEventHandler {
     payload: IFBMGenericTemplatePayload;
@@ -29,6 +30,7 @@ export const getMessengerGenericTemplate = ({ React, styled }: MessagePluginFact
     const MessengerContent = getMessengerContent({ React, styled });
     const MessengerButton = getMessengerButton({ React, styled });
     const Divider = getDivider({ React, styled });
+    const FlexImage = getFlexImage({ React, styled });
 
     const CarouselRoot = styled(Carousel)(({ theme }) => ({
         marginBottom: -32,
@@ -59,10 +61,11 @@ export const getMessengerGenericTemplate = ({ React, styled }: MessagePluginFact
         }
     });
 
-    const Image = styled.div(() => ({
+    const FixedImage = styled.div<{ src: string }>(({ src }) => ({
         paddingTop: '50%',
         backgroundSize: 'cover',
         backgroundPosition: 'center center',
+        backgroundImage: `url("${encodeURI(src)}")`
     }));
 
     const GenericContent = styled(MessengerContent)({
@@ -85,7 +88,9 @@ export const getMessengerGenericTemplate = ({ React, styled }: MessagePluginFact
             const { onAction, ...divProps } = this.props;
             const { image_url, title, subtitle, buttons, default_action } = element;
 
-            const isCentered = this.props.config.settings.designTemplate === 2
+            const isCentered = this.props.config.settings.designTemplate === 2;
+
+            const Image = FlexImage;
 
             return (
                 <ElementRoot key={index}>
@@ -94,7 +99,7 @@ export const getMessengerGenericTemplate = ({ React, styled }: MessagePluginFact
                             <>
                                 <Image
                                     onClick={e => default_action && onAction(e, default_action)}
-                                    style={this.getImageStyles(element)}
+                                    src={image_url}
                                 />
                                 <Divider />
                             </>

--- a/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
@@ -13,6 +13,7 @@ import './carousel.css';
 import { element } from 'prop-types';
 import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 import { getFlexImage } from '../FlexImage';
+import { config } from '../../../../../webchat/store/config/config-reducer';
 
 export interface IMessengerGenericTemplateProps extends IWithFBMActionEventHandler {
     payload: IFBMGenericTemplatePayload;
@@ -90,20 +91,16 @@ export const getMessengerGenericTemplate = ({ React, styled }: MessagePluginFact
 
             const isCentered = this.props.config.settings.designTemplate === 2;
 
-            const Image = FlexImage;
+            const image = image_url
+                ? this.props.config.settings.dynamicImageAspectRatio
+                    ? <FlexImage src={image_url} />
+                    : <FixedImage src={image_url} />
+                : null
 
             return (
                 <ElementRoot key={index}>
                     <Frame className={isCentered ? 'wide' : ''}>
-                        {image_url && (
-                            <>
-                                <Image
-                                    onClick={e => default_action && onAction(e, default_action)}
-                                    src={image_url}
-                                />
-                                <Divider />
-                            </>
-                        )}
+                        {image}
                         <GenericContent
                             onClick={e => default_action && onAction(e, default_action)}
                         >

--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/MessengerListTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/MessengerListTemplate.tsx
@@ -6,9 +6,11 @@ import { getMessengerButton } from '../MessengerButton/MessengerButton';
 import { getMessengerListTemplateElement } from './components/MessengerListTemplateElement';
 import { getMessengerFrame } from '../MessengerFrame';
 import { getMessengerListTemplateHeaderElement } from './components/MessengerListTemplateHeaderElement';
+import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 
 export interface IMessengerListTemplateProps extends IWithFBMActionEventHandler {
     payload: IFBMListTemplatePayload;
+    config: IWebchatConfig;
 }
 
 export const getMessengerListTemplate = ({ React, styled }: MessagePluginFactoryProps) => {
@@ -18,7 +20,7 @@ export const getMessengerListTemplate = ({ React, styled }: MessagePluginFactory
     const MessengerButton = getMessengerButton({ React, styled });
     const Divider = getDivider({ React, styled });
 
-    const MessengerListTemplate = ({ payload, onAction, ...divProps }: IMessengerListTemplateProps & React.HTMLProps<HTMLDivElement>) => {
+    const MessengerListTemplate = ({ payload, onAction, config, ...divProps }: IMessengerListTemplateProps & React.HTMLProps<HTMLDivElement>) => {
         const { elements, top_element_style, buttons } = payload;
 
         const regularElements = top_element_style === 'large'
@@ -37,6 +39,7 @@ export const getMessengerListTemplate = ({ React, styled }: MessagePluginFactory
                     <MessengerListTemplateHeaderElement
                         element={headerElement}
                         onAction={onAction}
+                        config={config}
                     />
                 )}
                 {regularElements.map((element, index) => (

--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateHeaderElement.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateHeaderElement.tsx
@@ -3,19 +3,21 @@ import { IWithFBMActionEventHandler } from '../../../MessengerPreview.interface'
 import { MessagePluginFactoryProps } from '../../../../../../common/interfaces/message-plugin';
 import { getMessengerSubtitle } from '../../MessengerSubtitle';
 import { getMessengerTitle } from '../../MessengerTitle';
+import { getFlexImage } from '../../FlexImage';
+import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 
 interface IMessengerListTemplateHeaderElementProps extends IWithFBMActionEventHandler {
     element: IFBMListTemplateElement;
+    config: IWebchatConfig;
 }
 
 export const getMessengerListTemplateHeaderElement = ({ React, styled }: MessagePluginFactoryProps) => {
     const MessengerSubtitle = getMessengerSubtitle({ React, styled });
     const MessengerTitle = getMessengerTitle({ React, styled });
+    const FlexImage = getFlexImage({ React, styled });
+
     const Root = styled.div(() => ({
         position: 'relative',
-        paddingTop: '50%',
-        backgroundSize: 'cover',
-        backgroundPosition: 'center center',
     }));
 
     const DarkLayer = styled.div({
@@ -45,19 +47,25 @@ export const getMessengerListTemplateHeaderElement = ({ React, styled }: Message
         color: 'hsla(0, 0%, 100%, .9)'
     });
 
-    const MessengerListTemplateHeaderElement = ({ element, onAction }: IMessengerListTemplateHeaderElementProps) => {
+    const FixedImage = styled.div(() => ({
+        paddingTop: '50%',
+        backgroundSize: 'cover',
+        backgroundPosition: 'center center'
+    }));
+
+    const MessengerListTemplateHeaderElement = ({ element, onAction, config }: IMessengerListTemplateHeaderElementProps) => {
         const { title, subtitle, image_url, default_action } = element;
         // TODO buttons, default_action
 
-        const styles: React.CSSProperties = {
-            backgroundImage: `url("${encodeURI(image_url)}")`
-        }
+        const image = config.settings.dynamicImageAspectRatio
+            ? <FlexImage src={image_url} />
+            : <FixedImage style={{ backgroundImage: image_url ? `url("${encodeURI(image_url)}")` : undefined }} />
 
         return (
             <Root
                 onClick={default_action && (e => onAction(e, default_action))}
-                style={styles}
             >
+                {image}
                 <DarkLayer />
                 <Content>
                     <Title>{title}</Title>

--- a/src/plugins/messenger/MessengerPreview/components/MessengerMediaTemplate/MessengerMediaTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerMediaTemplate/MessengerMediaTemplate.tsx
@@ -3,20 +3,24 @@ import { getMessengerFrame } from '../MessengerFrame';
 import { IFBMMediaTemplatePayload, IFBMMediaTemplateUrlElement } from '../../interfaces/MediaTemplatePayload.interface';
 import { IWithFBMActionEventHandler } from '../../MessengerPreview.interface';
 import { MessagePluginFactoryProps } from '../../../../../common/interfaces/message-plugin';
+import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
+import { getFlexImage } from '../FlexImage';
 
 interface IProps extends IWithFBMActionEventHandler {
     payload: IFBMMediaTemplatePayload;
+    config: IWebchatConfig;
 }
 
 export const getMessengerMediaTemplate = ({ React, styled }: MessagePluginFactoryProps) => {
 
     const MessengerFrame = getMessengerFrame({ React, styled });
+    const FlexImage = getFlexImage({ React, styled });
 
     const FourThirds = styled.div({
         paddingTop: '75%'
     });
 
-    const Image = styled(FourThirds)(() => ({
+    const FixedImage = styled(FourThirds)(() => ({
         backgroundSize: 'cover',
         backgroundPosition: 'center center'
     }));
@@ -32,7 +36,7 @@ export const getMessengerMediaTemplate = ({ React, styled }: MessagePluginFactor
         backgroundColor: 'black'
     })
 
-    const MessengerMediaTemplate = ({ payload, onAction, ...divProps }: IProps & React.HTMLProps<HTMLDivElement>) => {
+    const MessengerMediaTemplate = ({ payload, onAction, config, ...divProps }: IProps & React.HTMLProps<HTMLDivElement>) => {
         const { elements } = payload;
         const element = elements && elements[0];
 
@@ -43,13 +47,13 @@ export const getMessengerMediaTemplate = ({ React, styled }: MessagePluginFactor
         // TODO add buttons
 
         if (media_type === 'image') {
-            const styles:React.CSSProperties = {
-                backgroundImage: `url("${encodeURI(url)}")`
-            }
+            const image = config.settings.dynamicImageAspectRatio
+                    ? <FlexImage src={url} />
+                    : <FixedImage style={{ backgroundImage: `url("${encodeURI(url)}")` }} />
 
             return (
                 <MessengerFrame {...divProps}>
-                    <Image style={styles} />
+                    {image}
                 </MessengerFrame>
             )
         }


### PR DESCRIPTION
By using the `dynamicImageAspectRatio` setting, Gallery, List Header and Media Image Attachments will render their natural image aspect ratio and will not be cropped.

```javascript
initWebchat('...', {
  settings: {
    dynamicImageAspectRatio: true
  }
})
```

I can recommend using a service like [placekitten](https://placekitten.com) to get urls to images with fixed aspect ratios, like this 2:3 image (https://placekitten.com/200/300)
![fixed cat](https://placekitten.com/200/300)