### PR TITLE
Add tests for different message types

### DIFF
--- a/cypress/fixtures/messages/audio.json
+++ b/cypress/fixtures/messages/audio.json
@@ -1,0 +1,21 @@
+{
+	"text": null,
+	"data": {
+		"_cognigy": {
+			"_default": {
+				"_audio": {
+					"type": "audio",
+					"audioUrl": "https://www.winhistory.de/more/winstart/mp3/winxp.mp3"
+				}
+			},
+			"_webchat": {
+				"message": {
+					"attachment": {
+						"type": "audio",
+						"payload": { "url": "https://www.winhistory.de/more/winstart/mp3/winxp.mp3" }
+					}
+				}
+			}
+		}
+	}
+}

--- a/cypress/fixtures/messages/buttons.json
+++ b/cypress/fixtures/messages/buttons.json
@@ -1,0 +1,87 @@
+{
+	"text": null,
+	"data": {
+		"_cognigy": {
+			"_default": {
+				"_buttons": {
+					"type": "buttons",
+					"text": "foobar005",
+					"buttons": [
+						{
+							"id": 0.6868293520794431,
+							"payload": "foobar005b1pb",
+							"type": "postback",
+							"title": "foobar005b1"
+						},
+						{
+							"id": 0.17194659386513078,
+							"payload": "",
+							"type": "web_url",
+							"title": "foobar005b2",
+							"url": "foobar005b1url1"
+						},
+						{
+							"id": 0.6458078881527971,
+							"payload": "",
+							"type": "postback",
+							"title": "foobar005b3"
+						},
+						{
+							"id": 0.4156873092236142,
+							"payload": "000111222",
+							"type": "phone_number",
+							"title": "foobar005b4"
+						},
+						{
+							"id": 0.8354721780646182,
+							"payload": "null",
+							"type": "postback",
+							"title": ""
+						}
+					]
+				}
+			},
+			"_webchat": {
+				"message": {
+					"attachment": {
+						"type": "template",
+						"payload": {
+							"text": "foobar005",
+							"template_type": "button",
+							"buttons": [
+								{
+									"type": "postback",
+									"payload": "foobar005b1pb",
+									"title": "foobar005b1",
+									"url": "",
+									"webview_height_ratio": "full",
+									"messenger_extensions": false
+								},
+								{
+									"type": "web_url",
+									"title": "foobar005b2",
+									"url": "foobar005b1url1",
+									"messenger_extensions": false,
+									"webview_height_ratio": "full"
+								},
+								{
+									"type": "postback",
+									"payload": "",
+									"title": "foobar005b3",
+									"url": "",
+									"webview_height_ratio": "full",
+									"messenger_extensions": false
+								},
+								{
+									"title": "foobar005b4",
+									"type": "phone_number",
+									"payload": "000111222"
+								}
+							]
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/cypress/fixtures/messages/date-picker.json
+++ b/cypress/fixtures/messages/date-picker.json
@@ -1,0 +1,23 @@
+{
+	"text": "",
+	"data": {
+		"_plugin": {
+			"type": "date-picker",
+			"data": {
+				"eventName": "foobar012",
+				"locale": "en",
+				"enableTime": false,
+				"mode": "single",
+				"wantDisable": false,
+				"enable_disable": null,
+				"minDate": "today",
+				"maxDate": "tomorrow",
+				"openPickerButtonText": "foobar012b1",
+				"cancelButtonText": "foobar012b2",
+				"submitButtonText": "foobar012b3",
+				"time_24hr": true,
+				"dateFormat": ""
+			}
+		}
+	}
+}

--- a/cypress/fixtures/messages/gallery.json
+++ b/cypress/fixtures/messages/gallery.json
@@ -1,0 +1,96 @@
+{
+	"text": null,
+	"data": {
+		"_cognigy": {
+			"_default": {
+				"_gallery": {
+					"type": "carousel",
+					"items": [
+						{
+							"title": "foobar004g1",
+							"subtitle": "",
+							"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+							"buttons": [
+								{
+									"id": 0.9601740794827666,
+									"payload": "sw",
+									"type": "postback",
+									"title": "test"
+								}
+							],
+							"id": 0.5123901431260184
+						},
+						{
+							"title": "foobar004g2",
+							"subtitle": "foobar004g2sub1\nfoobar004g2sub2",
+							"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+							"buttons": [],
+							"id": 0.9969017542005371
+						},
+						{
+							"title": "foobar004g3",
+							"subtitle": "",
+							"imageUrl": "",
+							"buttons": [],
+							"id": 0.2782939283042508
+						}
+					]
+				}
+			},
+			"_webchat": {
+				"message": {
+					"attachment": {
+						"type": "template",
+						"payload": {
+							"template_type": "generic",
+							"elements": [
+								{
+									"title": "foobar004g1",
+									"subtitle": "",
+									"image_url": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+									"buttons": [
+										{
+											"type": "postback",
+											"payload": "sw",
+											"title": "foobar004g1b1"
+										},
+										{
+											"type": "postback",
+											"payload": "sw",
+											"title": "foobar004g1b2"
+										},
+										{
+											"type": "postback",
+											"payload": "sw",
+											"title": "foobar004g1b3"
+										},
+										{
+											"type": "postback",
+											"payload": "sw",
+											"title": "foobar004g1b4"
+										}
+									]
+								},
+								{
+									"title": "foobar004g2",
+									"subtitle": "foobar004g2sub1\nfoobar004g2sub2",
+									"image_url": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+									"buttons": []
+								},
+								{
+									"title": "foobar004g3",
+									"subtitle": "",
+									"image_url": "",
+									"buttons": []
+								}
+							]
+						}
+					}
+				}
+			}
+		}
+	},
+	"traceId": "endpoint-realtimeClient-98112b29-c8d0-4066-83fc-9aad91c4be0e",
+	"disableSensitiveLogging": false,
+	"source": "bot"
+}

--- a/cypress/fixtures/messages/image.json
+++ b/cypress/fixtures/messages/image.json
@@ -1,0 +1,23 @@
+{
+	"text": null,
+	"data": {
+		"_cognigy": {
+			"_default": {
+				"_image": {
+					"type": "image",
+					"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg"
+				}
+			},
+			"_webchat": {
+				"message": {
+					"attachment": {
+						"type": "image",
+						"payload": {
+							"url": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg"
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/cypress/fixtures/messages/list.json
+++ b/cypress/fixtures/messages/list.json
@@ -1,0 +1,52 @@
+{
+	"text": "THIS_TEXT_SHOULD_NOT_RENDER",
+	"data": {
+		"_cognigy": {
+			"_webchat": {
+				"message": {
+					"attachment": {
+						"type": "template",
+						"payload": {
+							"template_type": "list",
+							"elements": [
+								{
+									"title": "foobar009l1",
+									"subtitle": "foobar009ls1",
+									"image_url": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+									"buttons": [
+										{
+											"payload": "foobar009l1b1",
+											"type": "postback",
+											"title": "foobar009l1b1"
+										}
+									]
+								},
+								{
+									"title": "foobar009l2",
+									"subtitle": "",
+									"image_url": "undefined",
+									"buttons": null,
+									"default_action": {
+										"type": "web_url",
+										"url": "https://example.com"
+									}
+								}
+							],
+							"top_element_style": "large",
+							"buttons": [
+								{
+									"title": "foobar009b1",
+									"type": "web_url",
+									"url": "https://example.com",
+									"payload": "",
+									"messenger_extensions": false,
+									"webview_height_ratio": "full"
+								}
+							]
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/cypress/fixtures/messages/quick-replies.json
+++ b/cypress/fixtures/messages/quick-replies.json
@@ -1,0 +1,90 @@
+[
+	{
+		"text": null,
+		"data": {
+			"_cognigy": {
+				"_default": {
+					"_quickReplies": {
+						"type": "quick_replies",
+						"quickReplies": [
+							{
+								"id": 0.44535334241574,
+								"contentType": "postback",
+								"payload": "foobar003pb01",
+								"title": "foobar003qr01"
+							},
+							{
+								"id": 0.25146047888364853,
+								"contentType": "postback",
+								"payload": "foobar003pb02",
+								"title": "foobar003qr02",
+								"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b0/Wikipedia-favicon.png"
+							}
+						],
+						"text": "foobar003"
+					}
+				},
+				"_webchat": {
+					"message": {
+						"text": "foobar003",
+						"quick_replies": [
+							{
+								"content_type": "text",
+								"payload": "foobar003pb01",
+								"title": "foobar003qr01"
+							},
+							{
+								"content_type": "text",
+								"image_url": "https://upload.wikimedia.org/wikipedia/commons/b/b0/Wikipedia-favicon.png",
+								"payload": "foobar003pb02",
+								"title": "foobar003qr02"
+							}
+						]
+					}
+				}
+			}
+		}
+	},
+	{
+		"text": null,
+		"data": {
+			"_cognigy": {
+				"_default": {
+					"_quickReplies": {
+						"type": "quick_replies",
+						"quickReplies": [
+							{
+								"id": 0.44535334241574,
+								"contentType": "postback",
+								"payload": "foobar003pb01",
+								"title": "foobar003qr01"
+							},
+							{
+								"id": 0.25146047888364853,
+								"contentType": "postback",
+								"payload": "foobar003pb02",
+								"title": "foobar003qr02",
+								"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b0/Wikipedia-favicon.png"
+							}
+						],
+						"text": "foobar003"
+					}
+				},
+				"_webchat": {
+					"message": {
+						"text": "foobar003",
+						"quick_replies": [
+							{ "content_type": "text", "title": "foobar003qr01" },
+							{
+								"content_type": "text",
+								"image_url": "http://cognigy.com/favicon.ico",
+								"payload": "",
+								"title": "foobar003qr02"
+							}
+						]
+					}
+				}
+			}
+		}
+	}
+]

--- a/cypress/fixtures/messages/text-html.json
+++ b/cypress/fixtures/messages/text-html.json
@@ -1,0 +1,1 @@
+{ "text": "<h1>foobar010</h1>\n<div style=\"background: red\">foobar010red</div>", "data": {} }

--- a/cypress/fixtures/messages/text-multiline.json
+++ b/cypress/fixtures/messages/text-multiline.json
@@ -1,0 +1,1 @@
+{"text":"foobar002\nbarfoo002","data":{}}

--- a/cypress/fixtures/messages/text.json
+++ b/cypress/fixtures/messages/text.json
@@ -1,0 +1,1 @@
+{ "text": "foobar001", "data": {} }

--- a/cypress/fixtures/messages/video.json
+++ b/cypress/fixtures/messages/video.json
@@ -1,0 +1,23 @@
+{
+	"text": null,
+	"data": {
+		"_cognigy": {
+			"_default": {
+				"_video": {
+					"type": "video",
+					"videoUrl": "http://s3.amazonaws.com/akamai.netstorage/HD_downloads/Orion_SM.mp4"
+				}
+			},
+			"_webchat": {
+				"message": {
+					"attachment": {
+						"type": "video",
+						"payload": {
+							"url": "http://s3.amazonaws.com/akamai.netstorage/HD_downloads/Orion_SM.mp4"
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/cypress/integration/messages/audio.spec.ts
+++ b/cypress/integration/messages/audio.spec.ts
@@ -1,0 +1,31 @@
+/// <reference path="../../support/index.d.ts" />
+
+describe("Message with Audio", () => {
+    beforeEach(() => {
+        cy
+            .visitBuild()
+            .initMockWebchat()
+            .openWebchat()
+    })
+
+    it("should render audio player", () => {
+        cy.withMessageFixture('audio', () => {
+            cy
+                .get(".webchat-message-row audio").should("be.visible");
+        })
+    })
+
+    it("should have controls in player", () => {
+        cy.withMessageFixture('audio', () => {
+            cy
+                .get(".webchat-message-row audio").should("have.attr", "controls");
+        })
+    })
+
+    it("should have class 'webchat-media-template-audio'", () => {
+        cy.withMessageFixture('audio', () => {
+            cy
+                .get(".webchat-message-row > .webchat-media-template-audio");
+        })
+    })
+})

--- a/cypress/integration/messages/buttons.spec.ts
+++ b/cypress/integration/messages/buttons.spec.ts
@@ -1,0 +1,40 @@
+/// <reference path="../../support/index.d.ts" />
+
+describe("Message with Buttons", () => {
+    beforeEach(() => {
+        cy
+            .visitBuild()
+            .initMockWebchat()
+            .openWebchat()
+    })
+
+    it("should render message header", () => {
+        cy.withMessageFixture('buttons', () => {
+            cy
+                .contains("foobar005");
+        })
+    })
+
+    it("should render message buttons", () => {
+        cy.withMessageFixture('buttons', () => {
+            cy.wrap([1,2,3,4]).each(number => {
+                cy.contains(`foobar005b${number}`)
+            })
+        })
+    })
+
+    it("should post in chat on postback button click", () => {
+        cy.withMessageFixture('buttons', () => {
+            cy.contains("foobar005b1").click().get(".regular-message.user").contains("foobar005b1")
+        })
+    })
+
+    it("should have static class names", () => {
+        cy.withMessageFixture('buttons', () => {
+            cy
+                .get(".webchat-buttons-template-header")
+                .get(".webchat-buttons-template-root")
+                .get(".webchat-buttons-template-button")
+        })
+    })
+})

--- a/cypress/integration/messages/datePicker.spec.ts
+++ b/cypress/integration/messages/datePicker.spec.ts
@@ -1,5 +1,7 @@
 /// <reference path="../../support/index.d.ts" />
 
+import * as moment from "moment"
+
 describe("Date Picker", () => {
     beforeEach(() => {
         cy
@@ -42,7 +44,8 @@ describe("Date Picker", () => {
             cy
                 .contains("foobar012b3").click();
 
-            const formattedDate = new Date().toJSON().slice(0,10).split('-').reverse().join('/')
+						// Our default locale for english is "en-US"
+						const formattedDate = moment().format("MM/DD/YYYY");
             cy.get(".regular-message.user").contains(formattedDate);
         })
     })

--- a/cypress/integration/messages/datePicker.spec.ts
+++ b/cypress/integration/messages/datePicker.spec.ts
@@ -1,0 +1,50 @@
+/// <reference path="../../support/index.d.ts" />
+
+describe("Date Picker", () => {
+    beforeEach(() => {
+        cy
+            .visitBuild()
+            .initMockWebchat()
+            .openWebchat()
+    })
+
+    it("should render plugin open button", () => {
+        cy.withMessageFixture('date-picker', () => {
+            cy
+                .contains("foobar012b1").should("be.visible");
+        })
+    })
+
+    it("should open 'fullheight' plugin on open button click", () => {
+        cy.withMessageFixture('date-picker', () => {
+            cy
+                .contains("foobar012b1").click().get(".webchat-plugin-date-picker-header").contains(/^foobar012$/);
+        })
+    })
+
+    it("should render cancel and submit buttons", () => {
+        cy.withMessageFixture('date-picker', () => {
+            cy
+                .contains("foobar012b1").click();
+            cy
+                .contains("foobar012b2");
+            cy
+                .contains("foobar012b3");
+        })
+    })
+
+    it("should select today and post the date in chat", () => {
+        cy.withMessageFixture('date-picker', () => {
+            cy
+                .contains("foobar012b1").click();
+            cy
+                .get(".flatpickr-day.today").click();
+            cy
+                .contains("foobar012b3").click();
+
+            const formattedDate = new Date().toJSON().slice(0,10).split('-').reverse().join('/')
+            cy.get(".regular-message.user").contains(formattedDate);
+        })
+    })
+
+})

--- a/cypress/integration/messages/gallery.spec.ts
+++ b/cypress/integration/messages/gallery.spec.ts
@@ -1,0 +1,78 @@
+/// <reference path="../../support/index.d.ts" />
+
+describe("Message with Gallery", () => {
+    beforeEach(() => {
+        cy
+            .visitBuild()
+            .initMockWebchat()
+            .openWebchat()
+    })
+
+    it("should render gallery message", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy
+                .contains("foobar004g1")
+            cy
+                .contains("foobar004g3").should("be.not.visible")
+        })
+    })
+
+    it("should render image inside gallery", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy
+                .get(".webchat-carousel-template-root > div > div").should("have.css", "background-image")
+        })
+    })
+
+    it("should render subtitle", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy
+                .contains("foobar004g2")
+                .parent()
+                .contains(/foobar004g2sub1\sfoobar004g2sub2/)
+        })
+    })
+
+    it("should have scroll forward button", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy
+                .get(".control-next")
+        })
+    })
+    it("should scroll on clicking scroll forward button ", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy
+                .contains("foobar004g2").should("not.be.visible")
+                .get(".control-next")
+                .click()
+            cy
+                .contains("foobar004g2").should("be.visible")
+            cy
+                .contains("foobar004g3").should("not.be.visible")
+                .get(".control-next")
+                .click()
+                .contains("foobar004g2").should("be.not.visible")
+            cy
+                .contains("foobar004g3").should("be.visible")
+
+        })
+    })
+    it("should have scroll backward button", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy
+                .get(".control-prev").should("not.be.visible")
+                .get(".control-next")
+                .click()
+                .get(".control-prev").should("be.visible")
+        })
+    })
+
+    it("should post in chat on gallery button click", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy
+                .contains("foobar004g1b1")
+                .click()
+                .get(".regular-message.user").contains("foobar004g1b1")
+        })
+    })
+})

--- a/cypress/integration/messages/image.spec.ts
+++ b/cypress/integration/messages/image.spec.ts
@@ -1,0 +1,24 @@
+/// <reference path="../../support/index.d.ts" />
+
+describe("Message with Image", () => {
+    beforeEach(() => {
+        cy
+            .visitBuild()
+            .initMockWebchat()
+            .openWebchat()
+    })
+
+    it("should render image", () => {
+        cy.withMessageFixture('image', () => {
+            cy
+                .get(".webchat-message-row > div > div").should("have.css", "background-image");
+        })
+    })
+
+    it("should have class 'webchat-media-template-image'", () => {
+        cy.withMessageFixture('image', () => {
+            cy
+                .get(".webchat-message-row > .webchat-media-template-image");
+        })
+    })
+})

--- a/cypress/integration/messages/list.spec.ts
+++ b/cypress/integration/messages/list.spec.ts
@@ -1,0 +1,67 @@
+/// <reference path="../../support/index.d.ts" />
+
+describe("Message with List", () => {
+    beforeEach(() => {
+        cy
+            .visitBuild()
+            .initMockWebchat()
+            .openWebchat()
+    })
+
+    it("should render list", () => {
+        cy.withMessageFixture('list', () => {
+            cy
+                .get(".webchat-message-row").contains("foobar009l1")
+                .get(".webchat-message-row").contains("foobar009l2")
+        })
+    })
+
+    it("should render lists subtitle", () => {
+        cy.withMessageFixture('list', () => {
+            cy
+                .get(".webchat-message-row").contains("foobar009ls1")
+        })
+    })
+
+    it("should render top element of the list large", () => {
+        cy.withMessageFixture('list', () => {
+            cy
+                .get(".webchat-list-template-header > div").should("have.css", "background-image")
+        })
+    })
+
+    it("should render top element of the list small", () => {
+        cy.fixture("messages/list.json").then(list => {
+            list.data._cognigy._webchat.message.attachment.payload.top_element_style = "compaact";
+            cy.receiveMessage(null, list.data);
+            cy.get(".webchat-list-template-header > div").should("not.have.css", "background-image")
+        })
+    })
+
+    it("should post in chat on click on postback button", () => {
+        cy.withMessageFixture('list', () => {
+            cy
+                .contains("foobar009l1b1").click().get(".regular-message.user").contains("foobar009l1b1")
+        })
+    })
+
+    it("should render 'global' button", () => {
+        cy.withMessageFixture('list', () => {
+            cy
+                .contains("foobar009b1");
+        })
+    })
+
+    it("should have static class names", () => {
+        cy.withMessageFixture('list', () => {
+            cy
+                .get(".webchat-list-template-header")
+                .get(".webchat-list-template-root")
+                .get(".webchat-list-template-header-content")
+                .get(".webchat-list-template-header-content")
+                .get(".webchat-list-template-header-content")
+                .get(".webchat-list-template-element")
+        })
+    })
+    
+})

--- a/cypress/integration/messages/quickReplies.spec.ts
+++ b/cypress/integration/messages/quickReplies.spec.ts
@@ -1,0 +1,41 @@
+/// <reference path="../../support/index.d.ts" />
+
+describe("Message with Quick Replies", () => {
+
+    beforeEach(() => cy
+        .visitBuild()
+        .initMockWebchat()
+        .openWebchat())
+
+    function reInit() {
+        cy.visitBuild().initMockWebchat().openWebchat();
+    }
+
+    it("should render message with quick replies", () => {
+        cy.withMessageFixture('quick-replies', () => {
+            cy
+                .contains("foobar003");
+            cy
+                .contains("foobar003qr01")
+            cy
+                .contains("foobar003qr02")
+        }, reInit)
+    })
+
+    it("should click the quick reply and post as user message", () => {
+        cy.withMessageFixture('quick-replies', () => {
+            cy
+                .contains("foobar003qr01").click()
+            cy
+                .get(".regular-message.user")
+                .contains("foobar003qr01");
+        }, reInit);
+    })
+
+    it("should render image inside quick replies button", () => {
+        cy.withMessageFixture('quick-replies', () => {
+            cy.contains("foobar003qr02").children("img").should("have.length", 1);   
+            
+        }, reInit);
+    })
+})

--- a/cypress/integration/messages/text.spec.ts
+++ b/cypress/integration/messages/text.spec.ts
@@ -1,0 +1,38 @@
+/// <reference path="../../support/index.d.ts" />
+
+describe("Text message", () => {
+    beforeEach(() => {
+        cy
+            .visitBuild()
+            .initMockWebchat()
+            .openWebchat()
+    })
+
+    it("should render text message", () => {
+        cy.withMessageFixture('text', () => {
+            cy
+                .contains("foobar001");
+        })
+    })
+
+    it("should render multiline text message", () => {
+        cy.withMessageFixture('text-multiline', () => {
+            cy
+                .contains(/foobar002\sbarfoo002/)
+                .get('.regular-message')
+                .should('have.css', 'white-space')
+                .and('match', /pre-wrap/);
+        })
+    })
+
+    it("should render html in text message", () => {
+        cy.withMessageFixture('text-html', () => {
+            cy
+                .contains("foobar010")
+                .get('.regular-message > h1')
+                .get('.regular-message > div')
+                .contains('foobar010red')
+                .should('have.css', 'background');
+        })
+    })
+})

--- a/cypress/integration/messages/video.spec.ts
+++ b/cypress/integration/messages/video.spec.ts
@@ -1,0 +1,31 @@
+/// <reference path="../../support/index.d.ts" />
+
+describe("Message with Video", () => {
+    beforeEach(() => {
+        cy
+            .visitBuild()
+            .initMockWebchat()
+            .openWebchat()
+    })
+
+    it("should render video player", () => {
+        cy.withMessageFixture('video', () => {
+            cy
+                .get(".webchat-message-row video").should("be.visible");
+        })
+    })
+
+    it("should have controls in player", () => {
+        cy.withMessageFixture('video', () => {
+            cy
+                .get(".webchat-message-row video").should("have.attr", "controls");
+        })
+    })
+
+    it("should have class 'webchat-media-template-video'", () => {
+        cy.withMessageFixture('video', () => {
+            cy
+                .get(".webchat-message-row > .webchat-media-template-video");
+        })
+    })
+})

--- a/cypress/integration/startBehavior.spec.ts
+++ b/cypress/integration/startBehavior.spec.ts
@@ -13,7 +13,7 @@ describe('Start Behavior', () => {
                 }
             })
             .get('[data-cognigy-webchat-toggle]').click()
-            .window().contains('get started').should('be.visible');
+            .contains('get started').should('be.visible');
     });
 
     it('should not send a "get started message" if the history contains messages', () => {
@@ -29,7 +29,7 @@ describe('Start Behavior', () => {
             .receiveMessage('fake bot message')
             .get('[data-cognigy-webchat-toggle]').click()
             .wait(100)
-            .window().contains('get started').should('not.exist');
+            .contains('get started').should('not.exist');
     });
 
     // to fix this test, we have to fake a real connection (message is triggered after the connection)

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -16,7 +16,9 @@ declare namespace Cypress {
 
       getWebchat(): Chainable<any>;
 
-      receiveMessage(text?: string, data?: Object, source?: 'bot' | 'agent'): Chainable<any>;
+      receiveMessage(text?: string, data?: Object, source?: 'bot' | 'agent'): Chainable<ReturnType<cy["window"]>>;
+
+      withMessageFixture(withMessageFixture: string, callback: () => void, cleanUpFunc?: () => void): Chainable<any>;
     
       openWebchat(): Chainable<any>;
     }

--- a/dist/index.html
+++ b/dist/index.html
@@ -6,6 +6,7 @@
 
 <body>
     <script src="./webchat.js"></script>
+    <script src="./date-picker.webchat-plugin.js"></script>
     <script>
         var isTesting = window.location.search.indexOf('test') > -1;
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "cypress:serve": "http-server -a localhost -p 8787 dist/",
         "cypress:run": "cypress run",
         "test": "run-p -r cypress:serve cypress:run",
-        "pretest": "npm run webchat"
+        "pretest": "npm run webchat && npm run date-picker"
     },
     "dependencies": {
         "@cognigy/socket-client": "^4.4.0",


### PR DESCRIPTION
This pr adds tests for different types of messages. It should cover all the messages types supported by the Webchat itself plus its date picker plugin.

To run the tests do `npm test`.