### PR TITLE
Implement disableHtmlInputRendering setting

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -63,6 +63,8 @@ See it in action:
 | agentAvatarUrl | string | undefined | A custom avatar that sould be displayed next to agent messages
 | headerLogoUrl | string | COGNIGY.AI Logo | The logo to display in the header of the Webchat. Defaults to a COGNIGY.AI logo. 
 | enableConnectionStatusIndicator | boolean | false | Whether to show a warning if the connection is lost during a conversation. The warning will disappear when the connection is re-established. | enableTypingIndicator | boolean | true | Whether to enable typing indicators in the Webchat when the Conversational AI is replying. Requires a messageDelay to be set. 
+| disableHtmlInputRendering | boolean | false | If true, strips all html tags out from the input of the user.
+
 | disableInputAutofocus | boolean | false | By default, the input will automatically focus when a user opens the widget. If you set this to true, the input will no longer focus when opening the widget.
 | disablePersistentHistory | boolean | false | If true, disables storing of the chat history into LocalStorage (used for persistence). 
 | disableTextInputSanitization | boolean | false | By default, text inputs from the user will be sanitized for HTML with scripting. If you set this to true, users can send any kind of HTML text, including script-tags and onload-attributes etc.

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -8,6 +8,7 @@ export interface IWebchatSettings {
     backgroundImageUrl: string;
     colorScheme: string;
     designTemplate: number;
+    disableHtmlInputRendering: boolean;
     disableInputAutofocus: boolean;
     disablePersistentHistory: boolean;
     disableTextInputSanitization: boolean;

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -11,6 +11,7 @@ const getInitialState = (): ConfigState => ({
         backgroundImageUrl: '',
         colorScheme: '',
         designTemplate: 1,
+        disableHtmlInputRendering: false,
         disableInputAutofocus: false,
         disablePersistentHistory: false,
         disableTextInputSanitization: false,

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -54,6 +54,15 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<{}, St
                 text = sanitizeHTML(text || '');
             }
 
+            if (store.getState().config.settings.disableHtmlInputRendering) {
+                console.log(text);
+                text = new DOMParser()
+                    .parseFromString(text || '', 'text/html')
+                    .body
+                    .textContent || '';
+                    console.log(text);
+            }
+
             client.sendMessage(text || '', data);
 
             const displayMessage = { ...message, text };

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -55,12 +55,10 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<{}, St
             }
 
             if (store.getState().config.settings.disableHtmlInputRendering) {
-                console.log(text);
                 text = new DOMParser()
                     .parseFromString(text || '', 'text/html')
                     .body
                     .textContent || '';
-                    console.log(text);
             }
 
             client.sendMessage(text || '', data);


### PR DESCRIPTION
Please test the new `disableHtmlInputRendering` setting. With this set to true, input from the user should be free from the html tags.

Signed-off-by: Dmitrii Ostasevich <d.ostasevich@cognigy.com>