### PR TITLE
Bug/10150 multiline in gallery card descriptions not converted correctly

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -71,6 +71,7 @@ See it in action:
 | getStartedPayload | string | "GET_STARTED" | x | | The payload to send to your Flow when clicking the Get Started Button / when sending the auto message. 
 | getStartedText | string | "Get Started" | x | | The text to display in the Webchat when clicking the Get Started Button / when sending the auto message. 
 | headerLogoUrl | string | COGNIGY.AI Logo | x | | The logo to display in the header of the Webchat. Defaults to a COGNIGY.AI logo. 
+| ignoreLineBreaks | boolean | false | x | | Whether to ignore line breaks in the Messenger Generic Templates, Gallery Cards Subtitle. 
 | inputPlaceholder | string | "Write a reply" | x | | The placeholder text to display in the input field. 
 | messageLogoUrl | string | COGNIGY.AI Logo | x | | A custom avatar that should be displayed next to bot messages. Defaults to a COGNIGY.AI logo. 
 | persistentMenu | [Persistent Menu](#persistent-menu) | - | x | | The Persistent Menu to render in the Webchat.

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -27,6 +27,7 @@ export interface IWebchatSettings {
     getStartedPayload: string;
     getStartedText: string;
     headerLogoUrl: string;
+    ignoreLineBreaks: boolean;
     inputPlaceholder: string;
     messageDelay: number;
     /** TODO: this is the botAvatarUrl (rename for major) */

--- a/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
@@ -29,9 +29,9 @@ export interface IMessengerGenericTemplateState {
 
 export const getMessengerGenericTemplate = ({
     React,
-    styled
+    styled,
 }: MessagePluginFactoryProps) => {
-    const MessengerSubtitle = getMessengerSubtitle({ React, styled });
+    const MessengerSubtitle = getMessengerSubtitle({ React, styled});
     const MessengerTitle = getMessengerTitle({ React, styled });
     const MessengerFrame = getMessengerFrame({ React, styled });
     const MessengerContent = getMessengerContent({ React, styled });
@@ -112,7 +112,7 @@ export const getMessengerGenericTemplate = ({
                             style={default_action ? { cursor: "pointer" }:{}}
                         >
                             <MessengerTitle className="webchat-carousel-template-title" dangerouslySetInnerHTML={{__html: title}} />
-                            <MessengerSubtitle className="webchat-carousel-template-title" dangerouslySetInnerHTML={{__html: subtitle}} />
+                            <MessengerSubtitle className="webchat-carousel-template-title" dangerouslySetInnerHTML={{__html: subtitle}} config={this.props.config} />
                         </GenericContent>
                         {buttons &&
                             buttons.map((button, index) => (

--- a/src/plugins/messenger/MessengerPreview/components/MessengerSubtitle.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerSubtitle.tsx
@@ -1,11 +1,13 @@
 import { MessagePluginFactoryProps } from "../../../../common/interfaces/message-plugin";
+import { IWebchatConfig } from "../../../../common/interfaces/webchat-config";
 
 export const getMessengerSubtitle = ({ React, styled }: MessagePluginFactoryProps) => {
-    const MessengerSubtitle = styled.p({
+    const MessengerSubtitle = styled.p<{ config: IWebchatConfig }>(props => ({
         margin: 0,
         color: 'hsla(0, 0%, 0%, .54)',
-        fontSize: 13
-    });
+        fontSize: 13,
+        whiteSpace: props.config.settings.ignoreLineBreaks ? "initial" : "pre-wrap" ,
+    }));
 
     return MessengerSubtitle;
 }

--- a/src/plugins/messenger/MessengerPreview/components/MessengerSubtitle.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerSubtitle.tsx
@@ -6,7 +6,7 @@ export const getMessengerSubtitle = ({ React, styled }: MessagePluginFactoryProp
         margin: 0,
         color: 'hsla(0, 0%, 0%, .54)',
         fontSize: 13,
-        whiteSpace: props.config.settings.ignoreLineBreaks ? "initial" : "pre-wrap" ,
+        whiteSpace: props.config.settings.ignoreLineBreaks ? "initial" : "pre-line" ,
     }));
 
     return MessengerSubtitle;

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -30,6 +30,7 @@ const getInitialState = (): ConfigState => ({
         getStartedPayload: '',
         getStartedText: '',
         headerLogoUrl: '',
+        ignoreLineBreaks: false,
         inputPlaceholder: '',
         messageDelay: 1000,
         messageLogoUrl: '',


### PR DESCRIPTION
Previously when using Multiline in gallery card descriptions subtitle (Default tab, Gallery cards from Carousel)
The rendered card in the webchat will not display the line breaks,

This PR adds a flag "ignoreLineBreak" and also puts the line break as a default behaviour.

Setting the flag to true will make that the cards fall back to the old behaviour, this way our customers will have the choice to let things like the used to have them before.

To test:
- Create a simple Gallery Carousel in a Say node and add multiline text in the subtitle field, also add spaces in some lines.
- Talk to this from the webchat without activating the flag and also activating the flag. You should see the difference.