### PR TITLE
remove race condition causing "auto-send message" not to work

### DIFF
--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -1,7 +1,7 @@
 import { WebchatUI, WebchatUIProps } from "../../webchat-ui";
 import { connect } from "react-redux";
 import { StoreState } from "../store/store";
-import { sendMessage, triggerEngagementMessage, triggerInjectionMessage } from '../store/messages/message-middleware';
+import { sendMessage, triggerEngagementMessage } from '../store/messages/message-middleware';
 import { setInputMode, setFullscreenMessage, setOpen, toggleOpen } from '../store/ui/ui-reducer';
 import { getPluginsForMessage, isFullscreenPlugin } from '../../plugins/helper';
 

--- a/src/webchat/store/autoinject/autoinject-middleware.ts
+++ b/src/webchat/store/autoinject/autoinject-middleware.ts
@@ -1,0 +1,72 @@
+import { SocketClient } from "@cognigy/socket-client";
+import { Middleware } from "redux";
+import { StoreState } from "../store";
+import { autoInjectHandled, TAutoInjectAction, triggerAutoInject } from './autoinject-reducer';
+import { getAvatarForMessage, sendMessage } from '../messages/message-middleware';
+import { addMessage } from "../messages/message-reducer";
+import { Webchat } from "../../components/Webchat";
+
+export const createAutoInjectMiddleware = (webchat: Webchat): Middleware<unknown, StoreState> => api => next => (action: TAutoInjectAction) => {
+    switch (action.type) {
+        case 'SET_CONFIG':
+        case 'SET_CONNECTED':
+        case 'SET_OPEN': {
+            next(action);
+            
+            const state = api.getState();
+            const { isAutoInjectHandled: isAutoInjectTriggered, isConfiguredOnce, isConnectedOnce, isOpenedOnce } = state.autoInject;
+
+            if (isAutoInjectTriggered)
+                return;
+
+            if (!isConfiguredOnce || !isConnectedOnce || !isOpenedOnce)
+                return;
+
+            api.dispatch(triggerAutoInject());
+
+            return;
+        }
+
+        case 'TRIGGER_AUTO_INJECT': {
+            const state = api.getState();
+            // Now is the time to handle the "auto-inject message" (if configured)
+
+
+            // This should be handled just once, so let's trigger it to be handled!
+            api.dispatch(autoInjectHandled());
+
+            // Don't send a message if "startBehavior" is not set to "injection"
+            if (state.config.settings.startBehavior !== 'injection') {
+                break;
+            }
+
+
+            // Don't send a message if an "engagement message" is in the message history
+            const isEmptyExceptEngagementMesage = state.messages
+                .filter(message => message.source !== 'engagement')
+                .length === 0;
+
+            if (!isEmptyExceptEngagementMesage) {
+                break;
+            }
+
+            // We are going to send the auto-inject message, now!
+            const text = state.config.settings.getStartedPayload;
+            const label = state.config.settings.getStartedText;
+
+            /**
+             * IMPORTANT
+             * We are calling client.sendMessage, not webchat.sendMessage!
+             * This means the client will not auto-connect.
+             * The message will be sent as soon as the client connects
+             * 
+             * We manually add the message to the history
+             */
+
+             webchat.sendMessage(text, {}, { label });
+            break;
+        }
+    }
+
+    next(action);
+}

--- a/src/webchat/store/autoinject/autoinject-reducer.ts
+++ b/src/webchat/store/autoinject/autoinject-reducer.ts
@@ -1,0 +1,82 @@
+import { Reducer } from "redux";
+import { SetConfigAction } from '../config/config-reducer';
+import { SetConnectedAction } from '../connection/connection-reducer';
+import { SetOpenAction } from '../ui/ui-reducer';
+
+const getInitialState = () => ({
+    isOpenedOnce: false,
+    isConnectedOnce: false,
+    isConfiguredOnce: false,
+    isAutoInjectHandled: false
+});
+
+export interface IAutoInjectState extends ReturnType<typeof getInitialState> { }
+
+const TRIGGER_AUTO_INJECT = 'TRIGGER_AUTO_INJECT';
+export const triggerAutoInject = () => ({
+    type: TRIGGER_AUTO_INJECT as 'TRIGGER_AUTO_INJECT',
+});
+export type TTriggerAutoInjectAction = ReturnType<typeof triggerAutoInject>;
+
+const AUTO_INJECT_HANDLED = 'AUTO_INJECT_HANDLED';
+export const autoInjectHandled = () => ({
+    type: AUTO_INJECT_HANDLED as 'AUTO_INJECT_HANDLED',
+});
+export type TAutoInjectTriggeredAction = ReturnType<typeof autoInjectHandled>;
+
+export type TAutoInjectAction = SetConnectedAction | SetOpenAction | SetConfigAction | TTriggerAutoInjectAction | TAutoInjectTriggeredAction;
+
+/**
+ * This reducer collects and manages information about
+ * - whether the auto-inject message is ready to be sent
+ * - whether the auto-inject message has been sent already
+ */
+export const autoInject: Reducer<IAutoInjectState, TAutoInjectAction> = (state = getInitialState(), action) => {
+    switch (action.type) {
+        case 'SET_CONNECTED': {
+            if (action.connected && !state.isConnectedOnce) {
+                return {
+                    ...state,
+                    isConnectedOnce: true
+                }
+            }
+
+            break;
+        }
+
+        case 'SET_OPEN': {
+            if (action.open && !state.isOpenedOnce) {
+                return {
+                    ...state,
+                    isOpenedOnce: true
+                }
+            }
+
+            break;
+        }
+
+        case 'SET_CONFIG': {
+            if (!state.isConfiguredOnce) {
+                return {
+                    ...state,
+                    isConfiguredOnce: true
+                }
+            }
+
+            break;
+        }
+
+        case 'AUTO_INJECT_HANDLED': {
+            if (!state.isAutoInjectHandled) {
+                return {
+                    ...state,
+                    isAutoInjectHandled: true
+                }
+            }
+
+            break;
+        }
+    }
+
+    return state;
+}

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -55,7 +55,7 @@ const getInitialState = (): ConfigState => ({
     }
 });
 
-const SET_CONFIG = 'SET_CONFIG';
+export const SET_CONFIG = 'SET_CONFIG';
 export const setConfig = (config: ConfigState) => ({
     type: SET_CONFIG as 'SET_CONFIG',
     config

--- a/src/webchat/store/connection/connection-middleware.ts
+++ b/src/webchat/store/connection/connection-middleware.ts
@@ -21,7 +21,6 @@ export type ConnectAction = ReturnType<typeof connect>;
 export const createConnectionMiddleware = (client: SocketClient): Middleware<{}, StoreState> => store => next => (action: SetOpenAction | ToggleOpenAction | ConnectAction | SendMessageAction) => {
     switch (action.type) {
         case 'CONNECT': {
-
             if (!client.connected && !store.getState().connection.connecting) {
                 store.dispatch(setConnecting(true));
 
@@ -40,14 +39,6 @@ export const createConnectionMiddleware = (client: SocketClient): Middleware<{},
                 if (!client.connected) {
                     store.dispatch(connect())
                 }
-            }
-
-            break;
-        }
-
-        case 'TOGGLE_OPEN': {
-            if (!store.getState().ui.open) {
-                store.dispatch(connect())
             }
 
             break;

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -37,13 +37,7 @@ export const triggerEngagementMessage = () => ({
 });
 type TriggerEngagementMessageAction = ReturnType<typeof triggerEngagementMessage>;
 
-const TRIGGER_INJECTION_MESSAGE = 'TRIGGER_INJECTION_MESSAGE';
-export const triggerInjectionMessage = () => ({
-    type: TRIGGER_INJECTION_MESSAGE as 'TRIGGER_INJECTION_MESSAGE'
-});
-type TriggerInjectionMessageAction = ReturnType<typeof triggerInjectionMessage>;
-
-const getAvatarForMessage = (message: IMessage, state: StoreState) => {
+export const getAvatarForMessage = (message: IMessage, state: StoreState) => {
     switch (message.source) {
         case 'agent':
             return state.ui.agentAvatarOverrideUrl || state.config.settings.agentAvatarUrl || defaultAgentAvatar;
@@ -117,38 +111,6 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<{}, St
                     text
                 }));
             }
-
-            break;
-        }
-
-        case 'TRIGGER_INJECTION_MESSAGE': {
-            const state = store.getState();
-
-            const isInjectBehavior = state.config.settings.startBehavior === 'injection'
-                && state.config.settings.getStartedPayload;
-            if (!isInjectBehavior)
-                break;
-
-            // TODO
-            const isEmptyExceptEngagementMesage = state.messages.filter(message => message.source !== 'engagement').length === 0;
-            if (!isEmptyExceptEngagementMesage)
-                break;
-
-            const text = state.config.settings.getStartedPayload;
-            const label = state.config.settings.getStartedText;
-
-
-            /**
-             * IMPORTANT
-             * We are calling client.sendMessage, not webchat.sendMessage!
-             * This means the client will not auto-connect.
-             * The message will be sent as soon as the client connects
-             * 
-             * We manually add the message to the history
-             */
-            client.sendMessage(text);
-            const avatarUrl = getAvatarForMessage({ source: "user" }, state);
-            next(addMessage({ text: label, source: 'user', avatarUrl }));
 
             break;
         }

--- a/src/webchat/store/options/options-middleware.ts
+++ b/src/webchat/store/options/options-middleware.ts
@@ -28,10 +28,7 @@ export const optionsMiddleware: Middleware<{}, StoreState> = store => next => (a
                         store.dispatch(resetState(persisted));
                     } catch (e) { }
                 }
-
             }
-            
-            store.dispatch(triggerInjectionMessage());
         }
     }
 

--- a/src/webchat/store/reducer.ts
+++ b/src/webchat/store/reducer.ts
@@ -5,6 +5,7 @@ import { ui } from "./ui/ui-reducer";
 import { config } from "./config/config-reducer";
 import { connection } from "./connection/connection-reducer";
 import { unseenMessages } from './unseen-messages/unseen-message-reducer';
+import { autoInject } from './autoinject/autoinject-reducer';
 import { StoreState } from "./store";
 
 const rootReducer = combineReducers({
@@ -12,6 +13,7 @@ const rootReducer = combineReducers({
     unseenMessages,
     options,
     config,
+    autoInject,
     ui,
     connection
 });

--- a/src/webchat/store/store.ts
+++ b/src/webchat/store/store.ts
@@ -1,4 +1,4 @@
-import { createStore, applyMiddleware, compose } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import { StateType } from 'typesafe-actions';
 import { createMessageMiddleware } from './messages/message-middleware';
 import { registerMessageHandler } from './messages/message-handler';
@@ -14,6 +14,7 @@ import { IWebchatSettings } from '../../common/interfaces/webchat-config';
 import { uiMiddleware } from './ui/ui-middleware';
 import { registerUiHandler } from './ui/ui-handler';
 import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
+import { createAutoInjectMiddleware } from './autoinject/autoinject-middleware';
 
 
 export type StoreState = StateType<typeof reducer>;
@@ -29,6 +30,7 @@ export const createWebchatStore = (webchat: Webchat, url: string, overrideWebcha
             createConnectionMiddleware(client),
             createMessageMiddleware(client),
             createConfigMiddleware(url, overrideWebchatSettings),
+            createAutoInjectMiddleware(webchat),
             optionsMiddleware,
             uiMiddleware    
         ))

--- a/src/webchat/store/ui/ui-reducer.ts
+++ b/src/webchat/store/ui/ui-reducer.ts
@@ -14,7 +14,7 @@ export interface UIState {
     isPageVisible: boolean;
 }
 
-const SET_OPEN = 'SET_OPEN';
+export const SET_OPEN = 'SET_OPEN';
 export const setOpen = (open: boolean) => ({
     type: SET_OPEN as 'SET_OPEN',
     open


### PR DESCRIPTION
This PR fixes an issue that causes "auto-send messages" to not trigger properly.
The problem can occur when using "auto-send message" together with `webchat.open()` in the embedding code, causing a race condition.

The "before state" looked like this:
`initWebchat()` will trigger `load config`
`open webchat` will trigger `connect`
`connected` will trigger `handle injection message`
`handle injection message` checks if "injection message" is configured in the config and, if configured, will send the injection message

The problem:
if `connected` happens before `config loaded`, the `handle injection message` was executed without access to the endpoint configuration for "injection message".

The solution:
The "injection message" was moved to its own reducer/middleware.
The reducer registers whether certain things already happened once:
- webchat was opened
- connection was established
- config was loaded
- injection message was handled
It will listen to the `SET_OPEN`, `SET_CONNECTED`, and `SET_CONFIG` actions used by the other reducers and store whether they already happened.
Additionally, it will also register whether the "injection message" happened via a new action.

The middleware will listen to `SET_OPEN`, `SET_CONNECTED`, and `SET_CONFIG`events, handle them as usual, then check whether the "injection message" was not already handled and check whether it's ready.
If it's ready and not handled, it should be triggered now.

This fixes the "order of events" issue.

# How to Test
- configure a webchat endpoint with an "injection message"
- run the webchat from this branch towards that endpoint
- configure your embedding code to open the webchat immediately
```javascript
initWebchat('').then(webchat => {
  webchat.open();
});
```
- refresh the browser tab multiple times
  - without this fix, the injection message may not be sent
  - with this fix, the injection message should always be sent