### PR TITLE
add support for rtl websites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2691,6 +2691,11 @@
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true
         },
+        "cssjanus": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/cssjanus/-/cssjanus-1.3.2.tgz",
+            "integrity": "sha512-5pM/C1MIfoqhXa7k9PqSnrjj1SSZDakfyB1DZhdYyJoDUH+evGbsUg6/bpQapTJeSnYaj0rdzPUMeM33CvB0vw=="
+        },
         "csso": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
@@ -7400,6 +7405,14 @@
                 "jss": "^9.8.0",
                 "jss-preset-default": "^4.3.0",
                 "theming": "^1.3.0"
+            }
+        },
+        "stylis-rtl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stylis-rtl/-/stylis-rtl-1.0.1.tgz",
+            "integrity": "sha512-ue3KZaNk7Pbz4upJJIsTuntScouv4xIPkETZ/iNr5MTmD+c1IP7H2+VwvMGEHWAQbBXRPg/b/YayUAa6ORS3ww==",
+            "requires": {
+                "cssjanus": "^1.3.0"
             }
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "react-responsive-carousel": "^3.1.47",
         "redux": "^4.0.1",
         "styled-jss": "^2.2.3",
+        "stylis-rtl": "^1.0.1",
         "tinycolor2": "^1.4.1"
     },
     "devDependencies": {

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -19,6 +19,7 @@ import Avatar from './presentational/Avatar';
 import MessagePluginRenderer from './plugins/MessagePluginRenderer';
 import regularMessagePlugin from './plugins/message/regular';
 import { InputPlugin } from '../../common/interfaces/input-plugin';
+import stylisRTL  from 'stylis-rtl';
 
 import TypingIndicatorBubble from './presentational/TypingIndicatorBubble';
 import '../utils/normalize.css';
@@ -66,11 +67,24 @@ interface WebchatUIState {
     hadConnection: boolean; 
 }
 
+const stylisPlugins = [
+    isolate('[data-cognigy-webchat-root]')
+];
+
+/**
+ * for RTL-layout websites, use the stylis-rtl plugin to convert CSS,
+ * e.g. padding-left becomes padding-right etc.
+ */
+(() => {
+    const dir = document.getElementsByTagName('html')[0].attributes['dir'];
+    if (dir && dir.value === 'rtl') {
+        stylisPlugins.push(stylisRTL);
+    }
+})();
+
 const styleCache = createCache({
     key: 'cognigy-webchat',
-    stylisPlugins: [
-        isolate('[data-cognigy-webchat-root]'),
-    ]
+    stylisPlugins
 });
 
 const HistoryWrapper = styled(History)(({ theme }) => ({


### PR DESCRIPTION
In languages with RTL layout, such as arabic, the html tag typically has a "dir" attribute set to "rtl" (`<html dir="rtl" />`). If this is set, we use another stylis-plugin in addition that will transform all horizontally direction-based css instructions into the opposite direction, e.g. `padding-left` becomes `padding-right`. This makes sure that the chat history layout does not break.