### PR TITLE
List template layout in IE11

### DIFF
--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateElement.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateElement.tsx
@@ -73,7 +73,7 @@ export const getMessengerListTemplateElement = ({ React, styled }: MessagePlugin
                     tabIndex={default_action?.url ? 0 : -1}
                     onKeyDown={e => handleKeyDown(e, default_action)}
                 >
-                    <div style={{maxWidth:image_url ? '75%': ""}}>
+                    <div style={{maxWidth:image_url ? '74%': ""}}>
                         <MessengerTitle className="webchat-list-template-element-title" dangerouslySetInnerHTML={{ __html: title }} />
                         <MessengerSubtitle className="webchat-list-template-element-subtitle" dangerouslySetInnerHTML={{ __html: subtitle }} config={config} id={messengerSubtitleId} />
                         {button && (

--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateElement.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateElement.tsx
@@ -67,7 +67,6 @@ export const getMessengerListTemplateElement = ({ React, styled }: MessagePlugin
                 <Root
                     role={default_action?.url ? "link" : undefined}
                     onClick={default_action && (e => onAction(e, default_action))}
-                    style={default_action?.url ? { cursor: "pointer" } : {}}
                     className={`webchat-list-template-element ${default_action?.url ? "link" : ""}`}
                     aria-label={messengerAriaLabel} 
                     aria-describedby={subtitle ? messengerSubtitleId : undefined}

--- a/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateElement.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerListTemplate/components/MessengerListTemplateElement.tsx
@@ -22,9 +22,8 @@ export const getMessengerListTemplateElement = ({ React, styled }: MessagePlugin
     const ListButton = getMessengerListButton({ React, styled });
 
     const Root = styled(MessengerContent)(({ theme }) => ({
-        display: 'grid',
-        gridTemplateColumns: '1fr auto',
-        gridColumnGap: theme.unitSize,
+        display: 'flex',
+        justifyContent: 'space-between',
         backgroundColor: 'white',
         "&:focus": {
             outline: 'none',
@@ -42,20 +41,21 @@ export const getMessengerListTemplateElement = ({ React, styled }: MessagePlugin
 
 
     const MessengerListTemplateElement = ({ element, onAction, config }: IMessengerListTemplateElementProps) => {
-        const { title, subtitle, image_url, image_alt_text,  buttons, default_action } = element;
+        const { title, subtitle, image_url, image_alt_text, buttons, default_action } = element;
         // TODO default_action
 
         const button = buttons && buttons[0];
 
         const imgStyle: React.CSSProperties = {
-            backgroundImage: getBackgroundImage(image_url)
+            backgroundImage: getBackgroundImage(image_url),
+            width: '25%'
         }
         const messengerSubtitleId = `webchatListTemplateSubtitle-${uuid.v4()}`;
         const messengerTitle = title ? title + ". " : "";
-        const messengerAriaLabel  = default_action?.url ? messengerTitle + "Opens in new tab" : title;
+        const messengerAriaLabel = default_action?.url ? messengerTitle + "Opens in new tab" : title;
 
         const handleKeyDown = (event, default_action) => {
-            if(event.key === "Enter" && default_action) {
+            if (event.key === "Enter" && default_action) {
                 onAction(event, default_action);
             }
         }
@@ -63,23 +63,23 @@ export const getMessengerListTemplateElement = ({ React, styled }: MessagePlugin
         return (
             <div role="listitem">
                 <Root
-                    role={default_action?.url ? "link" : undefined} 
+                    role={default_action?.url ? "link" : undefined}
                     onClick={default_action && (e => onAction(e, default_action))}
                     className="webchat-list-template-element"
-                    style={default_action?.url ? { cursor: "pointer" }:{}}
-                    aria-label={messengerAriaLabel} 
+                    style={default_action?.url ? { cursor: "pointer" } : {}}
+                    aria-label={messengerAriaLabel}
                     aria-describedby={subtitle ? messengerSubtitleId : undefined}
                     tabIndex={default_action?.url ? 0 : -1}
-                    onKeyDown = {e => handleKeyDown(e, default_action)}
+                    onKeyDown={e => handleKeyDown(e, default_action)}
                 >
-                    <div>
-                        <MessengerTitle className="webchat-list-template-element-title" dangerouslySetInnerHTML={{__html: title}} />
-                        <MessengerSubtitle className="webchat-list-template-element-subtitle" dangerouslySetInnerHTML={{__html: subtitle}} config={config} id={messengerSubtitleId} />
+                    <div style={{maxWidth:image_url ? '75%': ""}}>
+                        <MessengerTitle className="webchat-list-template-element-title" dangerouslySetInnerHTML={{ __html: title }} />
+                        <MessengerSubtitle className="webchat-list-template-element-subtitle" dangerouslySetInnerHTML={{ __html: subtitle }} config={config} id={messengerSubtitleId} />
                         {button && (
                             <ListButton
-                                onClick={e => {e.stopPropagation(); onAction(e, button)}}
+                                onClick={e => { e.stopPropagation(); onAction(e, button) }}
                                 className="webchat-list-template-element-button"
-                                dangerouslySetInnerHTML={{__html: getButtonLabel(button)}}
+                                dangerouslySetInnerHTML={{ __html: getButtonLabel(button) }}
                             />
                         )}
                     </div>


### PR DESCRIPTION
This PR fixes the layout of the webchat lists elements which was broken in IE11 since it does not support grid layout, I have changed it to flex

Please test the Lists templates and make sure they are looking and working as before in the webchat channel in IE11, also test in other browsers.