### PR TITLE
fix rating dialog position for old browsers

### DIFF
--- a/src/webchat-ui/components/presentational/RatingDialog.tsx
+++ b/src/webchat-ui/components/presentational/RatingDialog.tsx
@@ -12,6 +12,8 @@ const Wrapper = styled.div({
     height: "100%",
     width: "100%",
     position: "absolute",
+    left: 0,
+    top: 0,
     display: "flex",
     justifyContent: "center",
     alignItems: "center",


### PR DESCRIPTION
dialog position in IE11 was messed up, fixed by adding top: 0 and left: 0 for the absolute positioning