### PR TITLE
Fix width of avatar in chat

### DIFF
--- a/src/webchat-embed/embedded-webchat-styles.css
+++ b/src/webchat-embed/embedded-webchat-styles.css
@@ -15,10 +15,6 @@
     z-index: 2;
 }
 
-[data-cognigy-webchat-root] [data-cognigy-webchat].webchat .webchat-avatar { 
-	max-width: 24px;
-}
-
 [data-cognigy-webchat-root] button[data-cognigy-webchat-toggle] {
     position: fixed;
 

--- a/src/webchat-embed/embedded-webchat-styles.css
+++ b/src/webchat-embed/embedded-webchat-styles.css
@@ -15,6 +15,9 @@
     z-index: 2;
 }
 
+[data-cognigy-webchat-root] [data-cognigy-webchat].webchat .webchat-avatar { 
+	max-width: 24px;
+}
 
 [data-cognigy-webchat-root] button[data-cognigy-webchat-toggle] {
     position: fixed;

--- a/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
@@ -155,8 +155,8 @@ export default ({
           return (
             <MessageRow key={key} align={align} className={className}>				
               	<Avatar src={message.avatarUrl as string} className={avatarClassName} aria-hidden="true"/>
-					<span className="sr-only">{messageSource}</span>
-             		{messageElement}
+				<span className="sr-only">{messageSource}</span>
+				{messageElement}
             </MessageRow>
           );
         }

--- a/src/webchat-ui/components/presentational/MessageRow.tsx
+++ b/src/webchat-ui/components/presentational/MessageRow.tsx
@@ -54,7 +54,7 @@ export default styled.div<IAlignmentProps & IVisibilityProps>(({ theme, align, h
             ...avatarStyles,
             flexGrow: 0,
             flexShrink: 0,
-            flexBasis: 26
+            flexBasis: 24
         },
         '&>:nth-child(n+2)': {
             // flexGrow: 1,


### PR DESCRIPTION
The width of the avatar was 26px and height was 24px, making the avatar look off. This PR fixes the width of the avatar in the chat, to make it a circle with equal width and height (24px). 

To test: 
- Test the avatar of both the sender and the receiver