### PR TITLE
feature/20919 add compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 /lib/
 dist/*.js
+dist/*.gz
+dist/*.br
 dist/*.zip
 dist/*.webmanifest
 dist/index.html

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -10,6 +10,18 @@ To integrate the Webchat into a Website, you need to
 See it in action:  
 [![Edit Basic Implementation](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/basic-cognigy-webchat-embedding-ict1u?fontsize=14&hidenavigation=1&theme=dark)
 
+## Using File Compression
+
+The Webchat Widget offers compressed file versions that can be used to reduce the amount of data that is delivered to the user and reduce site loading time.
+
+To use file compression you need to
+
+1. build the files using `npm run build`
+2. copy the `.js.gz` files for Gzip compression and `.js.br` for Brotli compression to the same folder you store your `.js` files in
+3. enable compression on your webserver
+
+compression can be enabled for most common web servers but the implementation depends on your used software, middleware and implementation.
+
 ## Using a Compatiblity Build
 
 For older browsers, we ship a seperate build of the Webchat called `webchat.legacy.js`, which comes with extra compatibility at the cost of increased size.

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@types/whatwg-fetch": "0.0.33",
         "babel-loader": "^8.2.3",
         "babel-polyfill": "^6.26.0",
+        "compression-webpack-plugin": "^9.2.0",
         "css-loader": "^6.5.1",
         "cypress": "^9.1.1",
         "es-check": "^6.1.1",
@@ -80,7 +81,8 @@
         "webpack": "^5.65.0",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.7.2",
-        "whatwg-fetch": "^3.6.2"
+        "whatwg-fetch": "^3.6.2",
+        "zlib": "^1.0.5"
       }
     },
     "node_modules/@babel/cli": {
@@ -4160,6 +4162,84 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression-webpack-plugin": {
+      "version": "9.2.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/compression-webpack-plugin/-/compression-webpack-plugin-9.2.0.tgz",
+      "integrity": "sha1-V/1TnRfFkH7r3rToPc/i1+zrnvY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/compression-webpack-plugin/node_modules/ajv": {
+      "version": "8.8.2",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha1-AbT+8gB6KL918Lf8AJ9iZ53kq7s=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/compression-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha1-adTThaRzPNvqtElkoRcKiPh/DhY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/compression-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compression-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.0.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/schema-utils/-/schema-utils-4.0.0.tgz",
+      "integrity": "sha1-YDMenjrnjsXRY1PEZ8NLOgodPfc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.8.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/compression/node_modules/debug": {
@@ -12483,6 +12563,15 @@
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "license": "MIT"
+    },
+    "node_modules/zlib": {
+      "version": "1.0.5",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/zlib/-/zlib-1.0.5.tgz",
+      "integrity": "sha1-bnyXL8NxxkWmr7A6sUdp3vEU/MA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.0"
+      }
     }
   },
   "dependencies": {
@@ -15427,6 +15516,57 @@
           "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        }
+      }
+    },
+    "compression-webpack-plugin": {
+      "version": "9.2.0",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/compression-webpack-plugin/-/compression-webpack-plugin-9.2.0.tgz",
+      "integrity": "sha1-V/1TnRfFkH7r3rToPc/i1+zrnvY=",
+      "dev": true,
+      "requires": {
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.8.2",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha1-AbT+8gB6KL918Lf8AJ9iZ53kq7s=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "5.1.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+          "integrity": "sha1-adTThaRzPNvqtElkoRcKiPh/DhY=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.3"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "4.0.0",
+          "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/schema-utils/-/schema-utils-4.0.0.tgz",
+          "integrity": "sha1-YDMenjrnjsXRY1PEZ8NLOgodPfc=",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "ajv": "^8.8.0",
+            "ajv-formats": "^2.1.1",
+            "ajv-keywords": "^5.0.0"
+          }
         }
       }
     },
@@ -21283,6 +21423,12 @@
       "version": "0.1.2",
       "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    },
+    "zlib": {
+      "version": "1.0.5",
+      "resolved": "https://cognigy.pkgs.visualstudio.com/_packaging/cognigy-feed/npm/registry/zlib/-/zlib-1.0.5.tgz",
+      "integrity": "sha1-bnyXL8NxxkWmr7A6sUdp3vEU/MA=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/whatwg-fetch": "0.0.33",
     "babel-loader": "^8.2.3",
     "babel-polyfill": "^6.26.0",
+    "compression-webpack-plugin": "^9.2.0",
     "css-loader": "^6.5.1",
     "cypress": "^9.1.1",
     "es-check": "^6.1.1",
@@ -105,6 +106,7 @@
     "webpack": "^5.65.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.7.2",
-    "whatwg-fetch": "^3.6.2"
+    "whatwg-fetch": "^3.6.2",
+    "zlib": "^1.0.5"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
-var path = require('path');
+const path = require('path');
 const TerserPlugin = require("terser-webpack-plugin");
+const zlib = require("zlib");
+const CompressionPlugin = require("compression-webpack-plugin");
 
 module.exports = {
     mode: 'development',
@@ -49,7 +51,27 @@ module.exports = {
             }
         ],
     },
-    plugins: [],
+    plugins: [
+        new CompressionPlugin({
+			filename: "[path][base].gz",
+			algorithm: "gzip",
+			test: /\.(js|css|html|svg|ts|tsx)$/,
+			threshold: 10240,
+			minRatio: 0.8,
+		}),
+		new CompressionPlugin({
+			filename: "[path][base].br",
+			algorithm: "brotliCompress",
+			test: /\.(js|css|html|svg|ts|tsx)$/,
+			compressionOptions: {
+				params: {
+					[zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+				},
+			},
+			threshold: 10240,
+			minRatio: 0.8,
+		}),
+    ],
     devServer: {
         port: 8787
     },


### PR DESCRIPTION
This PR adds file compression to build compressed versions of webchat, the plugins and all legacy versions.

How to test:
1. npm ci && npm run build
2. copy all .js.br and .js.gz files to the source folder you normally use to test webpack.js
3. Import webchat and plugins in your test file pointing to the old .js file, e.g. <script src="dist/webchat.js"></script>
4. run "http-server -g" to start a webserver distributing Gzip compressed files (if you don't have it installed do so using "npm install --global http-server" first)
5. Run the webchat and communicate with a flow, it should work as before, also test the plugins. There are no compressed plugins for speech-input and speech-output as their uncompressed size is so small that loading and decompressing would be less performant.
6. Open the network tab in the browser debugging tools and select the loaded files, they should have a content encoding header gz and their size should be same as the .js.gz file
7. Repeat step 4 to 6 with "http-server -b" instead testing the brotli compression, it should now be even smaller and have a br encoding.
8. Repeat everything with the .legacy files, it should work the same way.
9. Open the sources tab and open the .legacy.js files. Search for "=>" which represents arrow functions that should not be in the legacy files, you should have no hits or only some within comments