### PR TITLE
Implement option to disable saving into localStorage

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -64,7 +64,7 @@ See it in action:
 | headerLogoUrl | string | COGNIGY.AI Logo | The logo to display in the header of the Webchat. Defaults to a COGNIGY.AI logo. 
 | enableConnectionStatusIndicator | boolean | false | Whether to show a warning if the connection is lost during a conversation. The warning will disappear when the connection is re-established. | enableTypingIndicator | boolean | true | Whether to enable typing indicators in the Webchat when the Conversational AI is replying. Requires a messageDelay to be set. 
 | disableInputAutofocus | boolean | false | By default, the input will automatically focus when a user opens the widget. If you set this to true, the input will no longer focus when opening the widget.
-| disableLocalStorage | boolean | false | If true, disables storing any data in localStorage (including chat history). 
+| disablePersistentHistory | boolean | false | If true, disables storing of the chat history into LocalStorage (used for persistence). 
 | disableTextInputSanitization | boolean | false | By default, text inputs from the user will be sanitized for HTML with scripting. If you set this to true, users can send any kind of HTML text, including script-tags and onload-attributes etc.
 | enablePersistentMenu | boolean | false | Whether to enable the Persistent Menu 
 | persistentMenu | [Persistent Menu](#persistent-menu) | - | The Persistent Menu to render in the Webchat.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -64,6 +64,7 @@ See it in action:
 | headerLogoUrl | string | COGNIGY.AI Logo | The logo to display in the header of the Webchat. Defaults to a COGNIGY.AI logo. 
 | enableConnectionStatusIndicator | boolean | false | Whether to show a warning if the connection is lost during a conversation. The warning will disappear when the connection is re-established. | enableTypingIndicator | boolean | true | Whether to enable typing indicators in the Webchat when the Conversational AI is replying. Requires a messageDelay to be set. 
 | disableInputAutofocus | boolean | false | By default, the input will automatically focus when a user opens the widget. If you set this to true, the input will no longer focus when opening the widget.
+| disableLocalStorage | boolean | false | If true, disables storing any data in localStorage (including chat history). 
 | disableTextInputSanitization | boolean | false | By default, text inputs from the user will be sanitized for HTML with scripting. If you set this to true, users can send any kind of HTML text, including script-tags and onload-attributes etc.
 | enablePersistentMenu | boolean | false | Whether to enable the Persistent Menu 
 | persistentMenu | [Persistent Menu](#persistent-menu) | - | The Persistent Menu to render in the Webchat.

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -9,7 +9,7 @@ export interface IWebchatSettings {
     colorScheme: string;
     designTemplate: number;
     disableInputAutofocus: boolean;
-    disableLocalStorage: boolean;
+    disablePersistentHistory: boolean;
     disableTextInputSanitization: boolean;
     disableToggleButton: boolean;
     dynamicImageAspectRatio: boolean;

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -9,6 +9,7 @@ export interface IWebchatSettings {
     colorScheme: string;
     designTemplate: number;
     disableInputAutofocus: boolean;
+    disableLocalStorage: boolean;
     disableTextInputSanitization: boolean;
     disableToggleButton: boolean;
     dynamicImageAspectRatio: boolean;

--- a/src/webchat-embed/index.tsx
+++ b/src/webchat-embed/index.tsx
@@ -37,15 +37,13 @@ const initWebchat = async (webchatConfigUrl: string, options?: InitWebchatOption
             : plugin
         );
 
-    const { disableLocalStorage } = options && options.settings;
-
     // if no specific userId is provided, try to load one from localStorage, otherwise generate one and persist it in localstorage
     if ((!options || !options.userId) && localStorage) {
         let userId = localStorage.getItem('userId');
 
         if (!userId) {
             userId = uuid.v4();
-            !disableLocalStorage && localStorage.setItem('userId', userId);
+            localStorage.setItem('userId', userId);
         }
 
         if (!options)

--- a/src/webchat-embed/index.tsx
+++ b/src/webchat-embed/index.tsx
@@ -37,13 +37,15 @@ const initWebchat = async (webchatConfigUrl: string, options?: InitWebchatOption
             : plugin
         );
 
+    const { disableLocalStorage } = options && options.settings;
+
     // if no specific userId is provided, try to load one from localStorage, otherwise generate one and persist it in localstorage
     if ((!options || !options.userId) && localStorage) {
         let userId = localStorage.getItem('userId');
 
         if (!userId) {
             userId = uuid.v4();
-            localStorage.setItem('userId', userId);
+            !disableLocalStorage && localStorage.setItem('userId', userId);
         }
 
         if (!options)

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -12,7 +12,7 @@ const getInitialState = (): ConfigState => ({
         colorScheme: '',
         designTemplate: 1,
         disableInputAutofocus: false,
-        disableLocalStorage: false,
+        disablePersistentHistory: false,
         disableTextInputSanitization: false,
         disableToggleButton: false,
         dynamicImageAspectRatio: false,

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -12,6 +12,7 @@ const getInitialState = (): ConfigState => ({
         colorScheme: '',
         designTemplate: 1,
         disableInputAutofocus: false,
+        disableLocalStorage: false,
         disableTextInputSanitization: false,
         disableToggleButton: false,
         dynamicImageAspectRatio: false,

--- a/src/webchat/store/options/options-middleware.ts
+++ b/src/webchat/store/options/options-middleware.ts
@@ -27,9 +27,9 @@ export const optionsMiddleware: Middleware<{}, StoreState> = store => next => (a
     }
 
     const { active } = store.getState().config;
-    const { disableLocalStorage } = store.getState().config.settings;
+    const { disablePersistentHistory } = store.getState().config.settings;
 
-    if (localStorage && active && !disableLocalStorage) {
+    if (localStorage && active && !disablePersistentHistory) {
         localStorage.setItem(key, JSON.stringify(store.getState()));
     }
 

--- a/src/webchat/store/options/options-middleware.ts
+++ b/src/webchat/store/options/options-middleware.ts
@@ -26,10 +26,12 @@ export const optionsMiddleware: Middleware<{}, StoreState> = store => next => (a
         }
     }
 
-    const result = next(action);
+    const { active } = store.getState().config;
+    const { disableLocalStorage } = store.getState().config.settings;
 
-    if (localStorage)
+    if (localStorage && active && !disableLocalStorage) {
         localStorage.setItem(key, JSON.stringify(store.getState()));
+    }
 
-    return result;
+    return next(action);
 }


### PR DESCRIPTION
Please test the new option for initWebchat settings: "disableLocalStorage". If set true Webchat should not save to the browser's localStorage.

Quick config:

`initWebchat('https://endpoint-dev.cognigy.ai/20071358ef60561acb9288e5ccf1b251262538743e527873681010cd63ef926a', {
            sessionId: "MY_ID",
            settings: {
                colorScheme: '#FA2',
                disableLocalStorage: true,
            }
        }).then(webchat => {
            window.cognigyWebchat = webchat;
            webchat.open();
        });`