### PR TITLE
add "enableInjectionWithoutEmptyHistory" flag

### DIFF
--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -19,6 +19,7 @@ export interface IWebchatSettings {
   enableConnectionStatusIndicator: boolean;
   showEngagementMessagesInChat: boolean;
   enableAutoFocus: boolean;
+  enableInjectionWithoutEmptyHistory: boolean;
   enableFileUpload: boolean;
   enableGenericHTMLStyling: boolean;
   enableFocusTrap: boolean;

--- a/src/webchat/store/autoinject/autoinject-middleware.ts
+++ b/src/webchat/store/autoinject/autoinject-middleware.ts
@@ -2,6 +2,7 @@ import { Middleware } from "redux";
 import { StoreState } from "../store";
 import { autoInjectHandled, TAutoInjectAction, triggerAutoInject } from './autoinject-reducer';
 import { Webchat } from "../../components/Webchat";
+import { IWebchatConfig } from "../../../common/interfaces/webchat-config";
 
 export const createAutoInjectMiddleware = (webchat: Webchat): Middleware<unknown, StoreState> => api => next => (action: TAutoInjectAction) => {
     switch (action.type) {
@@ -30,6 +31,8 @@ export const createAutoInjectMiddleware = (webchat: Webchat): Middleware<unknown
 
         case 'TRIGGER_AUTO_INJECT': {
             const state = api.getState();
+            const config = state.config as IWebchatConfig;
+
             // Now is the time to handle the "auto-inject message" (if configured)
 
 
@@ -37,18 +40,22 @@ export const createAutoInjectMiddleware = (webchat: Webchat): Middleware<unknown
             api.dispatch(autoInjectHandled());
 
             // Don't send a message if "startBehavior" is not set to "injection"
-            if (state.config.settings.startBehavior !== 'injection') {
+            if (config.settings.startBehavior !== 'injection') {
                 break;
             }
 
-            // Don't send a message if an "engagement message" is in the message history
-            const isEmptyExceptEngagementMesage = state.messages
-                .filter(message => message.source !== 'engagement')
-                .length === 0;
-
-            if (!isEmptyExceptEngagementMesage) {
-                break;
+            // Don't trigger the auto inject message when the history is not empty
+            // except if explicitly set via enableAutoInjectWithHistory
+            if (!config.settings.enableInjectionWithoutEmptyHistory) {
+                const isEmptyExceptEngagementMesage = state.messages
+                    .filter(message => message.source !== 'engagement')
+                    .length === 0;
+    
+                if (!isEmptyExceptEngagementMesage) {
+                    break;
+                }
             }
+
 
             // We are going to send the auto-inject message, now!
             const text = state.config.settings.getStartedPayload;

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -1,100 +1,106 @@
 import { Reducer } from "redux";
-import { IWebchatConfig, IWebchatSettings } from "../../../common/interfaces/webchat-config";
+import {
+  IWebchatConfig,
+  IWebchatSettings,
+} from "../../../common/interfaces/webchat-config";
 
 export type ConfigState = IWebchatConfig;
 
 const getInitialState = (): ConfigState => ({
-    URLToken: '',
-    active: false,
-    settings: {
-        agentAvatarUrl: '',
-        backgroundImageUrl: '',
-        colorScheme: '',
-        designTemplate: 1,
-        disableBranding: false,
-        disableHtmlInput: false,
-        disableInputAutofocus: false,
-        disableLocalStorage: false,
-        disablePersistentHistory: false,
-        disableTextInputSanitization: false,
-        disableToggleButton: false,
-        dynamicImageAspectRatio: false,
-        enableConnectionStatusIndicator: true,
-        showEngagementMessagesInChat: false,
-        enableAutoFocus: false,
-        enableFileUpload: false,
-        enableFocusTrap: false,
-        enableGenericHTMLStyling: false,
-        enablePersistentMenu: false,
-        enableSTT: false,
-        enableStrictMessengerSync: false,
-        enableTTS: false,
-        enableTypingIndicator: false,
-        enableUnreadMessageBadge: false,
-        enableUnreadMessagePreview: false,
-        enableUnreadMessageSound: false,
-        enableUnreadMessageTitleIndicator: false,
-        engagementMessageText: '',
-        engagementMessageDelay: 5000,
-        getStartedButtonText: '',
-        getStartedPayload: '',
-        getStartedText: '',
-        headerLogoUrl: '',
-        ignoreLineBreaks: false,
-        inputPlaceholder: '',
-        messageDelay: 1000,
-        messageLogoUrl: '',
-        persistentMenu: {
-            title: '',
-            menuItems: []
-        },
-        startBehavior: 'none',
-        STTLanguage: '',
-        title: '',
-        unreadMessageTitleText: 'New Message',
-        unreadMessageTitleTextPlural: 'New Messages',
-        userAvatarUrl: '',
-        useSessionStorage: false
-    }
+  URLToken: "",
+  active: false,
+  settings: {
+    agentAvatarUrl: "",
+    backgroundImageUrl: "",
+    colorScheme: "",
+    designTemplate: 1,
+    disableBranding: false,
+    disableHtmlInput: false,
+    disableInputAutofocus: false,
+    disableLocalStorage: false,
+    disablePersistentHistory: false,
+    disableTextInputSanitization: false,
+    disableToggleButton: false,
+    dynamicImageAspectRatio: false,
+    enableConnectionStatusIndicator: true,
+    showEngagementMessagesInChat: false,
+    enableAutoFocus: false,
+    enableInjectionWithoutEmptyHistory: false,
+    enableFileUpload: false,
+    enableFocusTrap: false,
+    enableGenericHTMLStyling: false,
+    enablePersistentMenu: false,
+    enableSTT: false,
+    enableStrictMessengerSync: false,
+    enableTTS: false,
+    enableTypingIndicator: false,
+    enableUnreadMessageBadge: false,
+    enableUnreadMessagePreview: false,
+    enableUnreadMessageSound: false,
+    enableUnreadMessageTitleIndicator: false,
+    engagementMessageText: "",
+    engagementMessageDelay: 5000,
+    getStartedButtonText: "",
+    getStartedPayload: "",
+    getStartedText: "",
+    headerLogoUrl: "",
+    ignoreLineBreaks: false,
+    inputPlaceholder: "",
+    messageDelay: 1000,
+    messageLogoUrl: "",
+    persistentMenu: {
+      title: "",
+      menuItems: [],
+    },
+    startBehavior: "none",
+    STTLanguage: "",
+    title: "",
+    unreadMessageTitleText: "New Message",
+    unreadMessageTitleTextPlural: "New Messages",
+    userAvatarUrl: "",
+    useSessionStorage: false,
+  },
 });
 
-export const SET_CONFIG = 'SET_CONFIG';
+export const SET_CONFIG = "SET_CONFIG";
 export const setConfig = (config: ConfigState) => ({
-    type: SET_CONFIG as 'SET_CONFIG',
-    config
+  type: SET_CONFIG as "SET_CONFIG",
+  config,
 });
 export type SetConfigAction = ReturnType<typeof setConfig>;
 
-export const UPDATE_SETTINGS = 'UPDATE_SETTINGS';
+export const UPDATE_SETTINGS = "UPDATE_SETTINGS";
 export const updateSettings = (payload: Partial<IWebchatSettings>) => ({
-    type: UPDATE_SETTINGS as 'UPDATE_SETTINGS',
-    payload
+  type: UPDATE_SETTINGS as "UPDATE_SETTINGS",
+  payload,
 });
 export type UpdateSettingsAction = ReturnType<typeof updateSettings>;
 
-export const config: Reducer<ConfigState, SetConfigAction | UpdateSettingsAction> = (state = getInitialState(), action) => {
-
-    switch (action.type) {
-        case 'SET_CONFIG': {
-            return {
-                ...state,
-                ...action.config,
-                settings: {
-                    ...state.settings,
-                    ...action.config.settings
-                }
-            }
-        }
-        case 'UPDATE_SETTINGS': {
-            return {
-                ...state,
-                settings: {
-                    ...state.settings,
-                    ...action.payload
-                }
-            }
-        }
+export const config: Reducer<
+  ConfigState,
+  SetConfigAction | UpdateSettingsAction
+> = (state = getInitialState(), action) => {
+  switch (action.type) {
+    case "SET_CONFIG": {
+      return {
+        ...state,
+        ...action.config,
+        settings: {
+          ...state.settings,
+          ...action.config.settings,
+        },
+      };
     }
+    case "UPDATE_SETTINGS": {
+      return {
+        ...state,
+        settings: {
+          ...state.settings,
+          ...action.payload,
+        },
+      };
+    }
+  }
 
-    return state;
-}
+  return state;
+};


### PR DESCRIPTION
This PR adds a flag to re-create a behavior we changed in a bugfix.
If the customer sets `enableInjectionWithoutEmptyHistory`, a non-empty history should not prevent the auto-injection message from being triggered.