### PR TITLE
update socket-client to v4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1644,11 +1644,11 @@
             }
         },
         "@cognigy/socket-client": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.1.1.tgz",
-            "integrity": "sha512-NZudX/02TfGIG4ccS0E9/uDWmtY5s5J6yY6S3ADmn75NQIOQFbw1XHJRVkzExMBwjYcV6O5jOh1upTreE7pIRw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.2.0.tgz",
+            "integrity": "sha512-Xx17XR5Y+GlEknRyDfJZkbowDxGdgYbVZeOwJ+QG28x1JLgOq32z1X1KuFLVkmg44upvht3xQcK/76tKZ68ucw==",
             "requires": {
-                "@types/node": "^12.7.1",
+                "detect-browser": "^4.8.0",
                 "socket.io-client": "^2.2.0",
                 "url": "^0.11.0",
                 "uuid": "^3.3.2"
@@ -1839,7 +1839,8 @@
         "@types/node": {
             "version": "12.12.11",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
-            "integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ=="
+            "integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ==",
+            "dev": true
         },
         "@types/parse-json": {
             "version": "4.0.0",
@@ -3557,6 +3558,11 @@
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
             "dev": true
+        },
+        "detect-browser": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-4.8.0.tgz",
+            "integrity": "sha512-f4h2dFgzHUIpjpBLjhnDIteXv8VQiUm8XzAuzQtYUqECX/eKh67ykuiVoyb7Db7a0PUSmJa3OGXStG0CbQFUVw=="
         },
         "detect-file": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "webchat": "webpack --config webpack.production.js"
     },
     "dependencies": {
-        "@cognigy/socket-client": "^4.1.1",
+        "@cognigy/socket-client": "^4.2.0",
         "@emotion/cache": "^10.0.19",
         "@emotion/core": "^10.0.22",
         "@emotion/provider": "^0.11.2",


### PR DESCRIPTION
This PR updates the socket-client to v4.2.0 in order to stay compatible with IE11 (the compatibility options moved from webchat-client to socket-client).