### PR TITLE
fix gallery image not rendering correctly with dynamicImageAspectRatio

### DIFF
--- a/cypress/fixtures/messages/gallery.json
+++ b/cypress/fixtures/messages/gallery.json
@@ -9,7 +9,7 @@
 						{
 							"title": "foobar004g1",
 							"subtitle": "",
-							"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+							"imageUrl": "https://placekitten.com/300/300",
 							"buttons": [
 								{
 									"id": 0.9601740794827666,
@@ -23,7 +23,7 @@
 						{
 							"title": "foobar004g2",
 							"subtitle": "foobar004g2sub1\nfoobar004g2sub2",
-							"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+							"imageUrl": "https://placekitten.com/300/300",
 							"buttons": [],
 							"id": 0.9969017542005371
 						},
@@ -47,7 +47,7 @@
 								{
 									"title": "foobar004g1",
 									"subtitle": "",
-									"image_url": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+									"image_url": "https://placekitten.com/300/300",
 									"buttons": [
 										{
 											"type": "postback",
@@ -74,7 +74,7 @@
 								{
 									"title": "foobar004g2",
 									"subtitle": "foobar004g2sub1\nfoobar004g2sub2",
-									"image_url": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+									"image_url": "https://placekitten.com/300/300",
 									"buttons": []
 								},
 								{

--- a/cypress/fixtures/messages/image.json
+++ b/cypress/fixtures/messages/image.json
@@ -5,7 +5,7 @@
 			"_default": {
 				"_image": {
 					"type": "image",
-					"imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg"
+					"imageUrl": "https://placekitten.com/300/300"
 				}
 			},
 			"_webchat": {
@@ -13,7 +13,7 @@
 					"attachment": {
 						"type": "image",
 						"payload": {
-							"url": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg"
+							"url": "https://placekitten.com/300/300"
 						}
 					}
 				}

--- a/cypress/fixtures/messages/list.json
+++ b/cypress/fixtures/messages/list.json
@@ -12,7 +12,7 @@
 								{
 									"title": "foobar009l1",
 									"subtitle": "foobar009ls1",
-									"image_url": "https://upload.wikimedia.org/wikipedia/commons/0/06/Kitten_in_Rizal_Park%2C_Manila.jpg",
+									"image_url": "https://placekitten.com/300/300",
 									"buttons": [
 										{
 											"payload": "foobar009l1b1",

--- a/cypress/integration/messages/gallery.spec.ts
+++ b/cypress/integration/messages/gallery.spec.ts
@@ -92,5 +92,29 @@ describe("Message with Gallery", () => {
 				.get('[aria-label="Previous Item"]').click()
 				.get(".control-next").should("be.visible")
         })
-	})
+	})    
+    
+    it("should render the gallery image in a fixed aspect ratio", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy.get(".webchat-carousel-template-frame [role=img]").parent().then(element => {
+                expect(element.innerHeight()).to.equal(element.innerWidth() / 2);
+            });
+        })
+    });
+
+    it("should render the gallery image in a dynamic aspect ratio", () => {
+        cy.visitWebchat();
+        cy.initMockWebchat({
+            settings: {
+                dynamicImageAspectRatio: true
+            }
+        });
+        cy.openWebchat();
+
+        cy.withMessageFixture('gallery', () => {
+            cy.get(".webchat-carousel-template-frame img").then(element => {
+                expect(element.innerHeight()).to.equal(element.innerWidth());
+            });
+        })
+    });
 })

--- a/cypress/integration/messages/image.spec.ts
+++ b/cypress/integration/messages/image.spec.ts
@@ -29,5 +29,29 @@ describe("Message with Image", () => {
 			cy
                 .get('[aria-label="Attachment Image"]');
         })
-    })
+    });
+
+    it("should render the image in a fixed aspect ratio", () => {
+        cy.withMessageFixture('image', () => {
+            cy.get(".webchat-media-template-image > div").then(element => {
+                expect(element.innerHeight()).to.equal(element.innerWidth() * 3 / 4);
+            });
+        })
+    });
+
+    it("should render the image in a dynamic aspect ratio", () => {
+        cy.visitWebchat();
+        cy.initMockWebchat({
+            settings: {
+                dynamicImageAspectRatio: true
+            }
+        });
+        cy.openWebchat();
+
+        cy.withMessageFixture('image', () => {
+            cy.get(".webchat-media-template-image > img").then(element => {
+                expect(element.innerHeight()).to.equal(element.innerWidth());
+            });
+        })
+    });
 })

--- a/cypress/integration/messages/list.spec.ts
+++ b/cypress/integration/messages/list.spec.ts
@@ -72,6 +72,30 @@ describe("Message with List", () => {
                 .get("[role=list] [role=listitem]").contains("foobar009l2")
         })
     })
+    
+    it("should render the list header image in a fixed aspect ratio", () => {
+        cy.withMessageFixture('list', () => {
+            cy.get(".webchat-list-template-header > :first-child").parent().then(element => {
+                expect(element.innerHeight()).to.equal(element.innerWidth() / 2);
+            });
+        })
+    });
+
+    it("should render the list header image in a dynamic aspect ratio", () => {
+        cy.visitWebchat();
+        cy.initMockWebchat({
+            settings: {
+                dynamicImageAspectRatio: true
+            }
+        });
+        cy.openWebchat();
+
+        cy.withMessageFixture('list', () => {
+            cy.get(".webchat-list-template-header img").then(element => {
+                expect(element.innerHeight()).to.equal(element.innerWidth());
+            });
+        })
+    });
 
     
 })

--- a/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
@@ -195,7 +195,7 @@ export const getMessengerGenericTemplate = ({
             const image = image_url ? (
                 this.props.config.settings.dynamicImageAspectRatio ? (
                     <FlexImage
-						style={{ backgroundImage: getBackgroundImage(image_url) }}
+						src={image_url}
 						alt={image_alt_text || ""}
                     />
                 ) : (


### PR DESCRIPTION
This PR fixes an issue where images in "gallery templates" would not render properly if the `dynamicImageAspectRatio` flag is set to `true`.

I added tests to verify that the images in "image", "gallery" and "list" templates are rendered correctly according to the `dynamicImageAspectRatio` flag setting (`true` and `false`)