### PR TITLE
2.25.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@cognigy/webchat",
-    "version": "2.25.3",
+    "version": "2.25.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cognigy/webchat",
-    "version": "2.25.3",
+    "version": "2.25.4",
     "description": "Webchat Widget for Cognigy.AI",
     "author": "Cognigy GmbH <info@cognigy.com>",
     "contributors": [


### PR DESCRIPTION
## Bug Fixes
- fixed a bug where using "auto send message" would accidentally trigger if the session was restored and not empty

## Improvements
- providing an empty "get started text" will now result in the message not being rendered in the chat instead of falling back to the "payload"
- improved the accessibility of the "persistent menu"
- improved the accessibility of the "header"
- added "accessibility landmarks" to the webchat

## Possibly Breaking Changes
- CSS customization for the persistent menu may need to be updated because of a new `div` element
- If you used the "button" or "auto-send" option for start behavior, the implicit "fallback to payload value" for the "get started message text" is now gone, you will have to manually adjust that in your endpoint 