### PR TITLE
Bug/9198 fix connection status indicator

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -216,7 +216,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                                             ? this.renderRegularLayout()
                                             : this.renderFullscreenMessageLayout()
                                         }
-                                        {showDisconnectOverlay && <DisconnectOverlay isPermanent={!!reconnectionLimit}/>}
+                                        {showDisconnectOverlay && <DisconnectOverlay isPermanent={!!reconnectionLimit} onClose={this.props.onClose} />}
                                     </WebchatRoot>
                                 )}
                                 {!disableToggleButton && (

--- a/src/webchat-ui/components/presentational/DisconnectOverlay.tsx
+++ b/src/webchat-ui/components/presentational/DisconnectOverlay.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { styled } from '../../style';
+import IconButton from './IconButton';
+import CloseIcon from '../../assets/baseline-close-24px.svg';
 
 const Wrapper = styled.div(({ theme }) => ({
     display: 'flex',
@@ -29,16 +31,32 @@ const Dialog = styled.div(({ theme }) => ({
     boxShadow: theme.shadow,
 }));
 
-export default ({ isPermanent }) => {
+const HeaderIconButton = styled(IconButton)(({ theme }) => ({
+    position: 'absolute',
+    right: theme.unitSize,
+    top: theme.unitSize + 1,
+
+    color: theme.primaryContrastColor,
+    fill: theme.primaryContrastColor,
+}));
+
+export default ({ isPermanent, onClose }) => {
     return (
         <Wrapper>
             <Dialog>
                 {isPermanent ? (
                     <span>Connection lost. Try to reload the page</span>
                 ) : (
-                    <span>Connection lost. Trying to reconnect...</span>
-                )}
+                        <span>Connection lost. Trying to reconnect...</span>
+                    )}
             </Dialog>
+            <HeaderIconButton
+                data-header-close-button
+                onClick={onClose}
+                className="webchat-header-close-button"
+            >
+                <CloseIcon />
+            </HeaderIconButton>
         </Wrapper>
     );
 };

--- a/src/webchat/store/connection/connection-handler.ts
+++ b/src/webchat/store/connection/connection-handler.ts
@@ -7,7 +7,7 @@ export const registerConnectionHandler = (store: Store, client: SocketClient) =>
         store.dispatch(setConnected(true))
     }
 
-    const handleDicsonnected = () => {
+    const handleDisconnected = () => {
         store.dispatch(setConnected(false));
     }
 
@@ -16,7 +16,7 @@ export const registerConnectionHandler = (store: Store, client: SocketClient) =>
     client.on('socket/pong', handleConnected);
     client.on('output', handleConnected);
 
-    client.on('socket/disconnect', handleDicsonnected);
+    client.on('socket/disconnect', handleDisconnected);
 
     client.on('socket/error', error => {
         const reconnectionLimit = error.type === 'RECONNECTION_LIMIT';

--- a/src/webchat/store/connection/connection-handler.ts
+++ b/src/webchat/store/connection/connection-handler.ts
@@ -3,9 +3,21 @@ import { setConnected, setReconnectionLimit } from "./connection-reducer";
 import { SocketClient } from "@cognigy/socket-client";
 
 export const registerConnectionHandler = (store: Store, client: SocketClient) => {
-    client.on('socket/connect', () => { store.dispatch(setConnected(true)) });
-    client.on('socket/reconnect', () => { store.dispatch(setConnected(true)) });
-    client.on('socket/disconnect', () => { store.dispatch(setConnected(false)) });
+    const handleConnected = () => {
+        store.dispatch(setConnected(true))
+    }
+
+    const handleDicsonnected = () => {
+        store.dispatch(setConnected(false));
+    }
+
+    client.on('socket/connect', handleConnected);
+    client.on('socket/reconnect', handleConnected);
+    client.on('socket/pong', handleConnected);
+    client.on('output', handleConnected);
+
+    client.on('socket/disconnect', handleDicsonnected);
+
     client.on('socket/error', error => {
         const reconnectionLimit = error.type === 'RECONNECTION_LIMIT';
         if (reconnectionLimit) {


### PR DESCRIPTION
This PR addresses two issues with the connection status indicator:

# The Indicator stays even if the connection is reestablished
Customers reported that the indicator would randomly show up and stay even if the connection was restablished (e.g. they got messages from the bot while the indicator was there)
I tackled this by setting the "connected" state to "true" in case
- a message arrives from the bot
- a "pong" event is emitted from the socket (this is an internal feature of socket.io, check their docs)

# The Indicator completely blocks mobile views
On mobile views, the indicator blocks any interaction with the webchat, it even blocks the "close" button. This means users on phones have to reload the page in order to close the webchat again.
I tackled this by also rendering a "close" button into the connection status indicator