### PR TITLE
Fix crash when buttons are "null"

### DIFF
--- a/cypress/fixtures/messages/buttons-with-null-buttons.json
+++ b/cypress/fixtures/messages/buttons-with-null-buttons.json
@@ -1,0 +1,19 @@
+{
+	"text": null,
+	"data": {
+		"_cognigy": {
+			"_webchat": {
+				"message": {
+					"attachment": {
+						"type": "template",
+						"payload": {
+							"text": "foobar005",
+							"template_type": "button",
+							"buttons": null
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/cypress/fixtures/messages/gallery-with-null-buttons.json
+++ b/cypress/fixtures/messages/gallery-with-null-buttons.json
@@ -1,0 +1,28 @@
+{
+  "source": "bot",
+  "text": "dshu",
+  "data": {
+    "_cognigy": {
+      "_webchat": {
+        "message": {
+          "attachment": {
+            "type": "template",
+            "payload": {
+              "template_type": "generic",
+              "elements": [
+                {
+                  "title": "dffdg",
+                  "subtitle": "dg",
+                  "image_url": "",
+                  "default_action": { "type": "web_url" },
+                  "buttons": null
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "id": "some-id"
+}

--- a/cypress/fixtures/messages/list-with-null-buttons.json
+++ b/cypress/fixtures/messages/list-with-null-buttons.json
@@ -1,0 +1,43 @@
+{
+	"text": "THIS_TEXT_SHOULD_NOT_RENDER",
+	"data": {
+		"_cognigy": {
+			"_webchat": {
+				"message": {
+					"attachment": {
+						"type": "template",
+						"payload": {
+							"template_type": "list",
+							"elements": [
+								{
+									"title": "foobar009l1",
+									"subtitle": "foobar009ls1",
+									"image_url": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+									"buttons": [
+										{
+											"payload": "foobar009l1b1",
+											"type": "postback",
+											"title": "foobar009l1b1"
+										}
+									]
+								},
+								{
+									"title": "foobar009l2",
+									"subtitle": "",
+									"image_url": "undefined",
+									"buttons": null,
+									"default_action": {
+										"type": "web_url",
+										"url": "https://example.com"
+									}
+								}
+							],
+							"top_element_style": "large",
+							"buttons": null
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/cypress/fixtures/messages/quick-replies-with-null-quick-replies.json
+++ b/cypress/fixtures/messages/quick-replies-with-null-quick-replies.json
@@ -1,0 +1,13 @@
+{
+  "text": null,
+  "data": {
+    "_cognigy": {
+      "_webchat": {
+        "message": {
+          "text": "foobar003",
+          "quick_replies": null
+        }
+      }
+    }
+  }
+}

--- a/cypress/integration/regressions/19420-null-buttons.spec.ts
+++ b/cypress/integration/regressions/19420-null-buttons.spec.ts
@@ -1,0 +1,43 @@
+describe('Message Templates with null Buttons', () => {
+  beforeEach(() => {
+    cy.visitBuild();
+    cy.initMockWebchat();
+    cy.openWebchat();
+  });
+
+  it('renders a gallery with null buttons', () => {
+    cy.fixture('messages/gallery-with-null-buttons.json')
+      .then(({ text, data, source }) => {
+        cy.receiveMessage(text, data, source);
+      });
+
+    cy.contains('dffdg').should('be.visible');
+  });
+
+  it('renders a list with null buttons', () => {
+    cy.fixture('messages/list-with-null-buttons.json')
+      .then(({ text, data, source }) => {
+        cy.receiveMessage(text, data, source);
+      });
+
+    cy.contains('foobar009l1').should('be.visible');
+  });
+
+  it('renders a text with buttons with null buttons', () => {
+    cy.fixture('messages/buttons-with-null-buttons.json')
+      .then(({ text, data, source }) => {
+        cy.receiveMessage(text, data, source);
+      });
+
+    cy.contains('foobar005').should('be.visible');
+  });
+
+  it('renders text+quick replies with null quick replies', () => {
+    cy.fixture('messages/quick-replies-with-null-quick-replies.json')
+      .then(({ text, data, source }) => {
+        cy.receiveMessage(text, data, source);
+      });
+
+    cy.contains('foobar003').should('be.visible');
+  });
+});

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
@@ -33,7 +33,9 @@ export const getMessengerButtonTemplate = ({
         config,
         ...divProps
     }: IMessengerButtonTemplateProps & React.HTMLProps<HTMLDivElement>) => {
-        const { text, buttons } = payload;
+        const { text } = payload;
+        const buttons = payload.buttons || [];
+
         const webchatButtonTemplateButtonId = useRandomId("webchatButtonTemplateButton");
         const webchatButtonTemplateTextId = useRandomId("webchatButtonTemplateHeader");
         const buttonGroupAriaLabelledby = text ? webchatButtonTemplateTextId : undefined;

--- a/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
@@ -170,7 +170,8 @@ export const getMessengerGenericTemplate = ({
 
         renderElement = (element: IFBMGenericTemplateElement, index?: number) => {
             const { onAction, ...divProps } = this.props;
-            const { image_url, image_alt_text, title, subtitle, buttons, default_action } = element;
+            const { image_url, image_alt_text, title, subtitle, default_action } = element;
+            const buttons = element.buttons || [];
 
             const carouselListLength = this.props.payload.elements.length;
             const isCentered = this.props.config.settings.designTemplate === 2;


### PR DESCRIPTION
This PR fixes an issue from a customer where our "messenger templates" wouldn't handle "null" as a value for the "buttons array" well and the webchat would crash.

The solution is to assume that the buttons value is an empty array in case it's falsey.
I also checked quick replies and added tests.

See the test files for clarification.