### PR TITLE
Add `disableLocalStorage` setting

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -70,6 +70,7 @@ See it in action:
 | disableHtmlInput | boolean | false | If true, strips all html tags out from the input of the user.
 
 | disableInputAutofocus | boolean | false | By default, the input will automatically focus when a user opens the widget. If you set this to true, the input will no longer focus when opening the widget.
+| disableLocalStorage | boolean | false | If true, disables storing any information in browsers storage like persistent history and userId. This flag has a higher priority than `useSessionStorage` - setting this to true also disables SessionStorage.
 | disablePersistentHistory | boolean | false | If true, disables storing of the chat history into LocalStorage (used for persistence). 
 | disableTextInputSanitization | boolean | false | By default, text inputs from the user will be sanitized for HTML with scripting. If you set this to true, users can send any kind of HTML text, including script-tags and onload-attributes etc.
 | enablePersistentMenu | boolean | false | Whether to enable the Persistent Menu 

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -10,6 +10,7 @@ export interface IWebchatSettings {
     designTemplate: number;
     disableHtmlInput: boolean;
     disableInputAutofocus: boolean;
+    disableLocalStorage: boolean;
     disablePersistentHistory: boolean;
     disableTextInputSanitization: boolean;
     disableToggleButton: boolean;

--- a/src/webchat-embed/index.tsx
+++ b/src/webchat-embed/index.tsx
@@ -37,6 +37,7 @@ const initWebchat = async (webchatConfigUrl: string, options?: InitWebchatOption
             : plugin
         );
 
+    const disableLocalStorage = options && options.settings && options.settings.disableLocalStorage;
     const useSessionStorage = options && options.settings && options.settings.useSessionStorage;
     const browserStorage = useSessionStorage ? sessionStorage : localStorage;
 
@@ -46,7 +47,7 @@ const initWebchat = async (webchatConfigUrl: string, options?: InitWebchatOption
 
         if (!userId) {
             userId = uuid.v4();
-            browserStorage.setItem('userId', userId);
+            if (!disableLocalStorage) browserStorage.setItem('userId', userId);
         }
 
         if (!options)

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -13,6 +13,7 @@ const getInitialState = (): ConfigState => ({
         designTemplate: 1,
         disableHtmlInput: false,
         disableInputAutofocus: false,
+        disableLocalStorage: false,
         disablePersistentHistory: false,
         disableTextInputSanitization: false,
         disableToggleButton: false,

--- a/src/webchat/store/options/options-middleware.ts
+++ b/src/webchat/store/options/options-middleware.ts
@@ -9,7 +9,7 @@ type Actions = SetOptionsAction
 export const optionsMiddleware: Middleware<{}, StoreState> = store => next => (action: Actions) => {
     const key = getOptionsKey(store.getState().options);
     const { active } = store.getState().config; // Actual settings are loaded
-    const { disablePersistentHistory, useSessionStorage } = store.getState().config.settings;
+    const { disableLocalStorage, disablePersistentHistory, useSessionStorage } = store.getState().config.settings;
     const browserStorage = useSessionStorage ? window.sessionStorage : window.localStorage;
 
     switch (action.type) {
@@ -29,7 +29,7 @@ export const optionsMiddleware: Middleware<{}, StoreState> = store => next => (a
         }
     }
 
-    if (browserStorage && active && !disablePersistentHistory) {
+    if (browserStorage && active && !(disablePersistentHistory || disableLocalStorage)) {
         browserStorage.setItem(key, JSON.stringify(store.getState()));
     }
 


### PR DESCRIPTION
This PR adds new setting `disableLocalStorage`, which disables storing any information in local- and session- storage.

Signed-off-by: Dmitrii Ostasevich <d.ostasevich@cognigy.com>