### PR TITLE
improve reconnection behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1714,9 +1714,9 @@
             }
         },
         "@cognigy/socket-client": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.5.0.tgz",
-            "integrity": "sha512-LF+i36JlxEt20QtWVg+lIRblzkn7X2dfk9nuRRYkwdgxd1gpIOcmdp5qBfhJkGKst4c9W3kyWnZMiNv5/CDJ+Q==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.5.1.tgz",
+            "integrity": "sha512-QCURXBdbbiMrWVfTWxS9nsaAe3iP2eDir0mM3ougN5nH5vNJgI0IT7Biwt2Ml6g2w9+0v9ISJpYvcNEFdDMhUQ==",
             "requires": {
                 "detect-browser": "^4.8.0",
                 "socket.io-client": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "pretest": "npm run webchat && npm run date-picker"
     },
     "dependencies": {
-        "@cognigy/socket-client": "^4.5.0",
+        "@cognigy/socket-client": "^4.5.1",
         "@emotion/cache": "^10.0.19",
         "@emotion/core": "^10.0.22",
         "@emotion/provider": "^0.11.2",


### PR DESCRIPTION
This PR addresses an issue where inject/notify would not work after the webchat performed a reconnect.
For this to work, you need to make sure you are using a Cognigy v3 or v4 environment with the backend-side implementation for this to work.