### PR TITLE
check legacy outputs for es5 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "babel-polyfill": "^6.26.0",
         "css-loader": "^2.1.1",
         "cypress": "^9.1.1",
+        "es-check": "^6.1.1",
         "http-server": "^0.13.0",
         "idempotent-babel-polyfill": "^7.4.4",
         "npm-run-all": "^4.1.5",
@@ -1973,6 +1974,133 @@
       "integrity": "sha1-sjCA+jVSDpk6ijeg9byiaqRlCkg=",
       "license": "MIT"
     },
+    "node_modules/@caporal/core": {
+      "version": "2.0.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@caporal/core/-/core-2.0.2.tgz",
+      "integrity": "sha1-t92AjMWMqkV4bPS1sWA7N793rHI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "@types/lodash": "4.14.149",
+        "@types/node": "13.9.3",
+        "@types/table": "5.0.0",
+        "@types/tabtab": "^3.0.1",
+        "@types/wrap-ansi": "^3.0.0",
+        "chalk": "3.0.0",
+        "glob": "^7.1.6",
+        "lodash": "4.17.15",
+        "table": "5.4.6",
+        "tabtab": "^3.0.2",
+        "winston": "3.2.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@caporal/core/node_modules/@types/node": {
+      "version": "13.9.3",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/node/-/node-13.9.3.tgz",
+      "integrity": "sha1-Y1bfJkfenqxWn5pS7aNID6nnC00=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@caporal/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@caporal/core/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@caporal/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@caporal/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@caporal/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@caporal/core/node_modules/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@caporal/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@caporal/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@cognigy/socket-client": {
       "version": "4.5.5",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@cognigy/socket-client/-/socket-client-4.5.5.tgz",
@@ -2265,6 +2393,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha1-E0LWPZSMYGKDj7+WEBL3TU5jhEA=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -2360,6 +2495,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/table": {
+      "version": "5.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/table/-/table-5.0.0.tgz",
+      "integrity": "sha1-Z8OCETjrQdU4w9koZ3HGze6scXI=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tabtab": {
+      "version": "3.0.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/tabtab/-/tabtab-3.0.2.tgz",
+      "integrity": "sha1-BHZX/euYoTv9OMbZLYMnBmdZaVw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/tinycolor2": {
       "version": "1.4.3",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/tinycolor2/-/tinycolor2-1.4.3.tgz",
@@ -2400,6 +2552,13 @@
       "dependencies": {
         "whatwg-streams": "*"
       }
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha1-GLl6ly+U9gpnn9XHltlkIbmruf0=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.9.2",
@@ -3843,6 +4002,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/check-more-types": {
       "version": "2.24.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -4080,6 +4246,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha1-sEM9C06chH7xiGik7xb9X8gnHEg=",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/cliui": {
       "version": "5.0.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/cliui/-/cliui-5.0.0.tgz",
@@ -4191,6 +4364,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color/-/color-3.2.1.tgz",
+      "integrity": "sha1-NUTcGYyvRJDD7MmnkLVP6f9F4WQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
@@ -4206,10 +4390,28 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "license": "MIT"
     },
+    "node_modules/color-string": {
+      "version": "1.9.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha1-Y7br0b7BGZnR3zp5p1aUUawr6Ko=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.16",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/colorette/-/colorette-2.0.16.tgz",
       "integrity": "sha1-cTua+E/bAAE58EVGvUqT9ipQhdo=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colornames": {
+      "version": "1.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
       "dev": true,
       "license": "MIT"
     },
@@ -4221,6 +4423,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha1-jUQtEYYVL2BFO/gHDNZus2TlkkM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
       }
     },
     "node_modules/combined-stream": {
@@ -5397,6 +5610,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha1-yrasM99wydmnJ0kK5DrJladpsio=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -5606,6 +5831,16 @@
         "react": ">=16.3.0"
       }
     },
+    "node_modules/enabled": {
+      "version": "1.0.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-variable": "0.0.x"
+      }
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -5710,6 +5945,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-variable": {
+      "version": "0.0.6",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/env-variable/-/env-variable-0.0.6.tgz",
+      "integrity": "sha1-dKsgs3hsVFtitKSBOrjPInJsmAg=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/errno": {
       "version": "0.1.8",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/errno/-/errno-0.1.8.tgz",
@@ -5767,6 +6009,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-check": {
+      "version": "6.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/es-check/-/es-check-6.1.1.tgz",
+      "integrity": "sha1-+m8NwCkfz/RZmj8bnqnelYV9aXg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@caporal/core": "^2.0.2",
+        "acorn": "^8.4.1",
+        "glob": "^7.1.7"
+      },
+      "bin": {
+        "es-check": "index.js"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/es-check/node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha1-kJUf3g+PCd+TVJSB5fwUFEW3kc8=",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -5784,6 +6057,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promisify": {
+      "version": "6.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/es6-promisify/-/es6-promisify-6.1.1.tgz",
+      "integrity": "sha1-RoN2Ubewa/b/+JPQPyk5NmjQFiE=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -6260,6 +6540,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/extglob": {
       "version": "2.0.4",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/extglob/-/extglob-2.0.4.tgz",
@@ -6383,6 +6691,13 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fecha": {
+      "version": "4.2.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/fecha/-/fecha-4.2.1.tgz",
+      "integrity": "sha1-CoOtj4bvYqCR4iu1oDnNA9I+7M4=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
@@ -7593,6 +7908,194 @@
         "node": ">=10"
       }
     },
+    "node_modules/inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/internal-ip": {
       "version": "4.3.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -8495,6 +8998,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/kuler": {
+      "version": "1.0.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha1-73x4TzbJ+24W3TFQ0VJneysCKKY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colornames": "^1.1.1"
+      }
+    },
     "node_modules/lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -8849,6 +9362,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.3.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/logform/-/logform-2.3.0.tgz",
+      "integrity": "sha1-o5l6BZhd4uvTJa4NFm3/ycb+a1c=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colors": "^1.2.1",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^1.1.0",
+        "triple-beam": "^1.3.0"
       }
     },
     "node_modules/loglevel": {
@@ -9373,6 +9900,13 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/nan": {
       "version": "2.15.0",
@@ -9899,6 +10433,13 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-time": {
+      "version": "0.0.4",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/onetime/-/onetime-5.1.2.tgz",
@@ -9954,6 +10495,16 @@
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ospath": {
       "version": "1.2.2",
@@ -11369,6 +11920,16 @@
         "inherits": "^2.0.1"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha1-hEDsz5nqPnC9QJ1JqriOEMGJpFU=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-queue": {
       "version": "1.0.3",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/run-queue/-/run-queue-1.0.3.tgz",
@@ -11411,6 +11972,13 @@
       "dependencies": {
         "ret": "~0.1.10"
       }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+      "integrity": "sha1-yKIgq1Jc2U5g6/R93EBNYQ3F2Eo=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -11760,6 +12328,23 @@
       "version": "0.1.1",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz",
       "integrity": "sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM=",
       "dev": true,
       "license": "MIT"
     },
@@ -12334,6 +12919,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/static-extend/-/static-extend-0.1.2.tgz",
@@ -12784,6 +13379,127 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/table": {
+      "version": "5.4.6",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/table/-/table-5.4.6.tgz",
+      "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/table/node_modules/astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tabtab": {
+      "version": "3.0.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/tabtab/-/tabtab-3.0.2.tgz",
+      "integrity": "sha1-os6g8QNfiNFF19p36qu9P+A+Hsk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.1",
+        "es6-promisify": "^6.0.0",
+        "inquirer": "^6.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "untildify": "^3.0.3"
+      }
+    },
+    "node_modules/tabtab/node_modules/untildify": {
+      "version": "3.0.3",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/untildify/-/untildify-3.0.3.tgz",
+      "integrity": "sha1-HntCsUC8/ZIrIucMoSZb/jY0x8k=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/tapable": {
       "version": "1.1.3",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/tapable/-/tapable-1.1.3.tgz",
@@ -12981,6 +13697,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha1-adycGxdEbueakr9biEu0uRJ1BvU=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/theming": {
       "version": "1.3.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/theming/-/theming-1.3.0.tgz",
@@ -13168,6 +13891,13 @@
       "version": "0.6.6",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha1-pZUhTHKY24M57u7gg+TRC9jLjdk=",
       "dev": true,
       "license": "MIT"
     },
@@ -14814,6 +15544,92 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/winston": {
+      "version": "3.2.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha1-YwYTd5dsc1hAKL4kkKGEYFX3fwc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.4.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/winston-transport/-/winston-transport-4.4.1.tgz",
+      "integrity": "sha1-Qqgw4HNjcZwTwSvS+4eiJvaS3HU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.2.0",
+        "readable-stream": "^3.4.0",
+        "triple-beam": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.4.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/async": {
+      "version": "2.6.3",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/async/-/async-2.6.3.tgz",
+      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/winston/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/worker-farm": {
       "version": "1.7.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -16350,6 +17166,101 @@
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@braintree/sanitize-url/-/sanitize-url-5.0.2.tgz",
       "integrity": "sha1-sjCA+jVSDpk6ijeg9byiaqRlCkg="
     },
+    "@caporal/core": {
+      "version": "2.0.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@caporal/core/-/core-2.0.2.tgz",
+      "integrity": "sha1-t92AjMWMqkV4bPS1sWA7N793rHI=",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "@types/lodash": "4.14.149",
+        "@types/node": "13.9.3",
+        "@types/table": "5.0.0",
+        "@types/tabtab": "^3.0.1",
+        "@types/wrap-ansi": "^3.0.0",
+        "chalk": "3.0.0",
+        "glob": "^7.1.6",
+        "lodash": "4.17.15",
+        "table": "5.4.6",
+        "tabtab": "^3.0.2",
+        "winston": "3.2.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.9.3",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/node/-/node-13.9.3.tgz",
+          "integrity": "sha1-Y1bfJkfenqxWn5pS7aNID6nnC00=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "@cognigy/socket-client": {
       "version": "4.5.5",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@cognigy/socket-client/-/socket-client-4.5.5.tgz",
@@ -16598,6 +17509,12 @@
       "integrity": "sha1-l+3JA36gw4WFMgsolk3eOznkZg0=",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha1-E0LWPZSMYGKDj7+WEBL3TU5jhEA=",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -16683,6 +17600,21 @@
       "integrity": "sha1-/14vGQKWnTBSJaBHyKD9XJFc6+8=",
       "dev": true
     },
+    "@types/table": {
+      "version": "5.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/table/-/table-5.0.0.tgz",
+      "integrity": "sha1-Z8OCETjrQdU4w9koZ3HGze6scXI=",
+      "dev": true
+    },
+    "@types/tabtab": {
+      "version": "3.0.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/tabtab/-/tabtab-3.0.2.tgz",
+      "integrity": "sha1-BHZX/euYoTv9OMbZLYMnBmdZaVw=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/tinycolor2": {
       "version": "1.4.3",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/tinycolor2/-/tinycolor2-1.4.3.tgz",
@@ -16718,6 +17650,12 @@
       "requires": {
         "whatwg-streams": "*"
       }
+    },
+    "@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha1-GLl6ly+U9gpnn9XHltlkIbmruf0=",
+      "dev": true
     },
     "@types/yauzl": {
       "version": "2.9.2",
@@ -17820,6 +18758,12 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
+      "dev": true
+    },
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -17992,6 +18936,12 @@
         "string-width": "^4.2.0"
       }
     },
+    "cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha1-sEM9C06chH7xiGik7xb9X8gnHEg=",
+      "dev": true
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/cliui/-/cliui-5.0.0.tgz",
@@ -18075,6 +19025,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.2.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color/-/color-3.2.1.tgz",
+      "integrity": "sha1-NUTcGYyvRJDD7MmnkLVP6f9F4WQ=",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
@@ -18088,10 +19048,26 @@
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "color-string": {
+      "version": "1.9.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha1-Y7br0b7BGZnR3zp5p1aUUawr6Ko=",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "colorette": {
       "version": "2.0.16",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/colorette/-/colorette-2.0.16.tgz",
       "integrity": "sha1-cTua+E/bAAE58EVGvUqT9ipQhdo=",
+      "dev": true
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
       "dev": true
     },
     "colors": {
@@ -18099,6 +19075,16 @@
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/colors/-/colors-1.4.0.tgz",
       "integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g=",
       "dev": true
+    },
+    "colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha1-jUQtEYYVL2BFO/gHDNZus2TlkkM=",
+      "dev": true,
+      "requires": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -18969,6 +19955,17 @@
       "integrity": "sha1-yccHdaScPQO8LAbZpzvlUPl4+LE=",
       "dev": true
     },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha1-yrasM99wydmnJ0kK5DrJladpsio=",
+      "dev": true,
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -19146,6 +20143,15 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "dev": true,
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -19232,6 +20238,12 @@
       "integrity": "sha1-CY3JDruD2N/6CJ1VJWs1HTTE2lU=",
       "dev": true
     },
+    "env-variable": {
+      "version": "0.0.6",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/env-variable/-/env-variable-0.0.6.tgz",
+      "integrity": "sha1-dKsgs3hsVFtitKSBOrjPInJsmAg=",
+      "dev": true
+    },
     "errno": {
       "version": "0.1.8",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/errno/-/errno-0.1.8.tgz",
@@ -19277,6 +20289,25 @@
         "unbox-primitive": "^1.0.1"
       }
     },
+    "es-check": {
+      "version": "6.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/es-check/-/es-check-6.1.1.tgz",
+      "integrity": "sha1-+m8NwCkfz/RZmj8bnqnelYV9aXg=",
+      "dev": true,
+      "requires": {
+        "@caporal/core": "^2.0.2",
+        "acorn": "^8.4.1",
+        "glob": "^7.1.7"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha1-kJUf3g+PCd+TVJSB5fwUFEW3kc8=",
+          "dev": true
+        }
+      }
+    },
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -19287,6 +20318,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promisify": {
+      "version": "6.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/es6-promisify/-/es6-promisify-6.1.1.tgz",
+      "integrity": "sha1-RoN2Ubewa/b/+JPQPyk5NmjQFiE=",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -19630,6 +20667,28 @@
         "is-extendable": "^1.0.1"
       }
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/extglob/-/extglob-2.0.4.tgz",
@@ -19719,6 +20778,12 @@
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "fecha": {
+      "version": "4.2.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/fecha/-/fecha-4.2.1.tgz",
+      "integrity": "sha1-CoOtj4bvYqCR4iu1oDnNA9I+7M4=",
+      "dev": true
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -20575,6 +21640,141 @@
       "integrity": "sha1-5f1Vbs3VcmvpePoQAYYurLCpS8U=",
       "dev": true
     },
+    "inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+          "dev": true
+        }
+      }
+    },
     "internal-ip": {
       "version": "4.3.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -21178,6 +22378,15 @@
       "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
       "dev": true
     },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha1-73x4TzbJ+24W3TFQ0VJneysCKKY=",
+      "dev": true,
+      "requires": {
+        "colornames": "^1.1.1"
+      }
+    },
     "lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -21425,6 +22634,19 @@
             "strip-ansi": "^6.0.0"
           }
         }
+      }
+    },
+    "logform": {
+      "version": "2.3.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/logform/-/logform-2.3.0.tgz",
+      "integrity": "sha1-o5l6BZhd4uvTJa4NFm3/ycb+a1c=",
+      "dev": true,
+      "requires": {
+        "colors": "^1.2.1",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^1.1.0",
+        "triple-beam": "^1.3.0"
       }
     },
     "loglevel": {
@@ -21818,6 +23040,12 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "nan": {
       "version": "2.15.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/nan/-/nan-2.15.0.tgz",
@@ -22202,6 +23430,12 @@
         "wrappy": "1"
       }
     },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=",
+      "dev": true
+    },
     "onetime": {
       "version": "5.1.2",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/onetime/-/onetime-5.1.2.tgz",
@@ -22239,6 +23473,12 @@
       "version": "0.3.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "ospath": {
@@ -23284,6 +24524,12 @@
         "inherits": "^2.0.1"
       }
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha1-hEDsz5nqPnC9QJ1JqriOEMGJpFU=",
+      "dev": true
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/run-queue/-/run-queue-1.0.3.tgz",
@@ -23321,6 +24567,12 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safe-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+      "integrity": "sha1-yKIgq1Jc2U5g6/R93EBNYQ3F2Eo=",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -23604,6 +24856,23 @@
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz",
       "integrity": "sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4=",
       "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM=",
+          "dev": true
+        }
+      }
     },
     "slash": {
       "version": "2.0.0",
@@ -24073,6 +25342,12 @@
       "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
       "dev": true
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/static-extend/-/static-extend-0.1.2.tgz",
@@ -24408,6 +25683,97 @@
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/symbol-observable/-/symbol-observable-0.2.4.tgz",
       "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A="
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/table/-/table-5.4.6.tgz",
+      "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        },
+        "astral-regex": {
+          "version": "1.0.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/astral-regex/-/astral-regex-1.0.0.tgz",
+          "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/slice-ansi/-/slice-ansi-2.1.0.tgz",
+          "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "astral-regex": "^1.0.0",
+            "is-fullwidth-code-point": "^2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "tabtab": {
+      "version": "3.0.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/tabtab/-/tabtab-3.0.2.tgz",
+      "integrity": "sha1-os6g8QNfiNFF19p36qu9P+A+Hsk=",
+      "dev": true,
+      "requires": {
+        "debug": "^4.0.1",
+        "es6-promisify": "^6.0.0",
+        "inquirer": "^6.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "untildify": "^3.0.3"
+      },
+      "dependencies": {
+        "untildify": {
+          "version": "3.0.3",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/untildify/-/untildify-3.0.3.tgz",
+          "integrity": "sha1-HntCsUC8/ZIrIucMoSZb/jY0x8k=",
+          "dev": true
+        }
+      }
+    },
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/tapable/-/tapable-1.1.3.tgz",
@@ -24551,6 +25917,12 @@
         }
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha1-adycGxdEbueakr9biEu0uRJ1BvU=",
+      "dev": true
+    },
     "theming": {
       "version": "1.3.0",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/theming/-/theming-1.3.0.tgz",
@@ -24691,6 +26063,12 @@
       "version": "0.6.6",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha1-pZUhTHKY24M57u7gg+TRC9jLjdk=",
       "dev": true
     },
     "ts-loader": {
@@ -25903,6 +27281,75 @@
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha1-YwYTd5dsc1hAKL4kkKGEYFX3fwc=",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/async/-/async-2.6.3.tgz",
+          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.1",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/winston-transport/-/winston-transport-4.4.1.tgz",
+      "integrity": "sha1-Qqgw4HNjcZwTwSvS+4eiJvaS3HU=",
+      "dev": true,
+      "requires": {
+        "logform": "^2.2.0",
+        "readable-stream": "^3.4.0",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:cypress": "run-p -r cypress:serve cypress:run",
     "test:es5-legacy": "es-check es5 ./dist/*.legacy.js",
     "test": "npm run test:es5-legacy && npm run test:cypress",
-    "pretest": "npm run webchat && npm run date-picker && npm run message-renderer"
+    "pretest": "npm run bundle"
   },
   "dependencies": {
     "@braintree/sanitize-url": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "cypress:open": "cypress open",
     "cypress:serve": "http-server -a localhost -p 8787 dist/",
     "cypress:run": "cypress run",
-    "test": "run-p -r cypress:serve cypress:run",
+    "test:cypress": "run-p -r cypress:serve cypress:run",
+    "test:es5-legacy": "es-check es5 ./dist/*.legacy.js",
+    "test": "npm run test:es5-legacy && npm run test:cypress",
     "pretest": "npm run webchat && npm run date-picker && npm run message-renderer"
   },
   "dependencies": {
@@ -85,6 +87,7 @@
     "babel-polyfill": "^6.26.0",
     "css-loader": "^2.1.1",
     "cypress": "^9.1.1",
+    "es-check": "^6.1.1",
     "http-server": "^0.13.0",
     "idempotent-babel-polyfill": "^7.4.4",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
this PR adds a test step that will check the "legacy" build outputs for es5 compatibility to prevent regressions