### PR TITLE
Fix typing indicator flickering

### DIFF
--- a/src/common/interfaces/typing.ts
+++ b/src/common/interfaces/typing.ts
@@ -1,0 +1,1 @@
+export type TTyping = 'show' | 'hide' | 'remove';

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -30,6 +30,7 @@ import ChatIcon from '../assets/baseline-chat-24px.svg';
 import CloseIcon from '../assets/baseline-close-24px.svg';
 import DisconnectOverlay from './presentational/DisconnectOverlay';
 import { IWebchatConfig } from '../../common/interfaces/webchat-config';
+import { TTyping } from '../../common/interfaces/typing';
 
 export interface WebchatUIProps {
     messages: IMessage[];
@@ -39,7 +40,7 @@ export interface WebchatUIProps {
 
     onSendMessage: MessageSender;
     config: IWebchatConfig;
-    typingIndicator: boolean;
+    typingIndicator: TTyping;
 
     open: boolean;
 
@@ -292,6 +293,9 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         const { messages, typingIndicator, config, onEmitAnalytics } = this.props;
         const { messagePlugins = [] } = this.state;
 
+        const renderTypingIndicator = typingIndicator !== "remove";
+        const typingIndicatorHidden = typingIndicator === 'hide';
+
         return (
             <>
                 {messages.map((message, index) => (
@@ -307,8 +311,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                         onEmitAnalytics={onEmitAnalytics}
                     />
                 ))}
-                {typingIndicator && (
-                    <MessageRow align='left'>
+                {renderTypingIndicator && (
+                    <MessageRow align='left' hidden={typingIndicatorHidden}>
                         <TypingIndicatorBubble />
                     </MessageRow>
                 )}

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -293,7 +293,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         const { messages, typingIndicator, config, onEmitAnalytics } = this.props;
         const { messagePlugins = [] } = this.state;
 
-        const renderTypingIndicator = typingIndicator !== "remove";
+        const renderTypingIndicator = typingIndicator !== 'remove';
         const typingIndicatorHidden = typingIndicator === 'hide';
 
         return (

--- a/src/webchat-ui/components/presentational/MessageRow.tsx
+++ b/src/webchat-ui/components/presentational/MessageRow.tsx
@@ -5,11 +5,16 @@ export interface IAlignmentProps {
     align?: 'left' | 'right';
 }
 
-export default styled.div<IAlignmentProps>(({ theme, align }) => {
+interface IVisibilityProps {
+    hide?: boolean;
+}
+
+export default styled.div<IAlignmentProps & IVisibilityProps>(({ theme, align, hide }) => {
     let paddingLeft = theme.unitSize * 2;
     let paddingRight = theme.unitSize * 2;
     let flexDirection;
     let avatarStyles: any = {};
+    let visibility: "hidden" | "visible" = hide ? "hidden" : "visible";
     
     switch (align) {
         case 'right': {
@@ -36,6 +41,8 @@ export default styled.div<IAlignmentProps>(({ theme, align }) => {
 		alignItems: "flex-end",
         paddingLeft,
         paddingRight,
+        transition: "visibility 0s linear 200ms",
+        visibility,
 
         '&>*': {
             marginTop: theme.unitSize,

--- a/src/webchat/store/messages/message-handler.ts
+++ b/src/webchat/store/messages/message-handler.ts
@@ -1,7 +1,7 @@
 import { Store } from "redux";
 import { IMessage } from "../../../common/interfaces/message";
 import { ISendMessageOptions } from "./message-middleware";
-import { setBotAvatarOverrideUrl, setUserAvatarOverrideUrl, setAgentAvatarOverrideUrl } from "../ui/ui-reducer";
+import { setBotAvatarOverrideUrl, setUserAvatarOverrideUrl, setAgentAvatarOverrideUrl, setTyping } from "../ui/ui-reducer";
 import { SocketClient } from "@cognigy/socket-client";
 
 const RECEIVE_MESSAGE = 'RECEIVE_MESSAGE';
@@ -31,6 +31,7 @@ export const registerMessageHandler = (store: Store, client: SocketClient) => {
             }
         }
 
-        store.dispatch(receiveMessage(output))
+        store.dispatch(setTyping("remove"));
+        store.dispatch(receiveMessage(output));
     });
 }

--- a/src/webchat/store/typing/typing-handler.ts
+++ b/src/webchat/store/typing/typing-handler.ts
@@ -6,8 +6,17 @@ import { SocketClient } from "@cognigy/socket-client";
 export const registerTypingHandler = (store: Store, client: SocketClient) => {
     client.on('typingStatus', payload => {
         try {
-            const typing = payload.status === 'typingOn';
-            store.dispatch(setTyping(typing));
-        } catch (e) {}
+            const typingOn = payload.status === 'typingOn';
+            const oldValue = store.getState().ui.typing;
+            /*
+            * Dispatch setTyping('show') if we received `typingOn` or the old value was 'show', 
+            * otherwise skip. This way we can ignore double typingOff events {we do
+            * setTyping('remove') on the 'output' event, e.g. on receiving regular message}
+            */
+            const typingStatus = typingOn ? 'show' : oldValue === 'show' ? 'hide' : null;
+            if (typingStatus) {
+                store.dispatch(setTyping(typingStatus));
+            }
+        } catch (e) { }
     });
 }

--- a/src/webchat/store/ui/ui-reducer.ts
+++ b/src/webchat/store/ui/ui-reducer.ts
@@ -1,9 +1,10 @@
 import { Reducer } from "redux";
 import { IMessage } from "../../../common/interfaces/message";
+import { TTyping } from "../../../common/interfaces/typing";
 
 export interface UIState {
     open: boolean;
-    typing: boolean;
+    typing: TTyping;
     inputMode: string;
     fullscreenMessage: IMessage | undefined;
     agentAvatarOverrideUrl?: string;
@@ -25,7 +26,7 @@ export const toggleOpen = () => ({
 export type ToggleOpenAction = ReturnType<typeof toggleOpen>;
 
 const SET_TYPING = 'SET_TYPING';
-export const setTyping = (typing: boolean) => ({
+export const setTyping = (typing: TTyping) => ({
     type: SET_TYPING as 'SET_TYPING',
     typing
 });
@@ -69,7 +70,7 @@ type SetUserAvatarOverrideUrlAction = ReturnType<typeof setUserAvatarOverrideUrl
 
 const getInitialState = (): UIState => ({
     open: false,
-    typing: false,
+    typing: 'remove',
     inputMode: 'text',
     fullscreenMessage: undefined,
     agentAvatarOverrideUrl: undefined,


### PR DESCRIPTION
This PR fixes a flickering typing indicator issue when Webchat receives multiple typing events from backend. You can test it with an example flow attached to the ticket from #8777 task.

Fixes #99 

Signed-off-by: Dmitrii Ostasevich <d.ostasevich@cognigy.com>