### PR TITLE
bug/14208 added time format fix for en-GB date-picker locale

### DIFF
--- a/src/plugins/date-picker/index.tsx
+++ b/src/plugins/date-picker/index.tsx
@@ -160,6 +160,13 @@ const datePickerPlugin: MessagePluginFactory = ({ styled }) => {
       if (this.state.msg.length > 0) {
         if (message.source === 'bot')
           processedMessages.add(message.traceId);
+
+        /*
+          Flatpickr doesn't support a locale called en-GB so we added it to ensure that users with this locale can use it as well
+          As the unmodified message looks like this: "31/12/2021" we need to exchange month and day converting it to "12/31/2021"
+          This way Flatpickr can work with these values the way they would be sent from the "en" locale
+        */
+
         if(message.data._plugin.data.locale === 'en-GB')
         {
           const gbMessage = this.state.msg.substring(3,6).concat(this.state.msg.substring(0,3),this.state.msg.substring(6))

--- a/src/plugins/date-picker/index.tsx
+++ b/src/plugins/date-picker/index.tsx
@@ -29,6 +29,7 @@ const getFlatpickrLocaleId = (locale: string) => {
     case 'gb':
     case 'au':
     case 'ca':
+    case 'en-GB':
       return 'en';
   }
 
@@ -36,9 +37,9 @@ const getFlatpickrLocaleId = (locale: string) => {
 }
 
 /**
- * Transforms regional locales to flatpicks internal locale key
+ * Transforms regional locales to moments internal locale key
  */
-const getMomemtLocaleId = (locale: string) => {
+const getMomentLocaleId = (locale: string) => {
   switch (locale) {
     case 'au':
       return 'en-au';
@@ -154,12 +155,16 @@ const datePickerPlugin: MessagePluginFactory = ({ styled }) => {
 
     handleSubmit = () => {
       const { message } = this.props
-
+      
       // close plugin if user didn't choose a date
       if (this.state.msg.length > 0) {
         if (message.source === 'bot')
           processedMessages.add(message.traceId);
-
+        if(message.data._plugin.data.locale === 'en-GB')
+        {
+          const gbMessage = this.state.msg.substring(3,6).concat(this.state.msg.substring(0,3),this.state.msg.substring(6))
+          this.setState({msg:gbMessage})
+        }
         setTimeout(() => {
           this.props.onSendMessage(this.state.msg), {
             _plugin: "date-picker",
@@ -216,7 +221,7 @@ const datePickerPlugin: MessagePluginFactory = ({ styled }) => {
         || undefined;
 
       const localeId = data.locale || 'us';
-      const momentLocaleId = getMomemtLocaleId(localeId);
+      const momentLocaleId = getMomentLocaleId(localeId);
       const flatpickrLocaleId = getFlatpickrLocaleId(localeId);
       let locale = l10n[flatpickrLocaleId];
       const enableTime = !!data.enableTime;


### PR DESCRIPTION
Description:

Flatpickr doesn't support the en-GB locale therefore this fix is needed to get sure that month and day get switched for this locale. I also fixed some typos.

Success criteria:

- The locale en-GB can be handled by the date-picker plugin. This locale will be available in version 4.4.0+

How to test (steps):

1. Get the newest release from 4.4.0+ or the bug branch 14208
2. Create a question node with a date input
3. Set the locale to en-gb
4. Create a say node with the following text: {{ci.slots.DATE[0].start.month}} right behind
5. If successful the say node should reply with the proper month number

Additional considerations (describe):

- [ ] This PR impacts NLU
- [ ] This PR might have performance implications
- [ ] This PR changes an existing data model (and might affect existing legacy data)
  - Examples: adding, renaming, removing a field or changing the format or constraints of a field

Security implications (describe):

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications