### PR TITLE
bug/15533-Newlines-in-Content

### DIFF
--- a/src/webchat-ui/components/presentational/MarkdownMessageBubble.tsx
+++ b/src/webchat-ui/components/presentational/MarkdownMessageBubble.tsx
@@ -36,7 +36,7 @@ export const MarkdownMessageBubble = styled(MessageBubble)((props) => {
     'ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", monospace';
 
   return `
-    white-space: initial;
+    white-space: pre-wrap;
     color: ${textColor};
   
     th, 


### PR DESCRIPTION
Fixed whitespace for multiline text with wrap

This solves: Issue that say nodes with multiline text were displayed in one line

How to test: Create a flow with a say node with multiple lines of code and view it using the modified webchat. Multiline Text should be displayed in several lines