### PR TITLE
Add "enableStrictMessengerSync" flag, add "config" as parameters for message plugin matchers

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -56,6 +56,7 @@ See it in action:
 | getStartedButtonText | string | "GET_STARTED" | The text to display on the Get Started Button / when sending the auto message. 
 | inputPlaceholder | string | "Write a reply" | The placeholder text to display in the input field. 
 | enableSTT | boolean | false | Whether to enable speech input that lets the user speak to the Webchat instead of only typing. 
+| enableStrictMessengerSync | boolean | false | If set to true, will NOT render the message from the "Messenger" tab in the SAY node unless "Use Facebook Channel" is checked in the "Webchat" tab. 
 | enableTTS | boolean | false | Whether to enable the browser to read the bot messages aloud. 
 | colorScheme | string | The background color of the header and bot messages in the Webchat. | designTemplate | 1 or 2 | 1 | The Webchat design template to use. We default to design template 1 (bottom right with a button), you can switch to template 2, which is the centered webchat. 
 | messageLogoUrl | string | COGNIGY.AI Logo | A custom avatar that should be displayed next to bot messages. Defaults to a COGNIGY.AI logo. 

--- a/src/common/interfaces/message-plugin.ts
+++ b/src/common/interfaces/message-plugin.ts
@@ -16,7 +16,7 @@ export interface MessageComponentProps {
     theme: IWebchatTheme;
 }
 
-export type MessageMatcher = (message: IMessage) => boolean;
+export type MessageMatcher = (message: IMessage, config: IWebchatConfig) => boolean;
 
 export interface MessagePluginOptions {
     fullscreen: boolean;

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -18,6 +18,7 @@ export interface IWebchatSettings {
     enableFileUpload: boolean;
     enablePersistentMenu: boolean;
     enableSTT: boolean;
+    enableStrictMessengerSync: boolean;
     enableTTS: boolean;
     enableTypingIndicator: boolean;
     getStartedButtonText: string;

--- a/src/plugins/helper.tsx
+++ b/src/plugins/helper.tsx
@@ -1,6 +1,7 @@
 import { MessagePlugin, MessageComponent, MessagePluginOptions, MessageMatcher, MessagePluginFactory } from "../common/interfaces/message-plugin";
-import { InputPlugin, InputComponent, InputPluginOptions, InputRule, InputPluginFactory } from "../common/interfaces/input-plugin";
+import { InputPlugin, InputPluginFactory } from "../common/interfaces/input-plugin";
 import { IMessage } from "../common/interfaces/message";
+import { IWebchatConfig } from "../common/interfaces/webchat-config";
 
 const createStringMatcher = (name: string): MessageMatcher => message => message.data
     && message.data._plugin
@@ -50,11 +51,11 @@ export const registerInputPlugin = (plugin: InputPlugin | InputPluginFactory) =>
     }
 }
 
-export const getPluginsForMessage = (plugins: MessagePlugin[]) => (message: IMessage): MessagePlugin[] => {
+export const getPluginsForMessage = (plugins: MessagePlugin[], config: IWebchatConfig) => (message: IMessage): MessagePlugin[] => {
     let matchedPlugins: MessagePlugin[] = [];
-
+    
     for (const plugin of plugins) {
-        const isMatch = (plugin.match as MessageMatcher)(message);
+        const isMatch = (plugin.match as MessageMatcher)(message, config);
 
         if (isMatch) {
             matchedPlugins.push(plugin);

--- a/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
@@ -41,7 +41,7 @@ export default ({
 }: MessageProps): JSX.Element => {
   const attributes = Object.keys(props).length > 0 ? props : undefined;
 
-  const matchedPlugins = getPluginsForMessage(plugins)(message);
+  const matchedPlugins = getPluginsForMessage(plugins, config)(message);
   const source = message.source;
 
   let className;

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -1,11 +1,8 @@
-import * as React from 'react';
 import { WebchatUI, WebchatUIProps } from "../../webchat-ui";
 import { connect } from "react-redux";
 import { StoreState } from "../store/store";
 import { sendMessage } from '../store/messages/message-middleware';
 import { setInputMode, setFullscreenMessage, setOpen, toggleOpen } from '../store/ui/ui-reducer';
-import { MessagePlugin } from '../../common/interfaces/message-plugin';
-import { IMessage } from '../../common/interfaces/message';
 import { getPluginsForMessage, isFullscreenPlugin } from '../../plugins/helper';
 
 type FromState = Pick<WebchatUIProps, 'messages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config' | 'connected'>;
@@ -36,7 +33,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
             const lastMessage = state.messages.slice(-1)[0];
 
             const matchedPlugins = lastMessage
-                ? getPluginsForMessage(props.messagePlugins || [])(lastMessage)
+                ? getPluginsForMessage(props.messagePlugins || [], state.config)(lastMessage)
                 : [];
 
             const lastPlugin = matchedPlugins.slice(-1)[0];

--- a/src/webchat/store/config/config-middleware.ts
+++ b/src/webchat/store/config/config-middleware.ts
@@ -1,9 +1,7 @@
 import { Middleware } from "redux";
 import { StoreState } from "../store";
 import { setConfig, ConfigState } from "./config-reducer";
-import { SocketClient } from "@cognigy/socket-client";
 import { fetchWebchatConfig } from "../../helper/endpoint";
-import { Options } from "@cognigy/socket-client/lib/interfaces/options";
 import { IWebchatSettings } from "../../../common/interfaces/webchat-config";
 
 export interface ISendMessageOptions {

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -21,6 +21,7 @@ const getInitialState = (): ConfigState => ({
         enableFileUpload: false,
         enablePersistentMenu: false,
         enableSTT: false,
+        enableStrictMessengerSync: false,
         enableTTS: false,
         enableTypingIndicator: false,
         getStartedButtonText: '',

--- a/src/webchat/store/store.ts
+++ b/src/webchat/store/store.ts
@@ -10,7 +10,6 @@ import { createConfigMiddleware } from './config/config-middleware';
 import { createAnalyticsMiddleware } from './analytics/analytics-middleware';
 import { registerConnectionHandler } from './connection/connection-handler';
 import { Webchat } from '../components/Webchat';
-import { Options } from '@cognigy/socket-client/lib/interfaces/options';
 import { IWebchatSettings } from '../../common/interfaces/webchat-config';
 
 


### PR DESCRIPTION
If the `enableStrictMessengerSync` flag is provided via webchat settings, it will cause the messenger plugin to not render messages from the "messenger" tab unless the "Use Facebook Channel" feature is enabled in the "Webchat" tab.

Example Message 1: 
SAY
 - default tab 
   - text: "default"
 - webchat tab
   - Use Facebook Channel: off
   - type: none
 - messenger tab
   - type: Text & Quick Replies
   - text: "messenger"

Example Message 2:
SAY
 - default tab 
   - text: "default"
 - webchat tab
   - Use Facebook Channel: on
   - type: none
 - messenger tab
   - type: Text & Quick Replies
   - text: "messenger"

Example Message 3:
SAY
 - default tab 
   - text: "default"
 - webchat tab
   - Use Facebook Channel: ff
   - type: Text & Quick Replies
   - text: "webchat"
 - messenger tab
   - type: Text & Quick Replies
   - text: "messenger"

| message | result without the flag | result with flag |
| - | - | - |
| Message 1 | messenger | default |
| Message 2 | messenger | messenger |
| Message 3 | webchat | webchat |


To make this possible, the "matcher" of the messenger plugin has to access the webchat settings in order to decide whether to fall back to messenger template or not, so i added the webchat config (wich contain the settings) as an additional parameter to MessageMatcher functions.