### PR TITLE
2.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@cognigy/webchat",
-    "version": "2.25.4",
+    "version": "2.26.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cognigy/webchat",
-    "version": "2.25.4",
+    "version": "2.26.0",
     "description": "Webchat Widget for Cognigy.AI",
     "author": "Cognigy GmbH <info@cognigy.com>",
     "contributors": [


### PR DESCRIPTION
## New Features
- added the `updateSettings` API, allowing to update certain webchat settings at runtime

## Bug Fixes
- fixed a bug where messages with empty label would not be put into the history 