### PR TITLE
Fix avatar being cut off

### DIFF
--- a/src/webchat-ui/components/presentational/Avatar.tsx
+++ b/src/webchat-ui/components/presentational/Avatar.tsx
@@ -13,7 +13,7 @@ export default styled.div<IAvatarProps>(({ theme, src }) => ({
     width: theme.unitSize * 3,
 	border: `1px solid ${theme.greyWeakColor}`,
 	backgroundImage: getBackgroundImage(src),
-	backgroundSize: "contain",
+	backgroundSize: "cover",
 	backgroundPosition: "center center",
 	backgroundRepeat: "no-repeat"
 }));


### PR DESCRIPTION
This PR fixes the avatar images being cut off. 

- Zendesk ticket: [https://cognigy.zendesk.com/agent/tickets/3109](url)

- Sprint board work item: [https://cognigy.visualstudio.com/Cognigy.AI/_sprints/taskboard/Cognigy.AI%20Team/Cognigy.AI/Iteration%20KW%2048-49?workitem=11483](url)

Test 1: 

- Chat with our webchat and see if the image inside the avatar fills the circle completely.

Test 2: 

- Create a flow with say nodes.
- Create an endpoint and select the flow.
- In endpoint editor, configure the webchat by adding an image url for the webchat avatar. Make sure that the image has a dark background so that the change will be visible.
- Now, copy the config url and use it in our webchat.
- See if the avatar is displayed as expected after chatting with the bot