### PR TITLE
Fix double action on Lists with button and "Default action" url

### DIFF
--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateElement.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateElement.tsx
@@ -55,7 +55,7 @@ export const getMessengerListTemplateElement = ({ React, styled }: MessagePlugin
                     <MessengerSubtitle className="webchat-list-template-element-subtitle" dangerouslySetInnerHTML={{__html: subtitle}} />
                     {button && (
                         <ListButton
-                            onClick={e => onAction(e, button)}
+                            onClick={e => {e.stopPropagation(); onAction(e, button)}}
                             className="webchat-list-template-element-button"
                             dangerouslySetInnerHTML={{__html: getButtonLabel(button)}}
                         />

--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateHeaderElement.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateHeaderElement.tsx
@@ -96,7 +96,7 @@ export const getMessengerListTemplateHeaderElement = ({ React, styled }: Message
                     <Subtitle className="webchat-list-template-header-subtitle" dangerouslySetInnerHTML={{__html: subtitle}} />
                     {button && (
                         <ListHeaderButton
-                            onClick={e => onAction(e, button)}
+                            onClick={e => {e.stopPropagation(); onAction(e, button)}}
                             className="webchat-list-template-header-button"
                             dangerouslySetInnerHTML={{__html: getButtonLabel(button)}}
                         >


### PR DESCRIPTION
Test:
- Create a List in SayNode Webchat configuration with a postback button, also set default action url (use v3 as v4 lacks these options now).
- Talk to a bot. 
- Clicking on a button should result in a sent postback and should not open an "Default action" url.