### PR TITLE
Feature/force polling

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,7 +1,9 @@
 # Embedding the Cognigy Webchat
 
 ## Basic Implementation
+
 To integrate the Webchat into a Website, you need to
+
 1. load the `webchat.js` bundle via a `<script>` tag
 2. initialize the Webchat towards a Cognigy Endpoint using `initWebchat()`
 
@@ -9,40 +11,44 @@ See it in action:
 [![Edit Basic Implementation](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/basic-cognigy-webchat-embedding-ict1u?fontsize=14&hidenavigation=1&theme=dark)
 
 ## Using a Compatiblity Build
+
 For older browsers, we ship a seperate build of the Webchat called `webchat.legacy.js`, which comes with extra compatibility at the cost of increased size.
 
-| Browser | Version |
-| - | - |
-| Google Chrome | `>= 63` |
-| Firefox | `>= 55` |
-| Microsoft Edge | `>= 15` |
+| Browser           | Version |
+| ----------------- | ------- |
+| Google Chrome     | `>= 63` |
+| Firefox           | `>= 55` |
+| Microsoft Edge    | `>= 15` |
 | Internet Explorer | `>= 11` |
-| Safari | `>= 9` |
+| Safari            | `>= 9`  |
 
 See it in action:  
 [![Edit Using a Compatibility Build](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/embedding-the-cognigy-webchat-yu1yg?fontsize=14&hidenavigation=1&theme=dark)
 
-
 ## Using Webchat Plugins
+
 To make use of Webchat Plugins, you have to load them via `<script>` tags AFTER loading the `webchat.js` / `webchat.legacy.js` and BEFORE calling `initWebchat()`
 
 See it in action:  
 [![Edit Using Webchat Plugins](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/embedding-the-cognigy-webchat-1p6ky?fontsize=14&hidenavigation=1&theme=dark)
 
 ## Client-Side Configuration
+
 You can pass [Webchat Options](#webchat-options) as an additional argument to the `initWebchat()` function which can customize the way the Webchat connects to Cognigy as well as override the Settings from your Endpoint.
 
 ### Webchat Options
-| Name | Type | Default | Description |
-| - | - | - | - |
-| userId | string | random string[<sup>1</sup>](#persistent-user-id) | The user's id |
-| sessionId | string | random string | The session's id |
-| channel | string | `"webchat-client"` | The name of your client. Can be useful for analytics
-| reconnection | boolean | `true` | If `true`, will try to re-establish the connection after losing it
-| reconnectionLimit | number | `5` | Limit the maximum number of reconnection attempts, `0` means no limit
-| interval | number | `10000` | Interval time in miliseconds the webchat will wait inbetween polls when falling back to HTTP polling.
-| forceWebsockets | boolean | `false` | Rule whether to allow fallbacks to HTTP polling when Websockets are not available
-| settings | [Endpoint Settings](#endpoint-settings) | - | Can be used to (partially) override certain Settings from the Webchat Endpoint
+
+| Name              | Type                                    | Default                                          | Description                                                                                                      |
+| ----------------- | --------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| userId            | string                                  | random string[<sup>1</sup>](#persistent-user-id) | The user's id                                                                                                    |
+| sessionId         | string                                  | random string                                    | The session's id                                                                                                 |
+| channel           | string                                  | `"webchat-client"`                               | The name of your client. Can be useful for analytics                                                             |
+| reconnection      | boolean                                 | `true`                                           | If `true`, will try to re-establish the connection after losing it                                               |
+| reconnectionLimit | number                                  | `5`                                              | Limit the maximum number of reconnection attempts, `0` means no limit                                            |
+| interval          | number                                  | `10000`                                          | Interval time in miliseconds the webchat will wait inbetween polls when falling back to HTTP polling.            |
+| forceWebsockets   | boolean                                 | auto-determined by runtime-environment           | If `true`, the client will only use websockets and not fall back to http polling (wins over `disableWebsockets`) |
+| disableWebsockets | boolean                                 | false                                            | If `true`, the client will only use http polling and will not try to upgrade to websockets                       |
+| settings          | [Endpoint Settings](#endpoint-settings) | -                                                | Can be used to (partially) override certain Settings from the Webchat Endpoint                                   |
 
 <sup id="persistent-user-id">1</sup> The `userId` will be randomly generated on first page load and then persisted user via `LocalStorage`. When that user reloads the page, the Webchat will re-use the `userId` from `LocalStorage`.
 
@@ -50,63 +56,68 @@ See it in action:
 [![Edit Custom Webchat Options](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/embedding-the-cognigy-webchat-4xkv8?fontsize=14&hidenavigation=1&theme=dark)
 
 ### Endpoint Settings
-| Name | Type | Default | [UI Config](#UI-Configurable) | [Demo Exclusive](#Demo-Page-Settings) | Description |
-| - | - | - | - | - | - |
-| agentAvatarUrl | string | undefined | x | | A custom avatar that sould be displayed next to agent messages
-| colorScheme | string | #2C6CAF | x | | The background color of the header and bot messages in the Webchat. 
-| designTemplate | 1 or 2 | 1 | x | x | The Webchat design template to use. We default to design template 1 (bottom right with a button), you can switch to template 2, which is the centered webchat.
-| disableBranding | boolean | false | | | If true, hides "Powered by Cognigy" link
-| disableHtmlInput | boolean | false | | | If true, strips all html tags out from the input of the user.
-| disableInputAutofocus | boolean | false | | | By default, the input will automatically focus when a user opens the widget. If you set this to true, the input will no longer focus when opening the widget.
-| disableLocalStorage | boolean | false | | | If true, disables storing any information in browsers storage like persistent history and userId. This flag has a higher priority than `useSessionStorage` - setting this to true also disables SessionStorage.
-| disablePersistentHistory | boolean | false | | | If true, disables storing of the chat history into LocalStorage (used for persistence). 
-| disableTextInputSanitization | boolean | false | | | By default, text inputs from the user will be sanitized for HTML with scripting. If you set this to true, users can send any kind of HTML text, including script-tags and onload-attributes etc.
-| dynamicImageAspectRatio | boolean | false | | | If true, images from the "gallery", "attachment" or "top list item" template will not have a forced aspect ratio and will be fully displayed full-width without cropping
-| enableConnectionStatusIndicator | boolean | true | | | Whether to show a warning if the connection is lost during a conversation. The warning will disappear when the connection is re-established.
-| enablePersistentMenu | boolean | false | x | | Whether to enable the Persistent Menu 
-| enableStrictMessengerSync | boolean | false | | | If set to true, will NOT render the message from the "Messenger" tab in the SAY node unless "Use Facebook Channel" is checked in the "Webchat" tab. 
-| enableSTT | boolean | false | x | x | Whether to load the speech input plugin.
-| enableTTS | boolean | false | x | x | Whether to load the speech output plugin. 
-| enableTypingIndicator | boolean | true | x | | Whether to enable typing indicators in the Webchat when the Conversational AI is replying. Requires a messageDelay to be set. 
-| enableUnreadMessageBadge | boolean | false | | | If true, the webchat shows a badge with the number of unread messages at the toggle button
-| enableUnreadMessagePreview | boolean | false | | | If true, the webchat shows a message bubble with the latest retrieved bot message.
-| enableUnreadMessageSound | boolean | false | x | | If true, plays a notification sound for each incoming unread message  
-| enableUnreadMessageTitleIndicator | boolean | false | | If true, will indicate the amount of unread messages in the page title every 1000ms
-| engagementMessageText | string | "" |  |  | If this is set to a non-empty string, there will be an automatic "fake" engagement message being triggered after a delay
-| engagementMessageDelay | number | 5000 | | | The timeout after which the engagement message should be triggered (in milliseconds)
-| getStartedButtonText | string | "GET_STARTED" | x | | The text to display on the Get Started Button / when sending the auto message. 
-| getStartedPayload | string | "GET_STARTED" | x | | The payload to send to your Flow when clicking the Get Started Button / when sending the auto message. 
-| getStartedText | string | "Get Started" | x | | The text to display in the Webchat when clicking the Get Started Button / when sending the auto message. 
-| headerLogoUrl | string | COGNIGY.AI Logo | x | | The logo to display in the header of the Webchat. Defaults to a COGNIGY.AI logo. 
-| ignoreLineBreaks | boolean | false | x | | Whether to ignore line breaks in the Messenger Generic Templates, Gallery Cards Subtitle. 
-| inputPlaceholder | string | "Write a reply" | x | | The placeholder text to display in the input field. 
-| messageLogoUrl | string | COGNIGY.AI Logo | x | | A custom avatar that should be displayed next to bot messages. Defaults to a COGNIGY.AI logo. 
-| persistentMenu | [Persistent Menu](#persistent-menu) | - | x | | The Persistent Menu to render in the Webchat.
-| showEngagementMessagesInChat | boolean | false | | | If this is true, then engagement messages will also be shown in the chat window |
-| startBehavior | 'none' , 'button', 'injection' | 'none' | x | | If 'none', will start the webchat with a text input, 'button' will display a get started button with a preconfigured message, 'injection' will automatically send a message to the bot. |
-| title | string | Cognigy Webchat | x | | The text that will be shown in the title bar of the Webchat |
-| unreadMessageTitleText | string | "New Message" | x | | The website title that is displayed when the user retrieved one new message |
-| unreadMessageTitleTextPlural | string | "New Messages" | x | | The website title that is displayed when the user retrieved more than one new message |
-| userAvatarUrl | string | undefined | x | | A custom avatar that should be displayed next to user messages. Defaults to a user icon.
-| useSessionStorage | boolean | false | | | If true, to store chat history and userId sessionStorage is used instead of localStorage. Note: This means the userId will not be persisted after closing and re-opening a browser tab.
+
+| Name                              | Type                                | Default         | [UI Config](#UI-Configurable) | [Demo Exclusive](#Demo-Page-Settings)                                               | Description                                                                                                                                                                                                     |
+| --------------------------------- | ----------------------------------- | --------------- | ----------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| agentAvatarUrl                    | string                              | undefined       | x                             |                                                                                     | A custom avatar that sould be displayed next to agent messages                                                                                                                                                  |
+| colorScheme                       | string                              | #2C6CAF         | x                             |                                                                                     | The background color of the header and bot messages in the Webchat.                                                                                                                                             |
+| designTemplate                    | 1 or 2                              | 1               | x                             | x                                                                                   | The Webchat design template to use. We default to design template 1 (bottom right with a button), you can switch to template 2, which is the centered webchat.                                                  |
+| disableBranding                   | boolean                             | false           |                               |                                                                                     | If true, hides "Powered by Cognigy" link                                                                                                                                                                        |
+| disableHtmlInput                  | boolean                             | false           |                               |                                                                                     | If true, strips all html tags out from the input of the user.                                                                                                                                                   |
+| disableInputAutofocus             | boolean                             | false           |                               |                                                                                     | By default, the input will automatically focus when a user opens the widget. If you set this to true, the input will no longer focus when opening the widget.                                                   |
+| disableLocalStorage               | boolean                             | false           |                               |                                                                                     | If true, disables storing any information in browsers storage like persistent history and userId. This flag has a higher priority than `useSessionStorage` - setting this to true also disables SessionStorage. |
+| disablePersistentHistory          | boolean                             | false           |                               |                                                                                     | If true, disables storing of the chat history into LocalStorage (used for persistence).                                                                                                                         |
+| disableTextInputSanitization      | boolean                             | false           |                               |                                                                                     | By default, text inputs from the user will be sanitized for HTML with scripting. If you set this to true, users can send any kind of HTML text, including script-tags and onload-attributes etc.                |
+| dynamicImageAspectRatio           | boolean                             | false           |                               |                                                                                     | If true, images from the "gallery", "attachment" or "top list item" template will not have a forced aspect ratio and will be fully displayed full-width without cropping                                        |
+| enableConnectionStatusIndicator   | boolean                             | true            |                               |                                                                                     | Whether to show a warning if the connection is lost during a conversation. The warning will disappear when the connection is re-established.                                                                    |
+| enablePersistentMenu              | boolean                             | false           | x                             |                                                                                     | Whether to enable the Persistent Menu                                                                                                                                                                           |
+| enableStrictMessengerSync         | boolean                             | false           |                               |                                                                                     | If set to true, will NOT render the message from the "Messenger" tab in the SAY node unless "Use Facebook Channel" is checked in the "Webchat" tab.                                                             |
+| enableSTT                         | boolean                             | false           | x                             | x                                                                                   | Whether to load the speech input plugin.                                                                                                                                                                        |
+| enableTTS                         | boolean                             | false           | x                             | x                                                                                   | Whether to load the speech output plugin.                                                                                                                                                                       |
+| enableTypingIndicator             | boolean                             | true            | x                             |                                                                                     | Whether to enable typing indicators in the Webchat when the Conversational AI is replying. Requires a messageDelay to be set.                                                                                   |
+| enableUnreadMessageBadge          | boolean                             | false           |                               |                                                                                     | If true, the webchat shows a badge with the number of unread messages at the toggle button                                                                                                                      |
+| enableUnreadMessagePreview        | boolean                             | false           |                               |                                                                                     | If true, the webchat shows a message bubble with the latest retrieved bot message.                                                                                                                              |
+| enableUnreadMessageSound          | boolean                             | false           | x                             |                                                                                     | If true, plays a notification sound for each incoming unread message                                                                                                                                            |
+| enableUnreadMessageTitleIndicator | boolean                             | false           |                               | If true, will indicate the amount of unread messages in the page title every 1000ms |
+| engagementMessageText             | string                              | ""              |                               |                                                                                     | If this is set to a non-empty string, there will be an automatic "fake" engagement message being triggered after a delay                                                                                        |
+| engagementMessageDelay            | number                              | 5000            |                               |                                                                                     | The timeout after which the engagement message should be triggered (in milliseconds)                                                                                                                            |
+| getStartedButtonText              | string                              | "GET_STARTED"   | x                             |                                                                                     | The text to display on the Get Started Button / when sending the auto message.                                                                                                                                  |
+| getStartedPayload                 | string                              | "GET_STARTED"   | x                             |                                                                                     | The payload to send to your Flow when clicking the Get Started Button / when sending the auto message.                                                                                                          |
+| getStartedText                    | string                              | "Get Started"   | x                             |                                                                                     | The text to display in the Webchat when clicking the Get Started Button / when sending the auto message.                                                                                                        |
+| headerLogoUrl                     | string                              | COGNIGY.AI Logo | x                             |                                                                                     | The logo to display in the header of the Webchat. Defaults to a COGNIGY.AI logo.                                                                                                                                |
+| ignoreLineBreaks                  | boolean                             | false           | x                             |                                                                                     | Whether to ignore line breaks in the Messenger Generic Templates, Gallery Cards Subtitle.                                                                                                                       |
+| inputPlaceholder                  | string                              | "Write a reply" | x                             |                                                                                     | The placeholder text to display in the input field.                                                                                                                                                             |
+| messageLogoUrl                    | string                              | COGNIGY.AI Logo | x                             |                                                                                     | A custom avatar that should be displayed next to bot messages. Defaults to a COGNIGY.AI logo.                                                                                                                   |
+| persistentMenu                    | [Persistent Menu](#persistent-menu) | -               | x                             |                                                                                     | The Persistent Menu to render in the Webchat.                                                                                                                                                                   |
+| showEngagementMessagesInChat      | boolean                             | false           |                               |                                                                                     | If this is true, then engagement messages will also be shown in the chat window                                                                                                                                 |
+| startBehavior                     | 'none' , 'button', 'injection'      | 'none'          | x                             |                                                                                     | If 'none', will start the webchat with a text input, 'button' will display a get started button with a preconfigured message, 'injection' will automatically send a message to the bot.                         |
+| title                             | string                              | Cognigy Webchat | x                             |                                                                                     | The text that will be shown in the title bar of the Webchat                                                                                                                                                     |
+| unreadMessageTitleText            | string                              | "New Message"   | x                             |                                                                                     | The website title that is displayed when the user retrieved one new message                                                                                                                                     |
+| unreadMessageTitleTextPlural      | string                              | "New Messages"  | x                             |                                                                                     | The website title that is displayed when the user retrieved more than one new message                                                                                                                           |
+| userAvatarUrl                     | string                              | undefined       | x                             |                                                                                     | A custom avatar that should be displayed next to user messages. Defaults to a user icon.                                                                                                                        |
+| useSessionStorage                 | boolean                             | false           |                               |                                                                                     | If true, to store chat history and userId sessionStorage is used instead of localStorage. Note: This means the userId will not be persisted after closing and re-opening a browser tab.                         |
 
 ##### UI Configurable
+
 These settings can be controlled by a graphical input within the Endpoint editor
 
 ##### Demo Page Settings
+
 These settings only take effect on the integrated Demo page reachable through the "OPEN WEBCHAT" button in the Endpoint editor.
 
 See it in action:  
 [![Edit Override Endpoint Settings](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/embedding-the-cognigy-webchat-bpz1r?fontsize=14&hidenavigation=1&theme=dark)
 
 #### Persistent Menu
-| Name | Type | Default | Description |
-| - | - | - | - |
-| title | string | `""` | The title of the Persistent Menu |
-| menuItems | Array of [Persistent Menu Items](#persistent-menu-item) | `[]` | A List of Items that should appear in the Persistent Menu
+
+| Name      | Type                                                    | Default | Description                                               |
+| --------- | ------------------------------------------------------- | ------- | --------------------------------------------------------- |
+| title     | string                                                  | `""`    | The title of the Persistent Menu                          |
+| menuItems | Array of [Persistent Menu Items](#persistent-menu-item) | `[]`    | A List of Items that should appear in the Persistent Menu |
 
 #### Persistent Menu Item
-| Name | Type | Default | Description |
-| - | - | - | - |
-| title | string | `""` | The label of the Persisted Menu Item and visible Text on the Message |
-| payload | string | `""` | The actual text message that should be sent |
+
+| Name    | Type   | Default | Description                                                          |
+| ------- | ------ | ------- | -------------------------------------------------------------------- |
+| title   | string | `""`    | The label of the Persisted Menu Item and visible Text on the Message |
+| payload | string | `""`    | The actual text message that should be sent                          |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1714,9 +1714,9 @@
             }
         },
         "@cognigy/socket-client": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.4.0.tgz",
-            "integrity": "sha512-xVYwG44FOOoEmEuGeDrzOL5WVkEuX64RsmyxE9jySlaYKEFVMoProf5GqBcxIcNDol6pLPe8r4G+QpJ6p8oiRg==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.5.0.tgz",
+            "integrity": "sha512-LF+i36JlxEt20QtWVg+lIRblzkn7X2dfk9nuRRYkwdgxd1gpIOcmdp5qBfhJkGKst4c9W3kyWnZMiNv5/CDJ+Q==",
             "requires": {
                 "detect-browser": "^4.8.0",
                 "socket.io-client": "^2.2.0",
@@ -2581,7 +2581,8 @@
         "async-limiter": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+            "dev": true
         },
         "asynckit": {
             "version": "0.4.0",
@@ -2786,9 +2787,9 @@
             }
         },
         "base64-arraybuffer": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-            "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+            "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
         },
         "base64-js": {
             "version": "1.3.1",
@@ -2815,14 +2816,6 @@
             "dev": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
-            }
-        },
-        "better-assert": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-            "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-            "requires": {
-                "callsite": "1.0.0"
             }
         },
         "big.js": {
@@ -3148,11 +3141,6 @@
             "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
             "dev": true
         },
-        "callsite": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-            "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3470,7 +3458,8 @@
         "component-emitter": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+            "dev": true
         },
         "component-inherit": {
             "version": "0.0.3",
@@ -4100,6 +4089,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             },
@@ -4107,7 +4097,8 @@
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 }
             }
         },
@@ -4468,19 +4459,19 @@
             }
         },
         "engine.io-client": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
-            "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.0.tgz",
+            "integrity": "sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==",
             "requires": {
                 "component-emitter": "~1.3.0",
                 "component-inherit": "0.0.3",
-                "debug": "~4.1.0",
+                "debug": "~3.1.0",
                 "engine.io-parser": "~2.2.0",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
-                "parseqs": "0.0.5",
-                "parseuri": "0.0.5",
-                "ws": "~6.1.0",
+                "parseqs": "0.0.6",
+                "parseuri": "0.0.6",
+                "ws": "~7.4.2",
                 "xmlhttprequest-ssl": "~1.5.4",
                 "yeast": "0.1.2"
             },
@@ -4489,17 +4480,25 @@
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
                     "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 }
             }
         },
         "engine.io-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-            "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+            "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
             "requires": {
                 "after": "0.8.2",
                 "arraybuffer.slice": "~0.0.7",
-                "base64-arraybuffer": "0.1.5",
+                "base64-arraybuffer": "0.1.4",
                 "blob": "0.0.5",
                 "has-binary2": "~1.0.2"
             }
@@ -7817,11 +7816,6 @@
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
-        "object-component": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-            "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
-        },
         "object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -8120,20 +8114,14 @@
             "dev": true
         },
         "parseqs": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-            "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-            "requires": {
-                "better-assert": "~1.0.0"
-            }
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+            "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
         },
         "parseuri": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-            "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-            "requires": {
-                "better-assert": "~1.0.0"
-            }
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+            "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
         },
         "parseurl": {
             "version": "1.3.3",
@@ -9521,36 +9509,53 @@
             }
         },
         "socket.io-client": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
-            "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
+            "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
             "requires": {
                 "backo2": "1.0.2",
-                "base64-arraybuffer": "0.1.5",
                 "component-bind": "1.0.0",
-                "component-emitter": "1.2.1",
-                "debug": "~4.1.0",
-                "engine.io-client": "~3.4.0",
+                "component-emitter": "~1.3.0",
+                "debug": "~3.1.0",
+                "engine.io-client": "~3.5.0",
                 "has-binary2": "~1.0.2",
-                "has-cors": "1.1.0",
                 "indexof": "0.0.1",
-                "object-component": "0.0.3",
-                "parseqs": "0.0.5",
-                "parseuri": "0.0.5",
+                "parseqs": "0.0.6",
+                "parseuri": "0.0.6",
                 "socket.io-parser": "~3.3.0",
                 "to-array": "0.1.4"
+            },
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+                    "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
         },
         "socket.io-parser": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-            "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
+            "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
             "requires": {
-                "component-emitter": "1.2.1",
+                "component-emitter": "~1.3.0",
                 "debug": "~3.1.0",
                 "isarray": "2.0.1"
             },
             "dependencies": {
+                "component-emitter": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+                    "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+                },
                 "debug": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -11263,12 +11268,9 @@
             "dev": true
         },
         "ws": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-            "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
-            "requires": {
-                "async-limiter": "~1.0.0"
-            }
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+            "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
         },
         "xml2js": {
             "version": "0.4.17",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "pretest": "npm run webchat && npm run date-picker"
     },
     "dependencies": {
-        "@cognigy/socket-client": "^4.4.0",
+        "@cognigy/socket-client": "^4.5.0",
         "@emotion/cache": "^10.0.19",
         "@emotion/core": "^10.0.22",
         "@emotion/provider": "^0.11.2",


### PR DESCRIPTION
This PR upgrades the socket-client to version 4.5.0 which supports the new `disableWebsockets` flag.

Please test that
| forceWebsockets | disableWebsockets | expected result |
| - | - | - |
| `false` | `undefined` or `false` | first connection via http, then upgrade to websockets |
| `true` | `undefined` or `false` | direct websocket connection without upgrade |
| `true` | `true` | _same outcome as row above_ |
| `false` | `true` | connection via http polling without trying to upgrade to websockets (one http request per user message etc) |