### PR TITLE
Fix dom elements ids

### DIFF
--- a/src/common/utils/randomId.ts
+++ b/src/common/utils/randomId.ts
@@ -1,0 +1,8 @@
+import { useState } from "react"
+import uuid from "uuid"
+
+export const useRandomId = (prefix = "") => {
+    const [id] = useState(() => `${prefix}-${uuid.v4()}`);
+
+    return id;
+}

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
@@ -4,9 +4,9 @@ import { getDivider } from '../Divider';
 import { MessagePluginFactoryProps } from '../../../../../common/interfaces/message-plugin';
 import { getMessengerButton } from '../MessengerButton/MessengerButton';
 import { getMessengerButtonHeader } from '../MessengerButtonHeader';
-import uuid from "uuid";
 import { useEffect } from 'react';
 import {IWebchatConfig} from '../../../../../common/interfaces/webchat-config';
+import { useRandomId } from '../../../../../common/utils/randomId';
 
 interface IMessengerButtonTemplateProps extends IWithFBMActionEventHandler {
     payload: IFBMButtonTemplatePayload;
@@ -33,8 +33,8 @@ export const getMessengerButtonTemplate = ({
         ...divProps
     }: IMessengerButtonTemplateProps & React.HTMLProps<HTMLDivElement>) => {
         const { text, buttons } = payload;
-        const webchatButtonTemplateButtonId = `webchatButtonTemplateButton-${uuid.v4()}`;
-        const webchatButtonTemplateTextId = `webchatButtonTemplateHeader-${uuid.v4()}`;
+        const webchatButtonTemplateButtonId = useRandomId("webchatButtonTemplateButton");
+        const webchatButtonTemplateTextId = useRandomId("webchatButtonTemplateHeader");
         const buttonGroupAriaLabelledby = text ? webchatButtonTemplateTextId : undefined;
         const a11yProps = buttons?.length > 1 ? {role: "group", "aria-labelledby": buttonGroupAriaLabelledby} : {};
 

--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/MessengerListTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/MessengerListTemplate.tsx
@@ -8,7 +8,7 @@ import { getMessengerFrame } from '../MessengerFrame';
 import { getMessengerListTemplateHeaderElement } from './components/MessengerListTemplateHeaderElement';
 import { IWebchatConfig } from '../../../../../common/interfaces/webchat-config';
 import { useEffect } from 'react';
-import uuid from 'uuid';
+import { useRandomId } from '../../../../../common/utils/randomId';
 
 export interface IMessengerListTemplateProps extends IWithFBMActionEventHandler {
     payload: IFBMListTemplatePayload;
@@ -37,7 +37,7 @@ export const getMessengerListTemplate = ({ React, styled }: MessagePluginFactory
             : null;
 
         const button = buttons && buttons[0];
-        const listTemplateId = `webchatListTemplateRoot-${uuid.v4()}`;
+        const listTemplateId = useRandomId("webchatListTemplateRoot");
 
         useEffect(() => {
             const chatHistory = document.getElementById("webchatChatHistoryWrapperLiveLogPanel");

--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateElement.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateElement.tsx
@@ -8,7 +8,7 @@ import { getMessengerTitle } from '../../MessengerTitle';
 import { getMessengerListButton } from '../../MessengerListButton';
 import { getBackgroundImage } from '../../../lib/css';
 import { IWebchatConfig } from '../../../../../../common/interfaces/webchat-config';
-import uuid from "uuid";
+import { useRandomId } from '../../../../../../common/utils/randomId';
 
 interface IMessengerListTemplateElementProps extends IWithFBMActionEventHandler {
     element: IFBMListTemplateElement;
@@ -50,7 +50,7 @@ export const getMessengerListTemplateElement = ({ React, styled }: MessagePlugin
         const imgStyle: React.CSSProperties = {
             backgroundImage: getBackgroundImage(image_url)
         }
-        const messengerSubtitleId = `webchatListTemplateSubtitle-${uuid.v4()}`;
+        const messengerSubtitleId = useRandomId("webchatListTemplateSubtitle");
         const messengerTitle = title ? title + ". " : "";
         const messengerAriaLabel  = default_action?.url ? messengerTitle + "Opens in new tab" : title;
 

--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateHeaderElement.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateHeaderElement.tsx
@@ -8,7 +8,7 @@ import { getMessengerListButton } from '../../MessengerListButton';
 import { getButtonLabel } from '../../MessengerButton/lib/messengerButtonHelpers';
 import { getBackgroundImage } from '../../../lib/css';
 import { IWebchatConfig } from '../../../../../../common/interfaces/webchat-config';
-import uuid from "uuid";
+import { useRandomId } from '../../../../../../common/utils/randomId';
 
 interface IMessengerListTemplateHeaderElementProps extends IWithFBMActionEventHandler {
     element: IFBMListTemplateElement;
@@ -88,7 +88,7 @@ export const getMessengerListTemplateHeaderElement = ({ React, styled }: Message
         const button = buttons && buttons[0];
         const messengerTitle = title ? title + ". " : "";
         const ariaLabelForMessengerTitle = default_action?.url ? messengerTitle + "Opens in new tab" : title;
-        const messengerSubtitleId = `webchatListTemplateHeaderSubtitle-${uuid.v4()}`;
+        const messengerSubtitleId = useRandomId("webchatListTemplateHeaderSubtitle"); 
 
         const handleKeyDown = (event, default_action) => {
             if(default_action && event.key === "Enter") {

--- a/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
@@ -9,7 +9,7 @@ import { IWithFBMActionEventHandler } from '../../MessengerPreview.interface';
 import { MessagePluginFactoryProps } from '../../../../../common/interfaces/message-plugin';
 import { IWebchatConfig } from '../../../../../common/interfaces/webchat-config';
 import { getMessengerBubble } from '../MessengerBubble';
-import uuid from "uuid";
+import { useRandomId } from '../../../../../common/utils/randomId';
 
 interface Props extends IWithFBMActionEventHandler {
     message: IFBMRegularMessage;
@@ -55,8 +55,8 @@ export const getMessengerTextWithQuickReplies = ({
 
         const hasQuickReplies = quick_replies && quick_replies.length > 0;
         const hasMoreThanOneQuickReply = quick_replies && quick_replies.length > 1;
-        const webchatQuickReplyTemplateButtonId = `webchatQuickReplyTemplateButton-${uuid.v4()}`;
-        const webchatQuickReplyTemplateHeaderId = `webchatQuickReplyTemplateHeader-${uuid.v4()}`;
+        const webchatQuickReplyTemplateButtonId = useRandomId("webchatQuickReplyTemplateButton");
+        const webchatQuickReplyTemplateHeaderId = useRandomId("webchatQuickReplyTemplateHeader");
         const buttonGroupAriaLabelledby = text ? webchatQuickReplyTemplateHeaderId : undefined;
         const a11yProps = hasMoreThanOneQuickReply ? 
             {role: "group", "aria-labelledby": buttonGroupAriaLabelledby } : {};


### PR DESCRIPTION
This PR makes sure randomly generated ids for the dom elements do not change in lifecycle of the component.

To test:
- receive a message containing e.g. quickreplies or buttons
- open browser dev tool and check the ids of the elements
- receive another message
The ids of the previous message elements should remain the same