### PR TITLE
6848 - Replace @cognigy/webchat-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1652,22 +1652,6 @@
                 "socket.io-client": "^2.2.0",
                 "url": "^0.11.0",
                 "uuid": "^3.3.2"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "12.11.1",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.1.tgz",
-                    "integrity": "sha512-TJtwsqZ39pqcljJpajeoofYRfeZ7/I/OMUQ5pR4q5wOKf2ocrUvBAZUMhWsOvKx3dVc/aaV5GluBivt0sWqA5A=="
-                }
-            }
-        },
-        "@cognigy/webchat-client": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@cognigy/webchat-client/-/webchat-client-4.3.1.tgz",
-            "integrity": "sha512-H/32svhFhRHMXSVtg2HY/9b6j5zchp0O6zYczOAvp2xpOPSiL7Mprln/RJKUEcAfe8LhDCWOePikSwsjAUBuig==",
-            "requires": {
-                "@cognigy/socket-client": "^4.1.1",
-                "detect-browser": "^4.5.1"
             }
         },
         "@emotion/cache": {
@@ -1846,8 +1830,7 @@
         "@types/node": {
             "version": "12.12.11",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
-            "integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ==",
-            "dev": true
+            "integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ=="
         },
         "@types/parse-json": {
             "version": "4.0.0",
@@ -1908,6 +1891,24 @@
             "dev": true,
             "requires": {
                 "@types/node": "*"
+            }
+        },
+        "@types/whatwg-fetch": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-fetch/-/whatwg-fetch-0.0.33.tgz",
+            "integrity": "sha1-GcDShjyMsjgPIaHHNrecv3iVuxM=",
+            "dev": true,
+            "requires": {
+                "@types/whatwg-streams": "*"
+            }
+        },
+        "@types/whatwg-streams": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-streams/-/whatwg-streams-3.2.1.tgz",
+            "integrity": "sha512-Syv05sRL25b8cC8tqgXSQgLZZmqGq2GO+NafrtHbjPJccP6gWBXmHvo2Trw3AWXQ4QLIkVuOB7uStCuhzswyiw==",
+            "dev": true,
+            "requires": {
+                "whatwg-streams": "*"
             }
         },
         "@webassemblyjs/ast": {
@@ -3499,6 +3500,12 @@
                 }
             }
         },
+        "defined": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+            "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+            "dev": true
+        },
         "del": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
@@ -3535,11 +3542,6 @@
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
             "dev": true
-        },
-        "detect-browser": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-4.7.0.tgz",
-            "integrity": "sha512-x+7zkRxwEiQ8qLKKfln9pTa4n87fbPHVpHyImmpEQn5lAmKurWBVbg0tb99ruAHqSA0ejrXMp0MahKEulE7LqA=="
         },
         "detect-file": {
             "version": "1.0.0",
@@ -5672,6 +5674,12 @@
                 }
             }
         },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
         "jss": {
             "version": "9.8.7",
             "resolved": "https://registry.npmjs.org/jss/-/jss-9.8.7.tgz",
@@ -7431,6 +7439,15 @@
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
             "dev": true
         },
+        "resumer": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+            "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+            "dev": true,
+            "requires": {
+                "through": "~2.3.4"
+            }
+        },
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -8309,6 +8326,28 @@
             "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
             "dev": true
         },
+        "tape": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.3.tgz",
+            "integrity": "sha1-Lnzgox3wn41oUWZKcYQuDKUFevc=",
+            "dev": true,
+            "requires": {
+                "deep-equal": "~0.1.0",
+                "defined": "~0.0.0",
+                "inherits": "~2.0.1",
+                "jsonify": "~0.0.0",
+                "resumer": "~0.0.0",
+                "through": "~2.3.4"
+            },
+            "dependencies": {
+                "deep-equal": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz",
+                    "integrity": "sha1-skbCuApXCkfBG+HZvRBw7IeLh84=",
+                    "dev": true
+                }
+            }
+        },
         "terser": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.0.tgz",
@@ -8363,6 +8402,12 @@
                 "is-plain-object": "^2.0.1",
                 "prop-types": "^15.5.8"
             }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
         },
         "through2": {
             "version": "2.0.5",
@@ -9190,6 +9235,24 @@
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
             "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
             "dev": true
+        },
+        "whatwg-streams": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-streams/-/whatwg-streams-0.1.1.tgz",
+            "integrity": "sha1-3VV1yWW84T2nbcDdSVYpqHVy504=",
+            "dev": true,
+            "requires": {
+                "bluebird": "~1.0.0",
+                "tape": "~2.3.2"
+            },
+            "dependencies": {
+                "bluebird": {
+                    "version": "1.0.8",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.0.8.tgz",
+                    "integrity": "sha1-hRx4JebM5Z5LQ93pXVdLiGdUY/w=",
+                    "dev": true
+                }
+            }
         },
         "which": {
             "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "webchat": "webpack --config webpack.production.js"
     },
     "dependencies": {
-        "@cognigy/webchat-client": "^4.3.1",
+        "@cognigy/socket-client": "^4.1.1",
         "@emotion/cache": "^10.0.19",
         "@emotion/core": "^10.0.22",
         "@emotion/provider": "^0.11.2",
@@ -58,6 +58,7 @@
         "@types/react-redux": "^6.0.12",
         "@types/tinycolor2": "^1.4.2",
         "@types/uuid": "^3.4.6",
+        "@types/whatwg-fetch": "0.0.33",
         "babel-loader": "^8.0.6",
         "babel-polyfill": "^6.26.0",
         "css-loader": "^2.1.0",

--- a/src/common/interfaces/input-plugin.ts
+++ b/src/common/interfaces/input-plugin.ts
@@ -1,9 +1,9 @@
-import React, { ComponentProps } from 'react';
+import React from 'react';
 import { IMessage } from "./message";
-import { IWebchatConfig } from "@cognigy/webchat-client/lib/interfaces/webchat-config";
 import { MessageSender } from '../../webchat-ui/interfaces';
 import { MessagePluginFactoryProps } from './message-plugin';
 import { IWebchatTheme } from '../../webchat-ui/style';
+import { IWebchatConfig } from './webchat-config';
 
 export interface InputButtonProps extends React.HTMLProps<HTMLButtonElement> {
     active: boolean;

--- a/src/common/interfaces/message-plugin.ts
+++ b/src/common/interfaces/message-plugin.ts
@@ -1,8 +1,8 @@
 import React from 'react';
 import { IMessage } from "./message";
-import { IWebchatConfig } from "@cognigy/webchat-client/lib/interfaces/webchat-config";
 import { MessageSender } from '../../webchat-ui/interfaces';
 import { styled, IWebchatTheme } from '../../webchat-ui/style';
+import { IWebchatConfig } from './webchat-config';
 
 export interface MessageComponentProps {
     attributes?: React.HTMLProps<HTMLDivElement>;

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -1,0 +1,38 @@
+export interface IPersistentMenuItem {
+    title: string;
+    payload: string;
+}
+
+export interface IWebchatSettings {
+    backgroundImageUrl: string;
+    colorScheme: string;
+    designTemplate: number;
+    disableToggleButton: boolean;
+    dynamicImageAspectRatio: boolean;
+    enableConnectionStatusIndicator: boolean;
+    enableFileUpload: boolean;
+    enablePersistentMenu: boolean;
+    enableSTT: boolean;
+    enableTTS: boolean;
+    enableTypingIndicator: boolean;
+    getStartedButtonText: string;
+    getStartedPayload: string;
+    getStartedText: string;
+    headerLogoUrl: string;
+    inputPlaceholder: string;
+    messageDelay: number;
+    messageLogoUrl: string;
+    persistentMenu: {
+        title: string;
+        menuItems: IPersistentMenuItem[];
+    };
+    startBehavior: "none" | "button" | "injection";
+    STTLanguage: string;
+    title: string;
+}
+
+export interface IWebchatConfig {
+    active: boolean;
+    URLToken: string;
+    settings: IWebchatSettings;
+}

--- a/src/plugins/messenger/MessengerPreview/MessengerPreview.tsx
+++ b/src/plugins/messenger/MessengerPreview/MessengerPreview.tsx
@@ -12,7 +12,7 @@ import { getMessengerMediaTemplate } from './components/MessengerMediaTemplate/M
 import { FBMActionEventHandler } from './MessengerPreview.interface';
 import { MessagePluginFactoryProps } from '../../../common/interfaces/message-plugin';
 import { getMessengerTextWithQuickReplies } from './components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies';
-import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
+import { IWebchatConfig } from '../../../common/interfaces/webchat-config';
 
 export interface IMessengerPreviewProps extends React.HTMLProps<HTMLDivElement> {
     /** input.data._cognigy._facebook */

--- a/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
@@ -10,9 +10,9 @@ import { getMessengerSubtitle } from '../MessengerSubtitle';
 import { Carousel } from 'react-responsive-carousel';
 
 import './carousel.css';
-import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 import { getFlexImage } from '../FlexImage';
 import { getBackgroundImage } from '../../lib/css';
+import { IWebchatConfig } from '../../../../../common/interfaces/webchat-config';
 
 export interface IMessengerGenericTemplateProps extends IWithFBMActionEventHandler {
     payload: IFBMGenericTemplatePayload;

--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/MessengerListTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/MessengerListTemplate.tsx
@@ -6,7 +6,7 @@ import { getMessengerButton } from '../MessengerButton/MessengerButton';
 import { getMessengerListTemplateElement } from './components/MessengerListTemplateElement';
 import { getMessengerFrame } from '../MessengerFrame';
 import { getMessengerListTemplateHeaderElement } from './components/MessengerListTemplateHeaderElement';
-import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
+import { IWebchatConfig } from '../../../../../common/interfaces/webchat-config';
 
 export interface IMessengerListTemplateProps extends IWithFBMActionEventHandler {
     payload: IFBMListTemplatePayload;

--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateHeaderElement.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateHeaderElement.tsx
@@ -4,10 +4,10 @@ import { MessagePluginFactoryProps } from '../../../../../../common/interfaces/m
 import { getMessengerSubtitle } from '../../MessengerSubtitle';
 import { getMessengerTitle } from '../../MessengerTitle';
 import { getFlexImage } from '../../FlexImage';
-import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 import { getMessengerListButton } from '../../MessengerListButton';
 import { getButtonLabel } from '../../MessengerButton/lib/messengerButtonHelpers';
 import { getBackgroundImage } from '../../../lib/css';
+import { IWebchatConfig } from '../../../../../../common/interfaces/webchat-config';
 
 interface IMessengerListTemplateHeaderElementProps extends IWithFBMActionEventHandler {
     element: IFBMListTemplateElement;

--- a/src/plugins/messenger/MessengerPreview/components/MessengerMediaTemplate/MessengerMediaTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerMediaTemplate/MessengerMediaTemplate.tsx
@@ -3,9 +3,9 @@ import { getMessengerFrame } from '../MessengerFrame';
 import { IFBMMediaTemplatePayload, IFBMMediaTemplateUrlElement } from '../../interfaces/MediaTemplatePayload.interface';
 import { IWithFBMActionEventHandler } from '../../MessengerPreview.interface';
 import { MessagePluginFactoryProps } from '../../../../../common/interfaces/message-plugin';
-import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 import { getFlexImage } from '../FlexImage';
 import { getBackgroundImage } from '../../lib/css';
+import { IWebchatConfig } from '../../../../../common/interfaces/webchat-config';
 
 interface IProps extends IWithFBMActionEventHandler {
     payload: IFBMMediaTemplatePayload;

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { css, Global } from '@emotion/core';
 import { IMessage } from '../../common/interfaces/message';
 import Header from './presentational/Header';
-import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 import { ThemeProvider } from 'emotion-theming';
 import { CacheProvider } from '@emotion/core';
 import { IWebchatTheme, createWebchatTheme, styled } from '../style';
@@ -30,6 +29,7 @@ import WebchatWrapper from './presentational/WebchatWrapper';
 import ChatIcon from '../assets/baseline-chat-24px.svg';
 import CloseIcon from '../assets/baseline-close-24px.svg';
 import DisconnectOverlay from './presentational/DisconnectOverlay';
+import { IWebchatConfig } from '../../common/interfaces/webchat-config';
 
 export interface WebchatUIProps {
     messages: IMessage[];

--- a/src/webchat-ui/components/history/History.tsx
+++ b/src/webchat-ui/components/history/History.tsx
@@ -1,11 +1,5 @@
-import * as React from 'react';
-import { IMessage } from '../../../common/interfaces/message';
 import { styled } from '../../style';
 import { ChatScroller } from './ChatScroller';
-import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
-import { MessagePlugin } from '../../../common/interfaces/message-plugin';
-import { MessageSender } from '../../interfaces';
-
 
 export const History = styled(ChatScroller)(({ theme }) => ({
     paddingTop: theme.unitSize * 2,

--- a/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 import { IMessage } from '../../../common/interfaces/message';
 import { MessagePlugin } from '../../../common/interfaces/message-plugin';
 import { MessageSender } from '../../interfaces';
-import { IWebchatConfig } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 import { getPluginsForMessage } from '../../../plugins/helper';
 import MessageRow from '../presentational/MessageRow';
 import Avatar from '../presentational/Avatar';
-import { defaultBotAvatar, defaultUserImg } from '../WebchatUI';
 import { styled, IWebchatTheme } from '../../style';
+import { IWebchatConfig } from '../../../common/interfaces/webchat-config';
 
 export interface MessageProps extends React.HTMLProps<HTMLDivElement> {
     message: IMessage;

--- a/src/webchat-ui/components/plugins/input/text/TextInput.tsx
+++ b/src/webchat-ui/components/plugins/input/text/TextInput.tsx
@@ -4,7 +4,7 @@ import { styled } from '../../../../style';
 import { InputComponentProps } from '../../../../../common/interfaces/input-plugin';
 import SendIcon from './baseline-send-24px.svg';
 import MenuIcon from './baseline-menu-24px.svg';
-import { IPersistentMenuItem } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
+import { IPersistentMenuItem } from '../../../../../common/interfaces/webchat-config';
 
 
 const InputForm = styled.form(({ theme }) => ({

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -105,7 +105,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
                     {...props}
                     messagePlugins={messagePlugins}
                     inputPlugins={inputPlugins}
-                    onEmitAnalytics={this.emitAnalytics.bind(this.client)}
+                    onEmitAnalytics={this.emitAnalytics}
                 />
             </Provider>
         )

--- a/src/webchat/helper/endpoint.ts
+++ b/src/webchat/helper/endpoint.ts
@@ -1,0 +1,18 @@
+import { fetch } from 'whatwg-fetch';
+import { IWebchatConfig } from '../../common/interfaces/webchat-config';
+
+export const getEndpointBaseUrl = (webchatConfigUrl: string) => {
+    const partials = webchatConfigUrl.split('/');
+    partials.splice(partials.length - 1, 1);
+
+    return partials.join('/');
+}
+
+export const getEndpointUrlToken = (webchatConfigUrl: string) => {
+    return webchatConfigUrl.split('/').pop() as string;
+}
+
+export const fetchWebchatConfig = async (webchatConfigUrl: string) => {
+    const response = await fetch(webchatConfigUrl);
+    return response.json() as IWebchatConfig;
+}

--- a/src/webchat/store/analytics/analytics-middleware.ts
+++ b/src/webchat/store/analytics/analytics-middleware.ts
@@ -1,35 +1,35 @@
 
-import { WebchatClient } from "@cognigy/webchat-client";
 import { Middleware } from "redux";
 import { StoreState } from "../store";
 import { SetOpenAction, ToggleOpenAction } from "../ui/ui-reducer";
 import { SendMessageAction } from "../messages/message-middleware";
 import { ReceiveMessageAction } from "../messages/message-handler";
+import { Webchat } from "../../components/Webchat";
 
 type AnalyticsAction = SetOpenAction | ToggleOpenAction | SendMessageAction | ReceiveMessageAction;
 
 // creates an analytics middleware that emits events on the client
-export const createAnalyticsMiddleware = (client: WebchatClient): Middleware<{}, StoreState> => store => next => (action: AnalyticsAction) => {
+export const createAnalyticsMiddleware = (webchat: Webchat): Middleware<{}, StoreState> => store => next => (action: AnalyticsAction) => {
     switch (action.type) {
         case 'SET_OPEN': {
-            client.emitAnalytics(action.open ? 'webchat/open' : 'webchat/close');
+            webchat.emitAnalytics(action.open ? 'webchat/open' : 'webchat/close');
             break;
         }
 
         case 'TOGGLE_OPEN': {
             const open = !store.getState().ui.open;
-            client.emitAnalytics(open ? 'webchat/open' : 'webchat/close');
+            webchat.emitAnalytics(open ? 'webchat/open' : 'webchat/close');
             break;
         }
 
         case 'SEND_MESSAGE': {
-            client.emitAnalytics('webchat/outgoing-message', action.message);
+            webchat.emitAnalytics('webchat/outgoing-message', action.message);
             break;
         }
 
         case 'RECEIVE_MESSAGE': {
             if (action.message.text || action.message.data) {
-                client.emitAnalytics('webchat/incoming-message', action.message);
+                webchat.emitAnalytics('webchat/incoming-message', action.message);
             }
             break;
         }

--- a/src/webchat/store/config/config-middleware.ts
+++ b/src/webchat/store/config/config-middleware.ts
@@ -1,8 +1,10 @@
-import { WebchatClient } from "@cognigy/webchat-client";
 import { Middleware } from "redux";
 import { StoreState } from "../store";
-import { setConfig } from "./config-reducer";
-import { IWebchatSettings } from "@cognigy/webchat-client/lib/interfaces/webchat-config";
+import { setConfig, ConfigState } from "./config-reducer";
+import { SocketClient } from "@cognigy/socket-client";
+import { fetchWebchatConfig } from "../../helper/endpoint";
+import { Options } from "@cognigy/socket-client/lib/interfaces/options";
+import { IWebchatSettings } from "../../../common/interfaces/webchat-config";
 
 export interface ISendMessageOptions {
     /* overrides the displayed text within a chat bubble. useful for e.g. buttons */
@@ -16,24 +18,27 @@ export const loadConfig = () => ({
 export type LoadConfigAction = ReturnType<typeof loadConfig>;
 
 // forwards messages to the socket
-export const createConfigMiddleware = (client: WebchatClient, defaultSettings?: IWebchatSettings): Middleware<{}, StoreState> => store => next => (action: LoadConfigAction) => {
+export const createConfigMiddleware = (url: string, overrideWebchatSettings?: IWebchatSettings): Middleware<{}, StoreState> => store => next => (action: LoadConfigAction) => {
     switch (action.type) {
         case 'LOAD_CONFIG': {
-            if (!client.webchatConfig) {
-                client.loadWebchatConfig()
-                    .then(() => {
-                        // set the webchat settings (overridable by embed default settings)
-                        const settings = {
-                            ...client.webchatConfig.settings,
-                            ...defaultSettings
-                        }
-                        
-                        store.dispatch(setConfig({
-                            ...client.webchatConfig,
-                            settings
-                        }));
-                    })
-            }
+            // we might want to check whether we need to fetch the config
+
+            (async () => {
+                const endpointConfig = await fetchWebchatConfig(url);
+                
+                const settings: IWebchatSettings = {
+                    ...endpointConfig.settings,
+                    ...overrideWebchatSettings
+                };
+
+                const config: ConfigState = {
+                    ...endpointConfig,
+                    settings
+                };
+
+                store.dispatch(setConfig(config));
+            })();
+            
 
             break;
         }

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -1,5 +1,5 @@
 import { Reducer } from "redux";
-import { IWebchatConfig } from "@cognigy/webchat-client/lib/interfaces/webchat-config";
+import { IWebchatConfig } from "../../../common/interfaces/webchat-config";
 
 export type ConfigState = IWebchatConfig;
 
@@ -11,13 +11,12 @@ const getInitialState = (): ConfigState => ({
         colorScheme: '',
         designTemplate: 1,
         disableToggleButton: false,
-        startBehavior: 'none',
+        dynamicImageAspectRatio: false,
         enableFileUpload: false,
         enablePersistentMenu: false,
         enableSTT: false,
         enableTTS: false,
         enableTypingIndicator: false,
-        enableConnectionStatusIndicator: false,
         getStartedButtonText: '',
         getStartedPayload: '',
         getStartedText: '',
@@ -29,6 +28,7 @@ const getInitialState = (): ConfigState => ({
             title: '',
             menuItems: []
         },
+        startBehavior: 'none',
         STTLanguage: '',
         title: ''
     }

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -12,6 +12,7 @@ const getInitialState = (): ConfigState => ({
         designTemplate: 1,
         disableToggleButton: false,
         dynamicImageAspectRatio: false,
+        enableConnectionStatusIndicator: false,
         enableFileUpload: false,
         enablePersistentMenu: false,
         enableSTT: false,

--- a/src/webchat/store/connection/connection-handler.ts
+++ b/src/webchat/store/connection/connection-handler.ts
@@ -1,8 +1,8 @@
 import { Store } from "redux";
-import { WebchatClient } from "@cognigy/webchat-client";
 import { setConnected } from "./connection-reducer";
+import { SocketClient } from "@cognigy/socket-client";
 
-export const registerConnectionHandler = (store: Store, client: WebchatClient) => {
+export const registerConnectionHandler = (store: Store, client: SocketClient) => {
     client.on('socket/connect', () => { store.dispatch(setConnected(true)) });
     client.on('socket/disconnect', () => { store.dispatch(setConnected(false)) });
 }

--- a/src/webchat/store/connection/connection-middleware.ts
+++ b/src/webchat/store/connection/connection-middleware.ts
@@ -1,10 +1,9 @@
 import { Middleware } from "redux";
 import { StoreState } from "../store";
-import { WebchatClient } from '@cognigy/webchat-client';
-import { setConnected } from "./connection-reducer";
 import { SetOpenAction, ToggleOpenAction } from "../ui/ui-reducer";
 import { SendMessageAction } from "../messages/message-middleware";
 import { setOptions } from "../options/options-reducer";
+import { SocketClient } from "@cognigy/socket-client";
 
 export interface ISendMessageOptions {
     /* overrides the displayed text within a chat bubble. useful for e.g. buttons */
@@ -18,7 +17,7 @@ export const connect = () => ({
 export type ConnectAction = ReturnType<typeof connect>;
 
 // forwards messages to the socket
-export const createConnectionMiddleware = (client: WebchatClient): Middleware<{}, StoreState> => store => next => (action: SetOpenAction | ToggleOpenAction | ConnectAction | SendMessageAction) => {
+export const createConnectionMiddleware = (client: SocketClient): Middleware<{}, StoreState> => store => next => (action: SetOpenAction | ToggleOpenAction | ConnectAction | SendMessageAction) => {
     switch (action.type) {
         case 'CONNECT': {
             if (!client.connected) {

--- a/src/webchat/store/messages/message-handler.ts
+++ b/src/webchat/store/messages/message-handler.ts
@@ -1,8 +1,8 @@
 import { Store } from "redux";
-import { WebchatClient } from "@cognigy/webchat-client";
 import { IMessage } from "../../../common/interfaces/message";
 import { ISendMessageOptions } from "./message-middleware";
 import { setBotAvatarOverrideUrl, setUserAvatarOverrideUrl } from "../ui/ui-reducer";
+import { SocketClient } from "@cognigy/socket-client";
 
 const RECEIVE_MESSAGE = 'RECEIVE_MESSAGE';
 export const receiveMessage = (message: IMessage, options: Partial<ISendMessageOptions> = {}) => ({
@@ -12,7 +12,7 @@ export const receiveMessage = (message: IMessage, options: Partial<ISendMessageO
 });
 export type ReceiveMessageAction = ReturnType<typeof receiveMessage>;
 
-export const registerMessageHandler = (store: Store, client: WebchatClient) => {
+export const registerMessageHandler = (store: Store, client: SocketClient) => {
     client.on('output', output => {
         // handle custom webchat actions
         if (output.data && output.data._webchat) {

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -1,14 +1,13 @@
 import { Middleware } from "redux";
 import { StoreState } from "../store";
-import { IMessage, IBotMessage, IUserMessage } from "../../../common/interfaces/message";
-import { WebchatClient } from '@cognigy/webchat-client';
+import { IMessage, IBotMessage } from "../../../common/interfaces/message";
 import { addMessage } from "./message-reducer";
 import { Omit } from "react-redux";
 import { setFullscreenMessage } from "../ui/ui-reducer";
 import { SetConfigAction } from "../config/config-reducer";
-import { connect } from "../connection/connection-middleware";
 import { ReceiveMessageAction } from "./message-handler";
 import { defaultBotAvatar, defaultUserImg } from "../../../webchat-ui";
+import { SocketClient } from "@cognigy/socket-client";
 
 export interface ISendMessageOptions {
     /* overrides the displayed text within a chat bubble. useful for e.g. buttons */
@@ -24,7 +23,7 @@ export const sendMessage = (message: Omit<IMessage, 'source'>, options: Partial<
 export type SendMessageAction = ReturnType<typeof sendMessage>;
 
 // forwards messages to the socket
-export const createMessageMiddleware = (client: WebchatClient): Middleware<{}, StoreState> => store => next => (action: SendMessageAction | ReceiveMessageAction | SetConfigAction) => {
+export const createMessageMiddleware = (client: SocketClient): Middleware<{}, StoreState> => store => next => (action: SendMessageAction | ReceiveMessageAction | SetConfigAction) => {
     switch (action.type) {
         case 'SEND_MESSAGE': {
             const { message, options } = action;

--- a/src/webchat/store/options/options-reducer.ts
+++ b/src/webchat/store/options/options-reducer.ts
@@ -1,5 +1,5 @@
-import { Options } from "@cognigy/webchat-client";
 import { Reducer } from "redux";
+import { Options } from "@cognigy/socket-client/lib/interfaces/options";
 
 export type OptionsState = Pick<Options, 'userId' | 'sessionId' | 'channel'>;
 

--- a/src/webchat/store/options/options.ts
+++ b/src/webchat/store/options/options.ts
@@ -1,4 +1,4 @@
-import { Options } from "@cognigy/webchat-client";
+import { Options } from "@cognigy/socket-client/lib/interfaces/options";
 
 export const getOptionsKey = ({ userId, sessionId, channel }: Pick<Options, 'channel' | 'userId' | 'sessionId'>) => 
     JSON.stringify([channel, userId, sessionId]);

--- a/src/webchat/store/store.ts
+++ b/src/webchat/store/store.ts
@@ -1,6 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
 import { StateType } from 'typesafe-actions';
-import { WebchatClient } from '@cognigy/webchat-client/lib/webchat-client';
 import { createMessageMiddleware } from './messages/message-middleware';
 import { registerMessageHandler } from './messages/message-handler';
 import { optionsMiddleware } from './options/options-middleware';
@@ -11,17 +10,19 @@ import { createConfigMiddleware } from './config/config-middleware';
 import { IWebchatSettings } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 import { createAnalyticsMiddleware } from './analytics/analytics-middleware';
 import { registerConnectionHandler } from './connection/connection-handler';
+import { Webchat } from '../components/Webchat';
 
 
 export type StoreState = StateType<typeof reducer>;
 
 // creates a store and connects it to a webchat client
-export const createWebchatStore = (client: WebchatClient, defaultSettings?: IWebchatSettings) => {
+export const createWebchatStore = (webchat: Webchat, defaultSettings?: IWebchatSettings) => {
+    const { client } = webchat;
 
     const store = createStore(
         reducer,
         applyMiddleware(
-            createAnalyticsMiddleware(client),
+            createAnalyticsMiddleware(webchat),
             createConnectionMiddleware(client),
             createMessageMiddleware(client),
             createConfigMiddleware(client, defaultSettings),

--- a/src/webchat/store/store.ts
+++ b/src/webchat/store/store.ts
@@ -7,16 +7,17 @@ import { reducer } from './reducer';
 import { registerTypingHandler } from './typing/typing-handler';
 import { createConnectionMiddleware } from './connection/connection-middleware';
 import { createConfigMiddleware } from './config/config-middleware';
-import { IWebchatSettings } from '@cognigy/webchat-client/lib/interfaces/webchat-config';
 import { createAnalyticsMiddleware } from './analytics/analytics-middleware';
 import { registerConnectionHandler } from './connection/connection-handler';
 import { Webchat } from '../components/Webchat';
+import { Options } from '@cognigy/socket-client/lib/interfaces/options';
+import { IWebchatSettings } from '../../common/interfaces/webchat-config';
 
 
 export type StoreState = StateType<typeof reducer>;
 
 // creates a store and connects it to a webchat client
-export const createWebchatStore = (webchat: Webchat, defaultSettings?: IWebchatSettings) => {
+export const createWebchatStore = (webchat: Webchat, url: string, overrideWebchatSettings?: IWebchatSettings) => {
     const { client } = webchat;
 
     const store = createStore(
@@ -25,7 +26,7 @@ export const createWebchatStore = (webchat: Webchat, defaultSettings?: IWebchatS
             createAnalyticsMiddleware(webchat),
             createConnectionMiddleware(client),
             createMessageMiddleware(client),
-            createConfigMiddleware(client, defaultSettings),
+            createConfigMiddleware(url, overrideWebchatSettings),
             optionsMiddleware,
         )
     );

--- a/src/webchat/store/typing/typing-handler.ts
+++ b/src/webchat/store/typing/typing-handler.ts
@@ -1,9 +1,9 @@
-import { WebchatClient } from "@cognigy/webchat-client";
 import { Store } from "redux";
 import { setTyping } from "../ui/ui-reducer";
+import { SocketClient } from "@cognigy/socket-client";
 
 
-export const registerTypingHandler = (store: Store, client: WebchatClient) => {
+export const registerTypingHandler = (store: Store, client: SocketClient) => {
     client.on('typingStatus', payload => {
         try {
             const typing = payload.status === 'typingOn';


### PR DESCRIPTION
The goal of this PR is to get rid of the dependency on @cognigy/webchat-client.

Therefore, the following features moved here from WebchatClient:
- default channel name is set to "webchat-client"
- fetching of endpoint config
- providing of analytics event emitter
- interfaces for WebchatSettings

The API of the Webchat did not change in this PR.
Everything should work exactly as before.