### PR TITLE
(re-)store only relevant information from storage

### DIFF
--- a/src/webchat/store/options/options-middleware.ts
+++ b/src/webchat/store/options/options-middleware.ts
@@ -11,6 +11,7 @@ export const optionsMiddleware: Middleware<{}, StoreState> = store => next => (a
     const key = getOptionsKey(store.getState().options);
     const { active } = store.getState().config; // Actual settings are loaded
     const { disableLocalStorage, disablePersistentHistory, useSessionStorage } = store.getState().config.settings;
+    const { userId } = store.getState().options;
     const browserStorage = useSessionStorage ? window.sessionStorage : window.localStorage;
 
     switch (action.type) {
@@ -34,8 +35,11 @@ export const optionsMiddleware: Middleware<{}, StoreState> = store => next => (a
         }
     }
 
-    if (browserStorage && active && !(disablePersistentHistory || disableLocalStorage)) {
-        browserStorage.setItem(key, JSON.stringify(store.getState()));
+    if (browserStorage && active && userId && !(disablePersistentHistory || disableLocalStorage)) {
+        const { messages } = store.getState();
+        browserStorage.setItem(key, JSON.stringify({
+            messages,
+        }));
     }
 
     return next(action);

--- a/src/webchat/store/reducer.ts
+++ b/src/webchat/store/reducer.ts
@@ -23,31 +23,19 @@ export const resetState = (state?: StoreState) => ({
 });
 export type ResetStateAction = ReturnType<typeof resetState>;
 
-export const reducer = (currentState = rootReducer(undefined, { type: '' }), action) => {
+export const reducer = (state = rootReducer(undefined, { type: '' }), action) => {
     switch (action.type) {
         case 'RESET_STATE': {
-
-            // We do not want to restore some properties from storage but keep the value from state
-            const newState = action.state;
-            
-            // lossy ui state should not be restored, take the old value!
-            newState.connection.connected = currentState.connection.connected;
-            newState.connection.connecting = currentState.connection.connecting;
-            newState.ui.isPageVisible = currentState.ui.isPageVisible;
-            newState.config = currentState.config;
-
-            // do not restore unseen messages, would be weird with the open and isPageVisible state!
-            newState.unseenMessages = [];
-
-            // if the webchat was open already, do not close it again
-            newState.ui.open = currentState.ui.open || newState.ui.open;
-
-            // prepend the restored history to the current history
-            newState.messages = [...newState.messages, ...currentState.messages];
-
-            return rootReducer(newState, { type: '' });
+            // We only restore messages and prepend them to the current message history
+            return rootReducer({
+                ...state,
+                messages: [
+                    ...action.state.messages,
+                    ...state.messages,
+                ]
+            }, { type: '' })
         };
     };
 
-    return rootReducer(currentState, action);
+    return rootReducer(state, action);
 };


### PR DESCRIPTION
This PR changes what we store and restore for the "persistence history" mechanism to the local (-session) storage
- it is only the "messages" now.

Also fixes storing duplicate data with an empty keys (["","",""]) in storage.

To test: 
initialize the webchat with a fixed sessionId string and test it behaves normally, also with these endpoint settings:
                    `getStartedText: "INJECT",
                    startBehavior: "injection"`
and these:
                    `disablePersistentHistory: true,
                    engagementMessageText: "Hi!",
                    engagementMessageDelay: 500`
