### PR TITLE
Ignore "engagement message" in "get started button" rule

### DIFF
--- a/src/plugins/get-started-button-input/index.ts
+++ b/src/plugins/get-started-button-input/index.ts
@@ -3,7 +3,7 @@ import { InputRule, InputPlugin } from "../../common/interfaces/input-plugin";
 import { registerInputPlugin } from "../helper";
 
 const rule: InputRule = ({ config: { settings: { startBehavior, getStartedButtonText, getStartedPayload, getStartedText } }, messages }) =>
-    messages.length === 0
+    (messages.length === 0 || messages.length === 1 && messages[0].source === 'engagement')
     && startBehavior === 'button'
     && !!getStartedPayload
     && (!!getStartedButtonText || !!getStartedText)


### PR DESCRIPTION
This PR fixes an issue that would render the "get started button" useless if you used it with an engagement message since the message would be in the history and would cause the "get started button" to not render.

To solve this, I added an exception for the "get started button" rule to also show if there is only an engagement message in the chat.

Since there can only be one engagement message, we can implement this check cheaply.

To test this, apply the following settings to your webchat:

```javascript
{
  settings: {
    enableUnreadMessagePreview: true,
    showEngagementMessagesInChat: true,
    getStartedText: "Text",
    getStartedButtonText: "Button Text",
    getStartedPayload: "Payload",
    startBehavior: 'button',
    engagementMessageText: "Engagement Message",
    engagementMessageDelay: 1000
  }
}
```

Without the patch, the "get started button" will not be shown when the webchat was opened after the "engagement message" triggered. With the patch applied, it should still be shown.