### PR TITLE
Set up automatic browser compatibility testing via Github Actions > BrowserStack Automate > Selenium Webdriver

### DIFF
--- a/.github/workflows/bstack.yml
+++ b/.github/workflows/bstack.yml
@@ -1,0 +1,49 @@
+name: BrowserStack compatibility test
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  browser-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.8]
+    
+    steps:
+    # Set up browserstack env variables
+    - name: 'BrowserStack Env Setup'
+      uses: 'browserstack/github-actions/setup-env@v1.0.1'
+      with:
+        username:  ${{ secrets.BROWSERSTACK_USERNAME }}
+        access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+        build-name: BUILD_INFO
+        project-name: REPO_NAME
+        
+    # Set up local tunnel to browserstack
+    - name: 'BrowserStackLocal Setup'
+      uses: 'browserstack/github-actions/setup-local@v1.0.1'
+      with:
+        local-testing: start
+        local-identifier: random
+        local-logging-level: 'all-logs'
+        
+    - name: 'Checkout Repository'
+      uses: actions/checkout@v2
+    
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: 'Install dependencies'
+      run: npm ci
+      
+    - name: 'Run test on BrowserStack'
+      run: npm run browserstack-test
+
+      # Stops BrowserStack Tunnel
+    - name: 'BrowserStackLocal Stop'
+      uses: 'browserstack/github-actions/setup-local@v1.0.1'
+      with:
+        local-testing: stop

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-    "baseUrl": "http://localhost:8787/?test=true",
+    "baseUrl": "http://localhost:8888/?test=true",
     "video": false,
     "experimentalNetworkStubbing": true,
     "chromeWebSecurity": false

--- a/dist/index.html
+++ b/dist/index.html
@@ -6,8 +6,8 @@
 </head>
 
 <body>
-    <script src="./webchat.js"></script>
-    <script src="./date-picker.webchat-plugin.js"></script>
+    <script src="./webchat.legacy.js"></script>
+    <script src="./date-picker.webchat-plugin.legacy.js"></script>
     <script>
         var isTesting = window.location.search.indexOf('test') > -1;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "uifx": "^2.0.7"
       },
       "devDependencies": {
+        "@actions/core": "^1.5.0",
         "@babel/cli": "^7.7.0",
         "@babel/core": "^7.7.2",
         "@babel/plugin-proposal-class-properties": "^7.7.0",
@@ -64,6 +65,7 @@
         "npm-run-all": "^4.1.5",
         "react-svg-loader": "^3.0.3",
         "redux-devtools-extension": "^2.13.8",
+        "selenium-webdriver": "^4.0.0-rc-1",
         "style-loader": "^0.23.1",
         "svg-inline-loader": "^0.8.0",
         "svg-react-loader": "^0.4.6",
@@ -76,6 +78,24 @@
         "webpack-cli": "^3.3.10",
         "webpack-dev-server": "^3.9.0",
         "whatwg-fetch": "^3.0.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "dev": true,
+      "dependencies": {
+        "@actions/http-client": "^1.0.11"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "dev": true,
+      "dependencies": {
+        "tunnel": "0.0.6"
       }
     },
     "node_modules/@babel/cli": {
@@ -7391,6 +7411,12 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
+    },
     "node_modules/immutable": {
       "version": "4.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
@@ -8228,6 +8254,18 @@
         "jss": "^9.0.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "dev": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
     "node_modules/killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -8262,6 +8300,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -10896,6 +10943,36 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
+    "node_modules/selenium-webdriver": {
+      "version": "4.0.0-rc-2",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-rc-2.tgz",
+      "integrity": "sha512-HT974l00r7wdZL+SPS0f8lBLVYe/aKGAFONMvVroL7z9mHm3PC30IirsYqrvSkw51Pom3XJiN5gjXBRkxuHAdw==",
+      "dev": true,
+      "dependencies": {
+        "jszip": "^3.6.0",
+        "rimraf": "^3.0.2",
+        "tmp": "^0.2.1",
+        "ws": ">=7.4.6"
+      },
+      "engines": {
+        "node": ">= 10.15.0"
+      }
+    },
+    "node_modules/selenium-webdriver/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/selfsigned": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
@@ -11033,6 +11110,15 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "node_modules/set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -12267,6 +12353,15 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -13522,6 +13617,24 @@
     }
   },
   "dependencies": {
+    "@actions/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "dev": true,
+      "requires": {
+        "@actions/http-client": "^1.0.11"
+      }
+    },
+    "@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "dev": true,
+      "requires": {
+        "tunnel": "0.0.6"
+      }
+    },
     "@babel/cli": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.7.0.tgz",
@@ -19813,6 +19926,12 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
+    },
     "immutable": {
       "version": "4.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
@@ -20459,6 +20578,18 @@
         "css-vendor": "^0.3.8"
       }
     },
+    "jszip": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "dev": true,
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -20484,6 +20615,15 @@
       "dev": true,
       "requires": {
         "invert-kv": "^2.0.0"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "lines-and-columns": {
@@ -22619,6 +22759,29 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
+    "selenium-webdriver": {
+      "version": "4.0.0-rc-2",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-rc-2.tgz",
+      "integrity": "sha512-HT974l00r7wdZL+SPS0f8lBLVYe/aKGAFONMvVroL7z9mHm3PC30IirsYqrvSkw51Pom3XJiN5gjXBRkxuHAdw==",
+      "dev": true,
+      "requires": {
+        "jszip": "^3.6.0",
+        "rimraf": "^3.0.2",
+        "tmp": "^0.2.1",
+        "ws": ">=7.4.6"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "selfsigned": {
       "version": "1.10.7",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
@@ -22746,6 +22909,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "set-value": {
@@ -23783,6 +23952,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -24,11 +24,15 @@
     "speech-output": "webpack --config webpack.production-plugin.js --entry ./src/plugins/speech-output/index.tsx --output dist/speech-output.webchat-plugin.js",
     "webchat-legacy": "webpack --config webpack.production.legacy.js --output dist/webchat.legacy.js",
     "webchat": "webpack --config webpack.production.js",
+    "http-server": "http-server -a localhost -p 8888 dist/",
     "cypress:open": "cypress open",
-    "cypress:serve": "http-server -a localhost -p 8787 dist/",
+    "cypress:serve": "npm run http-server",
     "cypress:run": "cypress run",
     "test": "run-p -r cypress:serve cypress:run",
-    "pretest": "npm run webchat && npm run date-picker"
+    "pretest": "npm run webchat-legacy && npm run date-picker-legacy",
+    "selenium-test": "node selenium-test.js",
+    "browserstack-test": "run-p -r http-server selenium-test",
+    "prebrowserstack-test": "npm run pretest"
   },
   "dependencies": {
     "@braintree/sanitize-url": "^5.0.2",
@@ -57,6 +61,7 @@
     "uifx": "^2.0.7"
   },
   "devDependencies": {
+    "@actions/core": "^1.5.0",
     "@babel/cli": "^7.7.0",
     "@babel/core": "^7.7.2",
     "@babel/plugin-proposal-class-properties": "^7.7.0",
@@ -86,6 +91,7 @@
     "npm-run-all": "^4.1.5",
     "react-svg-loader": "^3.0.3",
     "redux-devtools-extension": "^2.13.8",
+    "selenium-webdriver": "^4.0.0-rc-1",
     "style-loader": "^0.23.1",
     "svg-inline-loader": "^0.8.0",
     "svg-react-loader": "^0.4.6",

--- a/selenium-test.js
+++ b/selenium-test.js
@@ -1,0 +1,119 @@
+const webdriver = require('selenium-webdriver');
+const core = require('@actions/core');
+
+// HTTP Server should be running on 8888 port of GitHub runner
+async function runTestWithCaps(capabilities) {
+	let driver = new webdriver.Builder()
+		.usingServer('http://hub-cloud.browserstack.com/wd/hub')
+		.withCapabilities(capabilities)
+		.build();
+
+	try {
+		await driver.manage().setTimeouts({ implicit: 30000 });
+		await driver.get("http://127.0.0.1:8888");
+
+		const webchatToggle = await driver.findElement(webdriver.By.className("webchat-toggle-button"));
+		await driver.wait(webdriver.until.elementIsVisible(webchatToggle));
+		await webchatToggle.click();
+
+		const getStartedButton = await driver.findElement(webdriver.By.id("webchatGetStartedButton"));
+		await driver.wait(webdriver.until.elementIsVisible(getStartedButton));
+		await getStartedButton.click();
+
+		await driver.sleep(5000);
+
+		const chatInput = await driver.findElement(webdriver.By.id("webchatInputMessageInputInTextMode"));
+		await chatInput.sendKeys("browser test");
+		await chatInput.sendKeys(webdriver.Key.ENTER);
+
+		const sentMessage = await driver.wait(webdriver.until.elementLocated(webdriver.By.className("webchat-message-row user")), 15000);
+		await driver.wait(webdriver.until.elementTextIs(sentMessage, "browser test"), 15000);
+
+		await driver.executeScript(
+			'browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"passed","reason": "Message sent!"}}'
+		);
+
+	} catch (e) {
+		console.log(e);
+		core.setFailed(`Action failed with error ${e}`);
+		await driver.executeScript(
+			'browserstack_executor: {"action": "setSessionStatus", "arguments": {"status":"failed","reason": "Message send failed."}}'
+		);
+	}
+
+	await driver.quit();
+}
+
+// Input capabilities 
+// Chrome win 10
+const capabilitiesChrome = {
+	'os': 'windows',
+	'os_version': '10',
+	'resolution': '1920x1080',
+	'browserName': 'Chrome',
+	'browser_version': 'latest',
+	'browserstack.local': 'true',
+	"browserstack.idleTimeout": 20,
+	'build': process.env.BROWSERSTACK_BUILD_NAME,
+	'name': "Chrome Win10 test",
+	'project': process.env.BROWSERSTACK_PROJECT_NAME,
+	'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER,
+	'browserstack.user': process.env.BROWSERSTACK_USERNAME,
+	'browserstack.key': process.env.BROWSERSTACK_ACCESS_KEY
+}
+
+// IE11 win 10
+const capabilitiesIE11 = {
+	'os': 'windows',
+	'os_version': '10',
+	'browserName': 'IE',
+	'browser_version': '11.0',
+	'resolution': '1920x1080',
+	'browserstack.local': 'true',
+	"browserstack.idleTimeout": 20,
+	'build': process.env.BROWSERSTACK_BUILD_NAME,
+	'name': "IE11 Win10 test",
+	'project': process.env.BROWSERSTACK_PROJECT_NAME,
+	'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER,
+	'browserstack.user': process.env.BROWSERSTACK_USERNAME,
+	'browserstack.key': process.env.BROWSERSTACK_ACCESS_KEY
+}
+
+// Safari OS X
+const capabilitiesSafari = {
+	'browserName': 'Safari',
+	'browser_version': '14.1',
+	'os': 'OS X',
+	'os_version': 'Big Sur',
+	'resolution': '1920x1080',
+	'browserstack.local': 'true',
+	"browserstack.idleTimeout": 20,
+	'build': process.env.BROWSERSTACK_BUILD_NAME,
+	'name': "Safari OS X test",
+	'project': process.env.BROWSERSTACK_PROJECT_NAME,
+	'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER,
+	'browserstack.user': process.env.BROWSERSTACK_USERNAME,
+	'browserstack.key': process.env.BROWSERSTACK_ACCESS_KEY
+}
+
+// Firefox win 10
+const capabilitiesFirefox = {
+	'os': 'windows',
+	'os_version': '10',
+	'resolution': '1280x800',
+	'browserName': 'firefox',
+	'browser_version': 'latest',
+	'browserstack.local': 'true',
+	"browserstack.idleTimeout": 20,
+	'build': process.env.BROWSERSTACK_BUILD_NAME,
+	'name': "Firefox Win10 test",
+	'project': process.env.BROWSERSTACK_PROJECT_NAME,
+	'browserstack.localIdentifier': process.env.BROWSERSTACK_LOCAL_IDENTIFIER,
+	'browserstack.user': process.env.BROWSERSTACK_USERNAME,
+	'browserstack.key': process.env.BROWSERSTACK_ACCESS_KEY
+}
+
+runTestWithCaps(capabilitiesChrome);
+runTestWithCaps(capabilitiesIE11);
+runTestWithCaps(capabilitiesSafari);
+runTestWithCaps(capabilitiesFirefox);


### PR DESCRIPTION
This PR adds the automatic browser compatibility testing I've prepared in a fork. For reference, please refer to the internal communication regarding this and/or reach out to me.

Note: This only works with the browserstack secrets mentioned in the communication