### PR TITLE
Fix for screen reader reading messages twice

### DIFF
--- a/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
@@ -154,9 +154,8 @@ export default ({
 
           return (
             <MessageRow key={key} align={align} className={className}>		
-              	<Avatar src={message.avatarUrl as string} className={avatarClassName} aria-hidden="true"/>
-				<span className="sr-only">{messageSource}</span>
-				{messageElement}
+                <Avatar src={message.avatarUrl as string} className={avatarClassName} aria-label={messageSource}/>
+                {messageElement}
             </MessageRow>
           );
         }


### PR DESCRIPTION
This PR fixes double-speaking issue that occurs while using NVDA. The messages are only read once when using ChromeVox and using NVDA in IE11. On using other browsers with NVDA, the screen reader reads the messages twice (Once when the message is added to the chat log and once when next message is added to the log). Strangely, removing the span with 'sr-only' class seems to fix this issue. 

Current sample sr output:
I say: **hi**
**hi** Bot says: **hello there**
**hello there** I say: Bye! 

Expected Behaviour:
I say: **hi**
Bot says: **hello there**
I say: Bye!

To test:
- Please use ChromeVox and NVDA(free screen reader for windows) to test this PR. 
- Interact with the bot and listen to what the screen reader speaks. The messages should not be repeated twice. 
- In order to view all the text that NVDA is currently speaking, you can use NVDA's speech viewer (To enable the speech viewer, check the "Speech Viewer" menu item under Tools in the NVDA menu).
- If possible, test this with VoiceOver as well.
