### PR TITLE
Add tests to check aria labels

### DIFF
--- a/cypress/fixtures/messages/quick-replies.json
+++ b/cypress/fixtures/messages/quick-replies.json
@@ -18,7 +18,8 @@
 								"contentType": "postback",
 								"payload": "foobar003pb02",
 								"title": "foobar003qr02",
-								"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b0/Wikipedia-favicon.png"
+								"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b0/Wikipedia-favicon.png",
+								"imageAltText": "alt text"
 							}
 						],
 						"text": "foobar003"
@@ -36,6 +37,7 @@
 							{
 								"content_type": "text",
 								"image_url": "https://upload.wikimedia.org/wikipedia/commons/b/b0/Wikipedia-favicon.png",
+								"image_alt_text": "alt text",
 								"payload": "foobar003pb02",
 								"title": "foobar003qr02"
 							}
@@ -64,7 +66,8 @@
 								"contentType": "postback",
 								"payload": "foobar003pb02",
 								"title": "foobar003qr02",
-								"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b0/Wikipedia-favicon.png"
+								"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b0/Wikipedia-favicon.png",
+								"imageAltText": "alt text"
 							}
 						],
 						"text": "foobar003"
@@ -78,6 +81,7 @@
 							{
 								"content_type": "text",
 								"image_url": "http://cognigy.com/favicon.ico",
+								"image_alt_text": "alt text",
 								"payload": "",
 								"title": "foobar003qr02"
 							}

--- a/cypress/integration/messageInput.spec.ts
+++ b/cypress/integration/messageInput.spec.ts
@@ -1,0 +1,28 @@
+describe('Webchat Message Input', () => {
+
+    it('message input filed should have correct aria-label', () => {
+        cy
+			.visitBuild()
+			.initMockWebchat()
+			.openWebchat()
+			.get('[aria-label="Message to send"]').should('be.visible');
+	});
+
+	it('message input filed should receive focus on open', () => {
+        cy
+			.visitBuild()
+			.initMockWebchat()
+			.openWebchat()
+			.get('[aria-label="Message to send"]').should('be.focused');
+	});
+
+	it('should be able to type in message input filed should', () => {
+        cy
+			.visitBuild()
+			.initMockWebchat()
+			.openWebchat()
+			.get('[aria-label="Message to send"]').type('Hi')
+			.get('[aria-label="Message to send"]').should('have.value', 'Hi');
+	});
+
+});

--- a/cypress/integration/messages/audio.spec.ts
+++ b/cypress/integration/messages/audio.spec.ts
@@ -25,7 +25,7 @@ describe("Message with Audio", () => {
     it("should have class 'webchat-media-template-audio'", () => {
         cy.withMessageFixture('audio', () => {
             cy
-                .get(".webchat-message-row > div > .webchat-media-template-audio");
+                .get(".webchat-message-row .webchat-media-template-audio");
         })
     })
 })

--- a/cypress/integration/messages/audio.spec.ts
+++ b/cypress/integration/messages/audio.spec.ts
@@ -25,7 +25,7 @@ describe("Message with Audio", () => {
     it("should have class 'webchat-media-template-audio'", () => {
         cy.withMessageFixture('audio', () => {
             cy
-                .get(".webchat-message-row > .webchat-media-template-audio");
+                .get(".webchat-message-row > div > .webchat-media-template-audio");
         })
     })
 })

--- a/cypress/integration/messages/audio.spec.ts
+++ b/cypress/integration/messages/audio.spec.ts
@@ -27,5 +27,15 @@ describe("Message with Audio", () => {
             cy
                 .get(".webchat-message-row .webchat-media-template-audio");
         })
-    })
+	})
+
+	it("should have sr-only default alternate text for audio", () => {
+        cy.withMessageFixture('audio', () => {
+            cy
+				.get(".webchat-message-row .webchat-media-template-audio .sr-only")
+				.contains("Attachment Audio")
+				.should("not.be.visible");
+        })
+	})	
+	
 })

--- a/cypress/integration/messages/buttons.spec.ts
+++ b/cypress/integration/messages/buttons.spec.ts
@@ -36,5 +36,11 @@ describe("Message with Buttons", () => {
                 .get(".webchat-buttons-template-root")
                 .get(".webchat-buttons-template-button")
         })
+	})
+	
+	it("group off buttons should have role 'group'", () => {
+        cy.withMessageFixture('buttons', () => {
+			cy.get("[role=group] .webchat-buttons-template-button").should("have.length", 4);
+        })				
     })
 })

--- a/cypress/integration/messages/gallery.spec.ts
+++ b/cypress/integration/messages/gallery.spec.ts
@@ -74,5 +74,22 @@ describe("Message with Gallery", () => {
                 .click()
                 .get(".regular-message.user").contains("foobar004g1b1")
         })
-    })
+	})
+
+	it("scroll forward button should have correct aria-label", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy
+				.get('[aria-label="next slide / item"]').click()
+				.get(".control-prev").should("be.visible")
+        })
+	})
+
+	it("scroll backward button should have correct aria-label", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy
+				.get('[aria-label="next slide / item"]').click()
+				.get('[aria-label="previous slide / item"]').click()
+				.get(".control-next").should("be.visible")
+        })
+	})
 })

--- a/cypress/integration/messages/image.spec.ts
+++ b/cypress/integration/messages/image.spec.ts
@@ -25,9 +25,9 @@ describe("Message with Image", () => {
 	it("should have role 'img' and an aria-label", () => {
         cy.withMessageFixture('image', () => {
             cy
-				.get("[role=img]").should("exist");
+				.get("[role=img]");
 			cy
-                .get('[aria-label="Attachment Image"]').should("exist");
+                .get('[aria-label="Attachment Image"]');
         })
     })
 })

--- a/cypress/integration/messages/image.spec.ts
+++ b/cypress/integration/messages/image.spec.ts
@@ -18,7 +18,7 @@ describe("Message with Image", () => {
     it("should have class 'webchat-media-template-image'", () => {
         cy.withMessageFixture('image', () => {
             cy
-                .get(".webchat-message-row > div > .webchat-media-template-image");
+                .get(".webchat-message-row .webchat-media-template-image");
         })
     })
 })

--- a/cypress/integration/messages/image.spec.ts
+++ b/cypress/integration/messages/image.spec.ts
@@ -20,5 +20,14 @@ describe("Message with Image", () => {
             cy
                 .get(".webchat-message-row .webchat-media-template-image");
         })
+	})
+	
+	it("should have role 'img' and an aria-label", () => {
+        cy.withMessageFixture('image', () => {
+            cy
+				.get("[role=img]").should("exist");
+			cy
+                .get('[aria-label="Attachment Image"]').should("exist");
+        })
     })
 })

--- a/cypress/integration/messages/image.spec.ts
+++ b/cypress/integration/messages/image.spec.ts
@@ -18,7 +18,7 @@ describe("Message with Image", () => {
     it("should have class 'webchat-media-template-image'", () => {
         cy.withMessageFixture('image', () => {
             cy
-                .get(".webchat-message-row > .webchat-media-template-image");
+                .get(".webchat-message-row > div > .webchat-media-template-image");
         })
     })
 })

--- a/cypress/integration/messages/list.spec.ts
+++ b/cypress/integration/messages/list.spec.ts
@@ -14,8 +14,8 @@ describe("Message with List", () => {
                 .get(".webchat-message-row").contains("foobar009l1")
                 .get(".webchat-message-row").contains("foobar009l2")
         })
-    })
-
+	})
+	
     it("should render lists subtitle", () => {
         cy.withMessageFixture('list', () => {
             cy
@@ -62,6 +62,15 @@ describe("Message with List", () => {
                 .get(".webchat-list-template-header-content")
                 .get(".webchat-list-template-element")
         })
+	})
+	
+	it("should render list and list items with correct roles", () => {
+        cy.withMessageFixture('list', () => {
+            cy
+                .get("[role=list]").should("be.visible")
+                .get("[role=list] [role=listitem]").contains("foobar009l2")
+        })
     })
+
     
 })

--- a/cypress/integration/messages/quickReplies.spec.ts
+++ b/cypress/integration/messages/quickReplies.spec.ts
@@ -37,5 +37,15 @@ describe("Message with Quick Replies", () => {
             cy.contains("foobar003qr02").children("img").should("have.length", 1);   
             
         }, reInit);
+	})
+	
+	it("should render image alt text when present", () => {
+        cy.withMessageFixture('quick-replies', () => {
+			cy.contains("foobar003qr02").children("img").should("have.attr", "alt")
+				.then(alttext => {
+					expect(alttext).to.be.eq("alt text");
+				});   
+            
+        }, reInit);
     })
 })

--- a/cypress/integration/messages/video.spec.ts
+++ b/cypress/integration/messages/video.spec.ts
@@ -25,7 +25,7 @@ describe("Message with Video", () => {
     it("should have class 'webchat-media-template-video'", () => {
         cy.withMessageFixture('video', () => {
             cy
-                .get(".webchat-message-row > div >  .webchat-media-template-video");
+                .get(".webchat-message-row .webchat-media-template-video");
         })
     })
 })

--- a/cypress/integration/messages/video.spec.ts
+++ b/cypress/integration/messages/video.spec.ts
@@ -25,7 +25,7 @@ describe("Message with Video", () => {
     it("should have class 'webchat-media-template-video'", () => {
         cy.withMessageFixture('video', () => {
             cy
-                .get(".webchat-message-row > .webchat-media-template-video");
+                .get(".webchat-message-row > div >  .webchat-media-template-video");
         })
     })
 })

--- a/cypress/integration/messages/video.spec.ts
+++ b/cypress/integration/messages/video.spec.ts
@@ -27,5 +27,14 @@ describe("Message with Video", () => {
             cy
                 .get(".webchat-message-row .webchat-media-template-video");
         })
-    })
+	})
+	
+	it("should have sr-only default alternate text for video", () => {
+        cy.withMessageFixture('video', () => {
+            cy
+				.get(".webchat-message-row .webchat-media-template-video .sr-only")
+				.contains("Attachment Video")
+				.should("not.be.visible");
+        })
+	})
 })

--- a/cypress/integration/sendMessage.spec.ts
+++ b/cypress/integration/sendMessage.spec.ts
@@ -1,0 +1,20 @@
+describe('Send Message', () => {
+
+    it('send message button should have correct aria-label', () => {
+        cy
+			.visitBuild()
+			.initMockWebchat()
+			.openWebchat()
+			.get('[aria-label="Send Message"]').should('be.visible');
+	});
+
+	it('should be possible to type and send message', () => {
+        cy
+			.visitBuild()
+			.initMockWebchat()
+			.openWebchat()
+			.get('[aria-label="Message to send"]').type('Hi')
+			.get('[aria-label="Send Message"]').click()
+			.get('.webchat-chat-history').contains('Hi');
+	});
+});

--- a/cypress/integration/webchatButton.spec.ts
+++ b/cypress/integration/webchatButton.spec.ts
@@ -1,0 +1,60 @@
+describe('Webchat Button', () => {
+
+    it('should have correct aria-label for open webchat button', () => {
+        cy
+			.visitBuild()
+			.initMockWebchat()
+            .get('[aria-label="Open chat"]').click()
+			.get('[aria-label="Open chat"]').should('not.exist');
+	});
+
+	it('should have correct aria-label for open webchat button with one unread message', () => {
+        cy
+			.visitBuild()
+			.initMockWebchat({
+                settings: {
+                    enableUnreadMessagePreview: true,
+                    engagementMessageText: 'engagement message text'
+                }
+			})
+			.wait(6000)
+            .get('[aria-label="One unread message in chat. Open chat"]').should('be.visible')
+			.get('[aria-label="One unread message in chat. Open chat"]').click()
+			.get('[aria-label="One unread message in chat. Open chat"]').should('not.exist');
+	});
+	
+	it('should have correct aria-label for open webchat button with one unread message', () => {
+        cy
+			.visitBuild()
+			.initMockWebchat({
+                settings: {
+                    enableUnreadMessagePreview: true,
+                }
+			})			
+			.withMessageFixture('text', ()=>{ 
+				cy.withMessageFixture('audio', ()=>{
+					cy.get('[aria-label="2 unread messages in chat. Open chat"]').should('be.visible');
+				});				
+			});            
+    });
+	
+	it('should have correct aria-label for close webchat button', () => {
+        cy
+			.visitBuild()
+			.initMockWebchat()
+            .get('[aria-label="Open chat"]').click()
+			.get('[aria-label="Close chat"]').should('be.visible')
+			.get('[aria-label="Close chat"]').click()
+			.get('[aria-label="Close chat"]').should('not.exist');
+	});
+	
+	it('should have correct aria-label for close button in chat window', () => {
+        cy
+			.visitBuild()
+			.initMockWebchat()
+            .get('[aria-label="Open chat"]').click()
+			.get('[aria-label="Close Chat"]').click()
+			.get('[aria-label="Close Chat"]').should('not.exist');
+	});
+
+});


### PR DESCRIPTION
This PR add new tests that uses aria-labels and roles as selectors, to ensure the presence of aria attributes in the elements. Also, adds test to ensure that alternate texts are present for images, audio and video. Additionaly, fixes the tests that are currently failing.

To test:
Run all tests using `npm test` or run individual tests using `npx cypress open`