### PR TITLE
remove carriage return from images

### DIFF
--- a/src/plugins/messenger/MessengerPreview/lib/css.ts
+++ b/src/plugins/messenger/MessengerPreview/lib/css.ts
@@ -5,6 +5,7 @@ export const getBackgroundImage = (url: string) => {
     const escapedUrl = url
         // remove line breaks
         .replace(/\n/g, '')
+        .replace(/\r/g, '')
         // escape " and \
         .replace(/\"\\/g, char => `\${char}`);
 


### PR DESCRIPTION
This fixes images not rendering correctly when the urls contain carriage returns \r