### PR TITLE
Prevent "reading" actions from local/session storage when disableLocalStorage flag is set

### DIFF
--- a/cypress/integration/disableLocalStorage.spec.ts
+++ b/cypress/integration/disableLocalStorage.spec.ts
@@ -1,0 +1,78 @@
+import { SinonSpy } from "cypress/types/sinon";
+
+describe("disableLocalStorage", () => {
+    it("does not try to read from localStorage when disableLocalStorage flag is set", () => {
+        cy.visitWebchat();
+
+        cy.window().then(window => {
+            cy.spy(window.localStorage, "getItem").as("lsGetItemSpy");
+            cy.spy(window.localStorage, "setItem").as("lsSetItemSpy");
+        })
+
+        cy.initWebchat({
+            settings: {
+                disableLocalStorage: true
+            }
+        });
+
+        cy.openWebchat();
+
+        cy.sendMessage("some message");
+
+        cy.window().contains('You said "some message".').should("be.visible");
+
+        // persisting messages is slightly delayed
+        cy.wait(1000);
+
+        cy.get("@lsGetItemSpy").then((spy: any) => {
+            expect((spy as SinonSpy).notCalled, "LocalStorage.getItem was never called").to.be.true;
+        });
+
+        cy.get("@lsSetItemSpy").then((spy: any) => {
+            expect((spy as SinonSpy).notCalled, "LocalStorage.setItem was never called").to.be.true;
+        });
+    });
+
+    it("does not try to read either from localStorage or sessionStorage when disableLocalStorage and useSessionStorage flags are set", () => {
+        cy.visitWebchat();
+
+        cy.window().then(window => {
+            cy.spy(window.localStorage, "getItem").as("lsGetItemSpy");
+            cy.spy(window.localStorage, "setItem").as("lsSetItemSpy");
+            cy.spy(window.sessionStorage, "getItem").as("ssGetItemSpy");
+            cy.spy(window.sessionStorage, "setItem").as("ssSetItemSpy");
+        })
+
+        cy.initWebchat({
+            settings: {
+                disableLocalStorage: true,
+                useSessionStorage: true
+            }
+        });
+
+        cy.openWebchat();
+
+        cy.sendMessage("some message");
+
+        cy.window().contains('You said "some message".').should("be.visible");
+        
+        // persisting messages is slightly delayed
+        cy.wait(1000);
+
+        cy.get("@lsGetItemSpy").then((spy: any) => {
+            expect((spy as SinonSpy).notCalled, "LocalStorage.getItem was never called").to.be.true;
+        });
+
+        cy.get("@lsSetItemSpy").then((spy: any) => {
+            expect((spy as SinonSpy).notCalled, "LocalStorage.setItem was never called").to.be.true;
+        });
+
+        cy.get("@ssGetItemSpy").then((spy: any) => {
+            expect((spy as SinonSpy).notCalled, "SessionStorage.getItem was never called").to.be.true;
+        });
+
+        cy.get("@ssSetItemSpy").then((spy: any) => {
+            expect((spy as SinonSpy).notCalled, "SessionStorage.setItem was never called").to.be.true;
+        });
+    });
+});

--- a/src/webchat-embed/index.tsx
+++ b/src/webchat-embed/index.tsx
@@ -11,6 +11,7 @@ import '../plugins/messenger';
 import '../plugins/rating';
 import { Webchat } from '../webchat/components/Webchat';
 import { getRegisteredMessagePlugins, prepareMessagePlugins } from '../plugins/helper';
+import { getStorage } from '../webchat/helper/storage';
 
 
 type SocketOptions = React.ComponentProps<typeof Webchat>['options'];
@@ -34,9 +35,9 @@ const initWebchat = async (webchatConfigUrl: string, options?: InitWebchatOption
             : plugin
         );
 
-    const disableLocalStorage = options && options.settings && options.settings.disableLocalStorage;
-    const useSessionStorage = options && options.settings && options.settings.useSessionStorage;
-    const browserStorage = useSessionStorage ? sessionStorage : localStorage;
+    const disableLocalStorage = options?.settings?.disableLocalStorage ?? false;
+    const useSessionStorage = options?.settings?.useSessionStorage ?? false;
+    const browserStorage = getStorage({ disableLocalStorage, useSessionStorage });
 
     // if no specific userId is provided, try to load one from localStorage/sessionStorage, otherwise generate one and persist it in localStorage/sessionStorage
     if ((!options || !options.userId) && browserStorage) {

--- a/src/webchat-embed/index.tsx
+++ b/src/webchat-embed/index.tsx
@@ -40,7 +40,11 @@ const initWebchat = async (webchatConfigUrl: string, options?: InitWebchatOption
 
     // if no specific userId is provided, try to load one from localStorage/sessionStorage, otherwise generate one and persist it in localStorage/sessionStorage
     if ((!options || !options.userId) && browserStorage) {
-        let userId = browserStorage.getItem('userId');
+        let userId;
+        
+        if (!disableLocalStorage) {
+            userId = browserStorage.getItem('userId');
+        }
 
         if (!userId) {
             userId = uuid.v4();

--- a/src/webchat/helper/storage.ts
+++ b/src/webchat/helper/storage.ts
@@ -1,0 +1,18 @@
+import { IWebchatSettings } from "../../common/interfaces/webchat-config";
+
+/**
+ * Returns the browser storage that should be used for this Webchat Embedding.
+ * 
+ * Note that for restricted environments, even a read-access to `window.localStorage`
+ * can result in an Error to throw, so we're first looking at the setting before accessing
+ * either of those.
+ */
+export const getStorage = (settings: Pick<IWebchatSettings, "disableLocalStorage" | "useSessionStorage">) => {
+    if (settings.disableLocalStorage)
+        return null;
+
+    if (settings.useSessionStorage)
+        return window.sessionStorage;
+
+    return window.localStorage;
+}

--- a/src/webchat/store/options/options-middleware.ts
+++ b/src/webchat/store/options/options-middleware.ts
@@ -3,6 +3,7 @@ import { getOptionsKey } from "./options";
 import { StoreState } from "../store";
 import { SetOptionsAction } from "./options-reducer";
 import { resetState } from "../reducer";
+import { getStorage } from "../../helper/storage";
 
 type Actions = SetOptionsAction
 
@@ -11,12 +12,12 @@ export const optionsMiddleware: Middleware<{}, StoreState> = store => next => (a
     const { active } = store.getState().config; // Actual settings are loaded
     const { disableLocalStorage, disablePersistentHistory, useSessionStorage } = store.getState().config.settings;
     const { userId } = store.getState().options;
-    const browserStorage = useSessionStorage ? window.sessionStorage : window.localStorage;
+    const browserStorage = getStorage({ useSessionStorage, disableLocalStorage });
 
     switch (action.type) {
         case 'SET_OPTIONS': {
             // TODO decouple this into a separate action or middleware handler
-            if (browserStorage && !disableLocalStorage) {
+            if (browserStorage) {
                 const key = getOptionsKey(action.options);
                 const persistedString = browserStorage.getItem(key);
 
@@ -31,7 +32,7 @@ export const optionsMiddleware: Middleware<{}, StoreState> = store => next => (a
         }
     }
 
-    if (browserStorage && active && userId && !(disablePersistentHistory || disableLocalStorage)) {
+    if (browserStorage && active && userId && !disablePersistentHistory) {
         const { messages, rating } = store.getState();
         browserStorage.setItem(key, JSON.stringify({
             messages,

--- a/src/webchat/store/options/options-middleware.ts
+++ b/src/webchat/store/options/options-middleware.ts
@@ -16,7 +16,7 @@ export const optionsMiddleware: Middleware<{}, StoreState> = store => next => (a
     switch (action.type) {
         case 'SET_OPTIONS': {
             // TODO decouple this into a separate action or middleware handler
-            if (browserStorage) {
+            if (browserStorage && !disableLocalStorage) {
                 const key = getOptionsKey(action.options);
                 const persistedString = browserStorage.getItem(key);
 


### PR DESCRIPTION
Previously, the `disableLocalStorage` flag would just prevent the webchat from persisting its state to `localStorage` / `sessionStorage` but didn't prevent it from reading from it.

This PR adds tests validating that neither `getItem` nor `setItem` is called for both `localStorage` and `sessionStorage` if the flag is set and sets up a check so we won't read from it.