### PR TITLE
fix analytics for open and close actions

### DIFF
--- a/src/webchat/store/analytics/analytics-middleware.ts
+++ b/src/webchat/store/analytics/analytics-middleware.ts
@@ -16,12 +16,6 @@ export const createAnalyticsMiddleware = (webchat: Webchat): Middleware<{}, Stor
             break;
         }
 
-        case 'TOGGLE_OPEN': {
-            const open = !store.getState().ui.open;
-            webchat.emitAnalytics(open ? 'webchat/open' : 'webchat/close');
-            break;
-        }
-
         case 'SEND_MESSAGE': {
             webchat.emitAnalytics('webchat/outgoing-message', action.message);
             break;


### PR DESCRIPTION
Using the webchat analytics api and logging the open and close events, they are always triggered twice.

Reason: TOGGLE_OPEN and SET_OPEN actions are handled in the analytics api seperately, but toggle_open calls set_open eventually, so clicking the open button will create 2 analytics events.

Solution: Removal of case for TOGGLE_OPEN in the analytics middleware

Test by using the analytics api (https://github.com/Cognigy/WebchatWidget/blob/master/docs/analytics-api.md)
with the event types "webchat/open" and "webchat/close"