### PR TITLE
Feature/16798 trigger rating from flow

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -73,8 +73,8 @@ export interface WebchatUIProps {
     showRatingDialog: boolean;
     onShowRatingDialog: (show: boolean) => void;
     onSetHasGivenRating: () => void;
-	customRatingTitle: string;
-	customRatingCommentText: string;
+    customRatingTitle: string;
+    customRatingCommentText: string;
 }
 
 interface WebchatUIState {
@@ -455,8 +455,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             showRatingDialog,
             onShowRatingDialog,
             onSetHasGivenRating,
-			customRatingTitle,
-			customRatingCommentText,
+            customRatingTitle,
+            customRatingCommentText,
             ...restProps
         } = props;
         const { theme, hadConnection, lastUnseenMessageText } = state;
@@ -509,8 +509,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                                             <RatingDialog
                                                 onCloseRatingDialog={() => onShowRatingDialog(false)}
                                                 onSendRating={this.handleSendRating}
-												ratingTitleText={customRatingTitle || ratingTitleText}
-												ratingCommentText={customRatingCommentText || ratingCommentText}
+                                                ratingTitleText={customRatingTitle || ratingTitleText}
+                                                ratingCommentText={customRatingCommentText || ratingCommentText}
                                             />
                                         }
                                         {showDisconnectOverlay && <DisconnectOverlay onConnect={onConnect} isPermanent={!!reconnectionLimit} onClose={onClose} />}

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -73,6 +73,8 @@ export interface WebchatUIProps {
     showRatingDialog: boolean;
     onShowRatingDialog: (show: boolean) => void;
     onSetHasGivenRating: () => void;
+	customRatingTitle: string;
+	customRatingCommentText: string;
 }
 
 interface WebchatUIState {
@@ -453,6 +455,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             showRatingDialog,
             onShowRatingDialog,
             onSetHasGivenRating,
+			customRatingTitle,
+			customRatingCommentText,
             ...restProps
         } = props;
         const { theme, hadConnection, lastUnseenMessageText } = state;
@@ -505,8 +509,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                                             <RatingDialog
                                                 onCloseRatingDialog={() => onShowRatingDialog(false)}
                                                 onSendRating={this.handleSendRating}
-                                                ratingTitleText={ratingTitleText}
-                                                ratingCommentText={ratingCommentText}
+												ratingTitleText={customRatingTitle || ratingTitleText}
+												ratingCommentText={customRatingCommentText || ratingCommentText}
                                             />
                                         }
                                         {showDisconnectOverlay && <DisconnectOverlay onConnect={onConnect} isPermanent={!!reconnectionLimit} onClose={onClose} />}

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -19,7 +19,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         connection: { connected, reconnectionLimit },
         ui: { open, typing, inputMode, fullscreenMessage },
         config,
-        rating: { showRatingDialog, hasGivenRating },
+		rating: { showRatingDialog, hasGivenRating, customRatingTitle, customRatingCommentText },
     }) => ({
         messages,
         unseenMessages,
@@ -32,6 +32,8 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         reconnectionLimit,
         showRatingDialog,
         hasGivenRating,
+		customRatingTitle,
+		customRatingCommentText,
     }),
     dispatch => ({
         onSendMessage: (text, data, options) => dispatch(sendMessage({ text, data }, options)),

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -19,7 +19,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         connection: { connected, reconnectionLimit },
         ui: { open, typing, inputMode, fullscreenMessage },
         config,
-		rating: { showRatingDialog, hasGivenRating, customRatingTitle, customRatingCommentText },
+        rating: { showRatingDialog, hasGivenRating, customRatingTitle, customRatingCommentText },
     }) => ({
         messages,
         unseenMessages,
@@ -32,8 +32,8 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         reconnectionLimit,
         showRatingDialog,
         hasGivenRating,
-		customRatingTitle,
-		customRatingCommentText,
+        customRatingTitle,
+        customRatingCommentText,
     }),
     dispatch => ({
         onSendMessage: (text, data, options) => dispatch(sendMessage({ text, data }, options)),

--- a/src/webchat/store/messages/message-handler.ts
+++ b/src/webchat/store/messages/message-handler.ts
@@ -2,8 +2,8 @@ import { Store } from "redux";
 import { IMessage } from "../../../common/interfaces/message";
 import { ISendMessageOptions } from "./message-middleware";
 import { setBotAvatarOverrideUrl, setUserAvatarOverrideUrl, setAgentAvatarOverrideUrl, setTyping } from "../ui/ui-reducer";
+import { setCustomRatingCommentText, setCustomRatingTitle, showRatingDialog } from "../rating/rating-reducer";
 import { SocketClient } from "@cognigy/socket-client";
-import { showRatingDialog } from "../rating/rating-reducer";
 
 const RECEIVE_MESSAGE = 'RECEIVE_MESSAGE';
 export const receiveMessage = (message: IMessage, options: Partial<ISendMessageOptions> = {}) => ({
@@ -34,9 +34,16 @@ export const registerMessageHandler = (store: Store, client: SocketClient) => {
 
 		// handle custom plugin actions
 		if (output.data && output.data._plugin) {
-			const { type } = output.data._plugin;
+			const { type, data } = output.data._plugin;
 
 			if (type === "request-rating") {
+				if (data && data.ratingCommentText) {
+					store.dispatch(setCustomRatingCommentText(data.ratingCommentText));
+				};
+				if (data && data.ratingTitleText) {
+					store.dispatch(setCustomRatingTitle(data.ratingTitleText));
+				};
+
 				store.dispatch(showRatingDialog(true));
 			};
 		}

--- a/src/webchat/store/messages/message-handler.ts
+++ b/src/webchat/store/messages/message-handler.ts
@@ -3,6 +3,7 @@ import { IMessage } from "../../../common/interfaces/message";
 import { ISendMessageOptions } from "./message-middleware";
 import { setBotAvatarOverrideUrl, setUserAvatarOverrideUrl, setAgentAvatarOverrideUrl, setTyping } from "../ui/ui-reducer";
 import { SocketClient } from "@cognigy/socket-client";
+import { showRatingDialog } from "../rating/rating-reducer";
 
 const RECEIVE_MESSAGE = 'RECEIVE_MESSAGE';
 export const receiveMessage = (message: IMessage, options: Partial<ISendMessageOptions> = {}) => ({
@@ -30,6 +31,15 @@ export const registerMessageHandler = (store: Store, client: SocketClient) => {
                 store.dispatch(setUserAvatarOverrideUrl(userAvatarOverrideUrl))
             }
         }
+
+		// handle custom plugin actions
+		if (output.data && output.data._plugin) {
+			const { type } = output.data._plugin;
+
+			if (type === "request-rating") {
+				store.dispatch(showRatingDialog(true));
+			};
+		}
 
         store.dispatch(setTyping("remove"));
         store.dispatch(receiveMessage(output));

--- a/src/webchat/store/messages/message-handler.ts
+++ b/src/webchat/store/messages/message-handler.ts
@@ -26,27 +26,27 @@ export const registerMessageHandler = (store: Store, client: SocketClient) => {
             if (botAvatarOverrideUrl !== undefined) {
                 store.dispatch(setBotAvatarOverrideUrl(botAvatarOverrideUrl));
             }
-            
+
             if (userAvatarOverrideUrl !== undefined) {
                 store.dispatch(setUserAvatarOverrideUrl(userAvatarOverrideUrl))
             }
         }
 
-		// handle custom plugin actions
-		if (output.data && output.data._plugin) {
-			const { type, data } = output.data._plugin;
+        // handle custom plugin actions
+        if (output.data && output.data._plugin) {
+            const { type, data } = output.data._plugin;
 
-			if (type === "request-rating") {
-				if (data && data.ratingCommentText) {
-					store.dispatch(setCustomRatingCommentText(data.ratingCommentText));
-				};
-				if (data && data.ratingTitleText) {
-					store.dispatch(setCustomRatingTitle(data.ratingTitleText));
-				};
+            if (type === "request-rating") {
+                if (data && data.ratingCommentText) {
+                    store.dispatch(setCustomRatingCommentText(data.ratingCommentText));
+                };
+                if (data && data.ratingTitleText) {
+                    store.dispatch(setCustomRatingTitle(data.ratingTitleText));
+                };
 
-				store.dispatch(showRatingDialog(true));
-			};
-		}
+                store.dispatch(showRatingDialog(true));
+            };
+        }
 
         store.dispatch(setTyping("remove"));
         store.dispatch(receiveMessage(output));

--- a/src/webchat/store/rating/rating-reducer.ts
+++ b/src/webchat/store/rating/rating-reducer.ts
@@ -1,95 +1,95 @@
 import { Reducer } from "redux";
 
 export interface RatingState {
-	hasGivenRating: boolean;
-	showRatingDialog: boolean;
-	customRatingTitle: string;
-	customRatingCommentText: string;
+    hasGivenRating: boolean;
+    showRatingDialog: boolean;
+    customRatingTitle: string;
+    customRatingCommentText: string;
 }
 
 const SHOW_RATING_DIALOG = "SHOW_RATING_DIALOG";
 export const showRatingDialog = (show: boolean) => ({
-	type: SHOW_RATING_DIALOG as "SHOW_RATING_DIALOG",
-	show
+    type: SHOW_RATING_DIALOG as "SHOW_RATING_DIALOG",
+    show
 });
 type ShowRatingDialogAction = ReturnType<typeof showRatingDialog>;
 
 const SET_HAS_GIVEN_RATING = "SET_HAS_GIVEN_RATING";
 export const setHasGivenRating = () => ({
-	type: SET_HAS_GIVEN_RATING as "SET_HAS_GIVEN_RATING",
+    type: SET_HAS_GIVEN_RATING as "SET_HAS_GIVEN_RATING",
 });
 type SetHasGivenRating = ReturnType<typeof setHasGivenRating>;
 
 const SET_CUSTOM_RATING_TITLE = "SET_CUSTOM_RATING_TITLE";
 export const setCustomRatingTitle = (text: string) => ({
-	type: SET_CUSTOM_RATING_TITLE as "SET_CUSTOM_RATING_TITLE",
-	text,
+    type: SET_CUSTOM_RATING_TITLE as "SET_CUSTOM_RATING_TITLE",
+    text,
 });
 type SetCustomRatingTitle = ReturnType<typeof setCustomRatingTitle>;
 
 const SET_CUSTOM_RATING_COMMENT_TEXT = "SET_CUSTOM_RATING_COMMENT_TEXT";
 export const setCustomRatingCommentText = (text: string) => ({
-	type: SET_CUSTOM_RATING_COMMENT_TEXT as "SET_CUSTOM_RATING_COMMENT_TEXT",
-	text,
+    type: SET_CUSTOM_RATING_COMMENT_TEXT as "SET_CUSTOM_RATING_COMMENT_TEXT",
+    text,
 });
 type SetCustomRatingCommentText = ReturnType<typeof setCustomRatingCommentText>;
 
 const getInitialState = (): RatingState => ({
-	hasGivenRating: false,
-	showRatingDialog: false,
-	customRatingTitle: "",
-	customRatingCommentText: "",
+    hasGivenRating: false,
+    showRatingDialog: false,
+    customRatingTitle: "",
+    customRatingCommentText: "",
 });
 
 type RatingAction = ShowRatingDialogAction
-	| SetHasGivenRating
-	| SetCustomRatingTitle
-	| SetCustomRatingCommentText;
+    | SetHasGivenRating
+    | SetCustomRatingTitle
+    | SetCustomRatingCommentText;
 
 
 export const rating: Reducer<RatingState, RatingAction> = (state = getInitialState(), action) => {
-	switch (action.type) {
-		case SHOW_RATING_DIALOG: {
+    switch (action.type) {
+        case SHOW_RATING_DIALOG: {
 
-			// reset custom texts when the rating dialog is closed
-			if (action.show === false) {
-				return {
-					...state,
-					showRatingDialog: action.show,
-					customRatingTitle: "",
-					customRatingCommentText: "",
-				}
+            // reset custom texts when the rating dialog is closed
+            if (action.show === false) {
+                return {
+                    ...state,
+                    showRatingDialog: action.show,
+                    customRatingTitle: "",
+                    customRatingCommentText: "",
+                }
 
-			} else {
-				return {
-					...state,
-					showRatingDialog: action.show
-				}
-			}
+            } else {
+                return {
+                    ...state,
+                    showRatingDialog: action.show
+                }
+            }
 
-		}
+        }
 
-		case SET_HAS_GIVEN_RATING: {
-			return {
-				...state,
-				hasGivenRating: true,
-			}
-		}
+        case SET_HAS_GIVEN_RATING: {
+            return {
+                ...state,
+                hasGivenRating: true,
+            }
+        }
 
-		case SET_CUSTOM_RATING_TITLE: {
-			return {
-				...state,
-				customRatingTitle: action.text,
-			}
-		}
+        case SET_CUSTOM_RATING_TITLE: {
+            return {
+                ...state,
+                customRatingTitle: action.text,
+            }
+        }
 
-		case SET_CUSTOM_RATING_COMMENT_TEXT: {
-			return {
-				...state,
-				customRatingCommentText: action.text,
-			}
-		}
-	}
+        case SET_CUSTOM_RATING_COMMENT_TEXT: {
+            return {
+                ...state,
+                customRatingCommentText: action.text,
+            }
+        }
+    }
 
-	return state;
+    return state;
 }

--- a/src/webchat/store/rating/rating-reducer.ts
+++ b/src/webchat/store/rating/rating-reducer.ts
@@ -3,6 +3,8 @@ import { Reducer } from "redux";
 export interface RatingState {
 	hasGivenRating: boolean;
 	showRatingDialog: boolean;
+	customRatingTitle: string;
+	customRatingCommentText: string;
 }
 
 const SHOW_RATING_DIALOG = "SHOW_RATING_DIALOG";
@@ -18,28 +20,73 @@ export const setHasGivenRating = () => ({
 });
 type SetHasGivenRating = ReturnType<typeof setHasGivenRating>;
 
+const SET_CUSTOM_RATING_TITLE = "SET_CUSTOM_RATING_TITLE";
+export const setCustomRatingTitle = (text: string) => ({
+	type: SET_CUSTOM_RATING_TITLE as "SET_CUSTOM_RATING_TITLE",
+	text,
+});
+type SetCustomRatingTitle = ReturnType<typeof setCustomRatingTitle>;
+
+const SET_CUSTOM_RATING_COMMENT_TEXT = "SET_CUSTOM_RATING_COMMENT_TEXT";
+export const setCustomRatingCommentText = (text: string) => ({
+	type: SET_CUSTOM_RATING_COMMENT_TEXT as "SET_CUSTOM_RATING_COMMENT_TEXT",
+	text,
+});
+type SetCustomRatingCommentText = ReturnType<typeof setCustomRatingCommentText>;
+
 const getInitialState = (): RatingState => ({
 	hasGivenRating: false,
 	showRatingDialog: false,
+	customRatingTitle: "",
+	customRatingCommentText: "",
 });
 
 type RatingAction = ShowRatingDialogAction
-	| SetHasGivenRating;
+	| SetHasGivenRating
+	| SetCustomRatingTitle
+	| SetCustomRatingCommentText;
 
 
 export const rating: Reducer<RatingState, RatingAction> = (state = getInitialState(), action) => {
 	switch (action.type) {
 		case SHOW_RATING_DIALOG: {
-			return {
-				...state,
-				showRatingDialog: action.show
+
+			// reset custom texts when the rating dialog is closed
+			if (action.show === false) {
+				return {
+					...state,
+					showRatingDialog: action.show,
+					customRatingTitle: "",
+					customRatingCommentText: "",
+				}
+
+			} else {
+				return {
+					...state,
+					showRatingDialog: action.show
+				}
 			}
+
 		}
 
 		case SET_HAS_GIVEN_RATING: {
 			return {
 				...state,
 				hasGivenRating: true,
+			}
+		}
+
+		case SET_CUSTOM_RATING_TITLE: {
+			return {
+				...state,
+				customRatingTitle: action.text,
+			}
+		}
+
+		case SET_CUSTOM_RATING_COMMENT_TEXT: {
+			return {
+				...state,
+				customRatingCommentText: action.text,
 			}
 		}
 	}


### PR DESCRIPTION
Added the possibility to receive a data message that will open the rating dialog. Supports optional custom title and comment texts for each rating  (configurable in the "Request Rating"-node in the related cognigy ui pr).