### PR TITLE
fix crash when handling empty structured content data

### DIFF
--- a/cypress/integration/regressions/empty-messenger-message.spec.ts
+++ b/cypress/integration/regressions/empty-messenger-message.spec.ts
@@ -1,0 +1,14 @@
+describe("Empty Messenger Message", () => {
+    it("Does not crash when rendering an empty Messenger Message", () => {
+        cy.visitWebchat().initMockWebchat().openWebchat();
+
+        cy.receiveMessage("", {
+            _cognigy: {
+                _webchat: {}
+            }
+        });
+        
+        cy.receiveMessage("hi");
+        cy.contains("hi").should("be.visible");
+    });
+});

--- a/src/plugins/messenger/index.tsx
+++ b/src/plugins/messenger/index.tsx
@@ -28,7 +28,11 @@ const getMessengerPayload = (message: IMessage, config: IWebchatConfig) => {
     return _webchat || _facebook;
 }
 
-const isMessengerPayload = (message: IMessage, config: IWebchatConfig) => !!getMessengerPayload(message, config);
+const isMessengerPayload = (message: IMessage, config: IWebchatConfig) => {
+    const payload = getMessengerPayload(message, config);
+
+    return payload && Object.keys(payload).length > 0;
+}
 
 // return true if a message is a messenger generic template with more than one element
 // one element should be rendered like default


### PR DESCRIPTION
This PR fixes an issue where the webchat would crash when rendering messages with the following data payload:
```javascript
{
  _cognigy: {
    _webchat: { }
  }
}
```

The reason was that we incorrectly matched those messages as "valid to be rendered by the messenger plugin" which then tried to access content from that empty object, resulting in a crash.

I added an automated regression-test