### PR TITLE
add "webchat-carousel-template-frame" class to gallery template

### DIFF
--- a/docs/css-customization.md
+++ b/docs/css-customization.md
@@ -411,6 +411,13 @@ The card element from a Gallery, here you can increase its size for example.
   width: 200px;
 }
 
+* *webchat-carousel-template-frame*  
+The frame that holds the cards and places them next to each other.
+```CSS
+[data-cognigy-webchat-root] .webchat-carousel-template-frame {
+  background-color: red;
+}
+
 ```
 * *webchat-carousel-template-content*  
 The content of the card, you can modify it's height and make it look smaller so you could show more content.

--- a/docs/css-customization.md
+++ b/docs/css-customization.md
@@ -412,10 +412,10 @@ The card element from a Gallery, here you can increase its size for example.
 }
 
 * *webchat-carousel-template-frame*  
-The frame that holds the cards and places them next to each other.
+The frame that adds the "card styles" such as background-color or box-shadow.
 ```CSS
 [data-cognigy-webchat-root] .webchat-carousel-template-frame {
-  background-color: red;
+  box-shadow: none;
 }
 
 ```

--- a/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
@@ -104,7 +104,7 @@ export const getMessengerGenericTemplate = ({
 
             return (
                 <ElementRoot key={index} className="webchat-carousel-template-root">
-                    <Frame className={isCentered ? "wide" : ""}>
+                    <Frame className={`webchat-carousel-template-frame ${isCentered ? "wide" : ""}`}>
                         {image}
                         <GenericContent
                             onClick={e => default_action && onAction(e, default_action)}


### PR DESCRIPTION
To improve CSS customization, we added the `webchat-carousel-template-frame` class to the "frame" element inbetween the `webchat-carousel-template-root` and the `webchat-carousel-template-content`