### PR TITLE
add "tsc:check" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "test:cypress": "run-p -r cypress:serve cypress:run",
     "test:es5-legacy": "es-check es5 ./dist/*.legacy.js",
     "test": "npm run test:es5-legacy && npm run test:cypress",
-    "pretest": "npm run bundle"
+    "pretest": "npm run bundle",
+    "tsc:check": "tsc --noEmit"
   },
   "dependencies": {
     "@braintree/sanitize-url": "^5.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,5 +55,12 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-  }
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "cypress"
+  ]
 }


### PR DESCRIPTION
This PR adds a `tsc:check` npm script which will fail if there are type errors in our source code.
As a follow-up, we will create PRs that fix individual type issues until we're "clean", after which we can make this part of the build process and/or an automated pipeline