### PR TITLE
fix "malformed data"

### DIFF
--- a/cypress/fixtures/messages/quick-replies.json
+++ b/cypress/fixtures/messages/quick-replies.json
@@ -77,7 +77,7 @@
 					"message": {
 						"text": "foobar003",
 						"quick_replies": [
-							{ "content_type": "text", "title": "foobar003qr01" },
+							{ "content_type": "text", "title": "foobar003qr01", "payload": "some-payload" },
 							{
 								"content_type": "text",
 								"image_url": "http://cognigy.com/favicon.ico",

--- a/cypress/integration/sendMessage.spec.ts
+++ b/cypress/integration/sendMessage.spec.ts
@@ -17,4 +17,21 @@ describe('Send Message', () => {
 			.get('[aria-label="Send Message"]').click()
 			.get('.webchat-chat-history').contains('Hi');
 	});
+
+	it('should not send messages without text and data', () => {
+		cy
+			.visitWebchat()
+			.initMockWebchat()
+			.openWebchat();
+
+		cy.wait(1000);
+
+		cy.sendMessage();
+		cy.sendMessage("");
+		cy.sendMessage("", {});
+
+		cy.getHistory().then(history => {
+			expect(history.length).to.equal(0);
+		});
+	});
 });

--- a/cypress/integration/startBehavior.spec.ts
+++ b/cypress/integration/startBehavior.spec.ts
@@ -96,4 +96,50 @@ describe('Start Behavior', () => {
         cy.openWebchat();
         cy.getMessageFromHistory({ text: "text", data: { some: "data" } });
     })
+
+    it('should not automatically send a "get started message" without text and data', () => {
+        cy
+            .visitWebchat()
+            .initWebchat({
+                settings: {
+                    startBehavior: "injection",
+                    getStartedText: "some text",
+                    getStartedPayload: "",
+                    getStartedData: {}
+                }
+            });
+
+        cy.openWebchat();
+        cy.wait(3000);
+        cy.getHistory().then(history => {
+            expect(history.find(message => {
+                if (message.text)
+                    return false;
+
+                if (message.data) {
+                    if (typeof message.data === 'object' && Object.keys(message.data).length > 0) {
+                        return false
+                    }
+                }
+
+                return true;
+            }), "history doesn't have an empty message").to.be.undefined;
+        });
+    })
+
+    it('should not display a get-started-button without text and data', () => {
+        cy
+            .visitWebchat()
+            .initWebchat({
+                settings: {
+                    startBehavior: "button",
+                    getStartedText: "some text",
+                    getStartedPayload: "",
+                    getStartedData: {}
+                }
+            });
+
+        cy.openWebchat();
+        cy.get('[data-cognigy-webchat-toggle]').should('not.exist');
+    })
 });

--- a/src/plugins/get-started-button-input/index.ts
+++ b/src/plugins/get-started-button-input/index.ts
@@ -6,7 +6,15 @@ const rule: InputRule = ({ config: { settings: { startBehavior, getStartedButton
     (messages.length === 0 || messages.length === 1 && messages[0].source === 'engagement')
     && startBehavior === 'button'
     && !!getStartedPayload
-    && (!!getStartedButtonText || !!getStartedText || !!getStartedData)
+    && (
+        !!getStartedButtonText 
+        || !!getStartedText 
+        || (
+            !!getStartedData 
+            && typeof getStartedData === 'object' 
+            && Object.keys(getStartedData).length > 0
+        )
+    )
 
 const getStartedInputPlugin: InputPlugin = {
     type: 'rule',

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -70,6 +70,15 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<{}, St
                     .textContent || '';
             }
 
+            // data is either a non-empty object or null
+            data = (data && typeof data === 'object' && Object.keys(data).length > 0)
+                ? data
+                : null;
+
+            // don't send empty messages!
+            if (!text && !data)
+                break;
+
             client.sendMessage(text || '', data);
 
             const displayMessage = { ...message, text };


### PR DESCRIPTION
This PR fixes an issue where sending empty messages would cause the webchat to not work properly anymore.
This happened when we send a message without text and data through the socket.

The fix checks that a message has either text or data, where data has to be a non-empty object. Otherwise, it gets dropped.
Additionally, this PR fixes an issue where the "get started button" would be shown if empty text and no data were configured.
