### PR TITLE
Feature/11814 open a url in the existing tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 dist/*.js
 dist/*.zip
 dist/*.webmanifest
+dist/index.html
 
 cypress/screenshots
 cypress/videos

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
@@ -37,7 +37,8 @@ export const getMessengerButton = ({ React, styled }: MessagePluginFactoryProps)
         const buttonType = button.type;
         const isWebURL = buttonType === "web_url";
         const buttonTitle = button.title ? button.title + ". " : "";
-        const ariaLabel = isWebURL ? buttonTitle + "Opens in new tab" : undefined;
+        const isWebURLButtonTargetBlank = button.target !== "_self";
+        const ariaLabel = isWebURL && isWebURLButtonTargetBlank ? buttonTitle + "Opens in new tab" : undefined;
 
         return (
             <Button 

--- a/src/plugins/messenger/MessengerPreview/interfaces/Action.interface.ts
+++ b/src/plugins/messenger/MessengerPreview/interfaces/Action.interface.ts
@@ -3,4 +3,5 @@ export interface IFBMDefaultAction {
     url: string;
     messenger_extensions: boolean;
     webview_height_ratio: 'compact' | 'tall' | 'full';
+    target?: '_self' | '_blank'
 }

--- a/src/plugins/messenger/MessengerPreview/interfaces/Button.interface.ts
+++ b/src/plugins/messenger/MessengerPreview/interfaces/Button.interface.ts
@@ -9,6 +9,7 @@ export interface IFBMURLButton {
     type: 'web_url';
     url: string;
     title: string;
+    target?: '_self' | '_blank';
 }
 
 export interface IFBMPostbackButton {

--- a/src/plugins/messenger/index.tsx
+++ b/src/plugins/messenger/index.tsx
@@ -80,7 +80,9 @@ const messengerPlugin: MessagePluginFactory = ({ React, styled }) => {
                     // @ts-ignore
                     if (action.type === 'web_url' && action.url) {
                         // @ts-ignore
-                        window.open(action.url, '_blank');
+                        const target = action.target === "_self" ? "_self" : "_blank";
+                        // @ts-ignore
+                        window.open(action.url, target);
                     }
                 }}
                 config={config}
@@ -114,7 +116,9 @@ const fullscreenMessengerGenericPlugin: MessagePluginFactory = ({ React, styled 
                     // @ts-ignore
                     if (action.type === 'web_url') {
                         // @ts-ignore
-                        window.open(action.url, '_blank');
+                        const target = action.target === "_self" ? "_self" : "_blank";
+                        // @ts-ignore
+                        window.open(action.url, target);
                     }
                 }}
                 config={config}

--- a/src/plugins/messenger/index.tsx
+++ b/src/plugins/messenger/index.tsx
@@ -80,9 +80,7 @@ const messengerPlugin: MessagePluginFactory = ({ React, styled }) => {
                     // @ts-ignore
                     if (action.type === 'web_url' && action.url) {
                         // @ts-ignore
-                        const target = action.target === "_self" ? "_self" : "_blank";
-                        // @ts-ignore
-                        window.open(action.url, target);
+                        window.open(action.url, action.target === "_self" ? "_self" : "_blank");
                     }
                 }}
                 config={config}
@@ -116,9 +114,7 @@ const fullscreenMessengerGenericPlugin: MessagePluginFactory = ({ React, styled 
                     // @ts-ignore
                     if (action.type === 'web_url') {
                         // @ts-ignore
-                        const target = action.target === "_self" ? "_self" : "_blank";
-                        // @ts-ignore
-                        window.open(action.url, target);
+                        window.open(action.url, action.target === "_self" ? "_self" : "_blank");
                     }
                 }}
                 config={config}


### PR DESCRIPTION
Description:

This PR enables the Webchat Widget to open URLs from buttons, galleries and lists in the same tab using the "target" property that can be applied in Cognigy AI version 4.4.0+

Success criteria:

- The URL opens in the same tab

How to test (steps):

1. Create a say node with a button with target self
2. Click the button, it should open in the same tab
3. Create a say node with a button with no target defined
4. Click the button, it should open in a new tab
5. Test this behaviour in galleries with buttons and lists with a button

Additional considerations (describe):

- [ ] This PR impacts NLU
- [ ] This PR might have performance implications
- [ ] This PR changes an existing data model (and might affect existing legacy data)
  - Examples: adding, renaming, removing a field or changing the format or constraints of a field

Security implications (describe):

- [ ] Possible injection vector
- [ ] Authentication/Access controls touched
- [ ] Sensitive Data could be exposed
- [ ] XSS
- [ ] Logging/Monitoring touched
- [ ] Exchanges data with external systems
- [x] No security implications