### PR TITLE
Force Websockets for iOS/Node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1714,9 +1714,9 @@
             }
         },
         "@cognigy/socket-client": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.3.0.tgz",
-            "integrity": "sha512-fPaaAVeM/q648rl1ulkQSMy2X+jTEBQszKGfB3o7qkC+P2Y0rMGAxXjzTQcObhkSZI4ELmDcelIoHfZE1dowzw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.3.1.tgz",
+            "integrity": "sha512-0f8gjE41m5Cse+RDKTj87qLXwo2yME5XWnO7QFY6yl72gCXyzMs6wSJZJFdPwItyVt9aBEb7cA/Iqq8V0AmMFA==",
             "requires": {
                 "detect-browser": "^4.8.0",
                 "socket.io-client": "^2.2.0",
@@ -3827,11 +3827,11 @@
             }
         },
         "engine.io-client": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.1.tgz",
-            "integrity": "sha512-RJNmA+A9Js+8Aoq815xpGAsgWH1VoSYM//2VgIiu9lNOaHFfLpTjH4tOzktBpjIs5lvOfiNY1dwf+NuU6D38Mw==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.2.tgz",
+            "integrity": "sha512-AWjc1Xg06a6UPFOBAzJf48W1UR/qKYmv/ubgSCumo9GXgvL/xGIvo05dXoBL+2NTLMipDI7in8xK61C17L25xg==",
             "requires": {
-                "component-emitter": "1.2.1",
+                "component-emitter": "~1.3.0",
                 "component-inherit": "0.0.3",
                 "debug": "~4.1.0",
                 "engine.io-parser": "~2.2.0",
@@ -3842,6 +3842,13 @@
                 "ws": "~6.1.0",
                 "xmlhttprequest-ssl": "~1.5.4",
                 "yeast": "0.1.2"
+            },
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+                    "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+                }
             }
         },
         "engine.io-parser": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "webchat": "webpack --config webpack.production.js"
     },
     "dependencies": {
-        "@cognigy/socket-client": "^4.3.0",
+        "@cognigy/socket-client": "^4.3.1",
         "@emotion/cache": "^10.0.19",
         "@emotion/core": "^10.0.22",
         "@emotion/provider": "^0.11.2",

--- a/src/webchat-ui/components/branding/Branding.tsx
+++ b/src/webchat-ui/components/branding/Branding.tsx
@@ -18,16 +18,19 @@ const Link = styled.a(({ theme }) => ({
 }));
 
 const Logo = styled(CognigyLogo)(({ theme }) => ({
-    fill: tinycolor(theme.greyWeakColor).setAlpha(.9).toHex8String(),
+    fill: theme.greyWeakColor,
     height: 11,
+    width: 80,
     marginLeft: 3,
+    opacity: .9
 }));
 
 const URL = 'https://cognigy.com/';
 
 const Branding = () => (
     <Link href={URL} target="_blank">
-        Powered by <Logo />
+        <span>Powered by</span>
+        <Logo />
     </Link>
 );
 


### PR DESCRIPTION
This PR fixes issues with recent versions of iOS browsers, which now block 3rd-party cookies completely by default. This is not an issue when using the `forceWebsockets` option. This PR uses an updated version of `@cognigy/socket-client` which will set `forceWebsockets` to `true` for `ios`, `ios-webview` and `chrome on iOS`. I also added `node` because it needs that too.

In addition to that, i fixed a visual bug with the recently added branding bar for IE11, which found a creative way to lay out the bar and also did not display the logo color correctly. brilliant.