### PR TITLE
added "disableInputAutocomplete" flag

### DIFF
--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -11,6 +11,7 @@ export interface IWebchatSettings {
   disableBranding: boolean;
   disableHtmlContentSanitization: boolean;
   disableHtmlInput: boolean;
+  disableInputAutocomplete: boolean;
   disableInputAutofocus: boolean;
   disableLocalStorage: boolean;
   disablePersistentHistory: boolean;

--- a/src/webchat-ui/components/plugins/input/text/TextInput.tsx
+++ b/src/webchat-ui/components/plugins/input/text/TextInput.tsx
@@ -236,6 +236,7 @@ export class TextInput extends React.PureComponent<InputComponentProps, TextInpu
         const { props, state } = this;
         const { text, active, mode } = state;
         const {
+            disableInputAutocomplete,
             disableInputAutofocus,
             enablePersistentMenu,
             persistentMenu,
@@ -274,6 +275,7 @@ export class TextInput extends React.PureComponent<InputComponentProps, TextInpu
                             placeholder={props.config.settings.inputPlaceholder}
                             className="webchat-input-message-input"
                             aria-label="Message to send"
+                            autoComplete={disableInputAutocomplete ? 'off' : undefined}
                             id="webchatInputMessageInputInTextMode"
                         />
                         <SubmitButton disabled={this.state.text === ''} className="webchat-input-button-send" aria-label="Send Message">

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -17,6 +17,7 @@ const getInitialState = (): ConfigState => ({
     disableBranding: false,
     disableHtmlContentSanitization: false,
     disableHtmlInput: false,
+    disableInputAutocomplete: false,
     disableInputAutofocus: false,
     disableLocalStorage: false,
     disablePersistentHistory: false,


### PR DESCRIPTION
This PR lets you disable the "autosuggest" feature from the regular text input field following bug reports that Samsung phone keyboards tend to display the autosuggestion options above the software keyboard leading to errors.