### PR TITLE
Fix missing "get started button" messages

### DIFF
--- a/src/plugins/get-started-button-input/GetStartedInput.tsx
+++ b/src/plugins/get-started-button-input/GetStartedInput.tsx
@@ -16,10 +16,10 @@ const GetStartedButton = styled(Button)(({ theme }) => ({
 export default ({ onSendMessage, config }: InputComponentProps) => (
     <Toolbar>
         <GetStartedButton
-            onClick={() => onSendMessage(config.settings.getStartedPayload, null, { label: config.settings.getStartedText })}
+            onClick={() => onSendMessage(config.settings.getStartedPayload, null, { label: config.settings.getStartedText ?? '' })}
             color='primary'
         >
-            {config.settings.getStartedButtonText || config.settings.getStartedText}
+            {config.settings.getStartedButtonText}
         </GetStartedButton>
     </Toolbar>
 )

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -71,21 +71,11 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<{}, St
 
             const displayMessage = { ...message, text };
 
-            if (options.label)
+            if (typeof options.label === 'string')
                 displayMessage.text = options.label;
 
             next(setFullscreenMessage(undefined));
 
-            /**
-             * Do not add the message to the history 
-             * if the label is set but empty.
-             * 
-             * This allows "silently" send a message
-             * to bot, e.g. injected start message
-             **/ 
-            if (typeof options.label === "string" && options.label.trim().length === 0) {
-                break;
-            }
             next(addMessage({
                 ...displayMessage,
                 avatarUrl: getAvatarForMessage(displayMessage, store.getState())


### PR DESCRIPTION
This is a followup PR to https://github.com/Cognigy/WebchatWidget/pull/159.

The PR solved the issue by removing the "implicit fallback" to the "get started payload", but it also changed the behavior to "not adding a message at all" while it should be "add a message with empty text content".

Messages without text content will not be rendered by default and result in the same end-user experience, while developers can still rely on tracking the empty message in the chat history (the get started button itself e.g. can vanish immediately instead of staying there until a response appeared)

To test this:
- set up a flow which sends a text message after 3 seconds
- set up an endpoint with a "get started button" with no text but a payload
- point your webchat to the endpoint, don't use persistent history (so the get started button will show)
- click the "get started" button
  - it should immediately disappear on click, not "when the answer arrived"

