### PR TITLE
Bug/11084 fix connection state issues

### DIFF
--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -69,7 +69,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 
     // component API (for usage via ref)
     connect = async () => {
-		await this.store.dispatch(connect());
+		this.store.dispatch(connect());
     }
 
     sendMessage: MessageSender = (text, data, options) => {

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -69,7 +69,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 
     // component API (for usage via ref)
     connect = async () => {
-        this.store.dispatch(connect());
+		await this.store.dispatch(connect());
     }
 
     sendMessage: MessageSender = (text, data, options) => {

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -69,7 +69,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 
     // component API (for usage via ref)
     connect = async () => {
-		this.store.dispatch(connect());
+        this.store.dispatch(connect());
     }
 
     sendMessage: MessageSender = (text, data, options) => {

--- a/src/webchat/store/options/options-reducer.ts
+++ b/src/webchat/store/options/options-reducer.ts
@@ -20,8 +20,9 @@ export const options: Reducer<OptionsState, SetOptionsAction> = (state = getInit
     switch (action.type) {
         case 'SET_OPTIONS': {
             return action.options;
-        }
-    }
+		}
 
-    return state;
+		default:
+			return state;
+    }
 }

--- a/src/webchat/store/options/options-reducer.ts
+++ b/src/webchat/store/options/options-reducer.ts
@@ -20,9 +20,9 @@ export const options: Reducer<OptionsState, SetOptionsAction> = (state = getInit
     switch (action.type) {
         case 'SET_OPTIONS': {
             return action.options;
-		}
+        };
 
-		default:
-			return state;
-    }
-}
+        default:
+            return state;
+    };
+};

--- a/src/webchat/store/reducer.ts
+++ b/src/webchat/store/reducer.ts
@@ -24,13 +24,13 @@ export const reducer = (state = rootReducer(undefined, { type: '' }), action) =>
     switch (action.type) {
         case 'RESET_STATE': {
 
-			// We do not want to restore some properties from storage but keep the value from state
-			const newState = action.state as StoreState;
-			newState.connection.connected = state.connection.connected;
+            // We do not want to restore some properties from storage but keep the value from state
+            const newState = action.state as StoreState;
+            newState.connection.connected = state.connection.connected;
 
-			return rootReducer(newState, { type: '' })
-        }
-    }
+            return rootReducer(newState, { type: '' })
+        };
+    };
 
     return rootReducer(state, action);
-}
+};

--- a/src/webchat/store/reducer.ts
+++ b/src/webchat/store/reducer.ts
@@ -23,7 +23,12 @@ export const resetState = (state?: StoreState) => ({
 export const reducer = (state = rootReducer(undefined, { type: '' }), action) => {
     switch (action.type) {
         case 'RESET_STATE': {
-            return rootReducer(action.state, { type: '' })
+
+			// We do not want to restore some properties from storage but keep the value from state
+			const newState = action.state as StoreState;
+			newState.connection.connected = state.connection.connected;
+
+			return rootReducer(newState, { type: '' })
         }
     }
 


### PR DESCRIPTION
This PR fixes the connection issues Kofax is reporting with their webchat: A "Connection lost ... " message that is persisted and stays, even after refresh. [(Work Item)](https://cognigy.visualstudio.com/Cognigy.AI/_sprints/taskboard/Cognigy.AI%20Team/Cognigy.AI/Iteration%20KW%2042-43?workitem=11084)

**Reproducing** this bug is difficult, please follow these steps:
- Run your webchat locally with a persisted state (local storage) and your webchat exposed to the browser console
- Talk to your chat in a new Firefox incognito window
- Copy your state from local storage (the value starting with messages) to a text editor. Search for and change the value for `"connected"` to `false`
- Open the console and overwrite your local state with the state from the last step, by dispatching to the exposed webchat store like so:
`cognigyWebchat.store.dispatch({ type: 'RESET_STATE', state: JSON.parse('COPY_YOUR_CHANGED_STATE_HERE') });`

Doing this without this fix displays the connection lost message. 

Doing it with the fix should not display the connection lost message, as the connected value dispatched in resetState is now ignored.
(You can see that it it updates the state if you add a new message and then run the console update again. The message will disappear.)