### PR TITLE
fix facebook channel default inheritance

### DIFF
--- a/src/plugins/messenger/index.tsx
+++ b/src/plugins/messenger/index.tsx
@@ -14,6 +14,9 @@ const getMessengerPayload = message => {
     if (!_cognigy)
         return null;
 
+    if (!_cognigy.syncWebchatWithFacebook)
+        return null;
+
     const { _facebook, _webchat } = _cognigy;
 
     return _webchat || _facebook;

--- a/src/plugins/messenger/index.tsx
+++ b/src/plugins/messenger/index.tsx
@@ -14,7 +14,7 @@ const getMessengerPayload = message => {
     if (!_cognigy)
         return null;
 
-    if (!_cognigy.syncWebchatWithFacebook)
+    if (!_cognigy._webchat && !_cognigy.syncWebchatWithFacebook)
         return null;
 
     const { _facebook, _webchat } = _cognigy;


### PR DESCRIPTION
This PR fixes the bug in where Webchat will always show the Facebook channel tab as a default, even if the "use Facebook channel"  checkbox is not checked.

To test, speak with a flow through the Webchat and write something in the default tab and facebook tab, checking the use Facebook channel box in the Webchat tab should work how it is intended