### PR TITLE
Feature/21499 Improve aria-label for button groups

### DIFF
--- a/cypress/integration/messages/buttons.spec.ts
+++ b/cypress/integration/messages/buttons.spec.ts
@@ -36,11 +36,21 @@ describe("Message with Buttons", () => {
                 .get(".webchat-buttons-template-root")
                 .get(".webchat-buttons-template-button")
         })
-	})
-	
-	it("group off buttons should have role 'group'", () => {
+    })
+
+    it("group off buttons should have role 'group'", () => {
         cy.withMessageFixture('buttons', () => {
-			cy.get("[role=group] .webchat-buttons-template-button").should("have.length", 4);
-        })				
+            cy.get("[role=group] .webchat-buttons-template-button").should("have.length", 4);
+        })
+    })
+
+    it("button group should have 'aria-labelledby' attribute", () => {
+        cy.withMessageFixture('buttons', () => {
+            cy.get("[role=group]")
+                .invoke("attr", "aria-labelledby")
+                .should("contain", "webchatButtonTemplateHeader")
+                .should("contain", "srOnly-webchatButtonTemplateHeader");
+            
+        });
     })
 })

--- a/cypress/integration/messages/quickReplies.spec.ts
+++ b/cypress/integration/messages/quickReplies.spec.ts
@@ -37,15 +37,34 @@ describe("Message with Quick Replies", () => {
             cy.contains("foobar003qr02").children("img").should("have.length", 1);   
             
         }, reInit);
-	})
-	
-	it("should render image alt text when present", () => {
+    })
+
+    it("should render image alt text when present", () => {
         cy.withMessageFixture('quick-replies', () => {
-			cy.contains("foobar003qr02").children("img").should("have.attr", "alt")
-				.then(alttext => {
-					expect(alttext).to.be.eq("alt text");
-				});   
+            cy.contains("foobar003qr02").children("img").should("have.attr", "alt")
+                .then(alttext => {
+                    expect(alttext).to.be.eq("alt text");
+                });   
             
         }, reInit);
     })
+
+    it("should have role 'group' when more than one quick reply button", () => {
+        cy.withMessageFixture('quick-replies', () => {
+            cy.get(".webchat-quick-reply-template-replies-container")
+                .should("have.attr", "role", "group");
+            
+        }, reInit);
+    })
+
+    it("quick reply button group should have 'aria-labelledby' attribute", () => {
+        cy.withMessageFixture('quick-replies', () => {
+            cy.get(".webchat-quick-reply-template-replies-container")
+                .invoke("attr", "aria-labelledby")
+                .should("contain", "webchatQuickReplyTemplateHeader")
+                .should("contain", "srOnly-webchatQuickReplyTemplateHeader");
+            
+        }, reInit);
+    })
+
 })

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
@@ -63,7 +63,7 @@ export const getMessengerButtonTemplate = ({
             <MessengerButtonHeader {...divProps} color={color} className="webchat-buttons-template-root">
                 {text && <Text className="webchat-buttons-template-header" dangerouslySetInnerHTML={{ __html }} id={webchatButtonTemplateTextId} />}
 
-                {/* sr-only text with total number of buttons or urls in the group*/}
+                {/* sr-only text with total number of buttons or links in the group*/}
                 {hasMoreThanOnebutton && 
                     <span className="sr-only" id={`srOnly-${webchatButtonTemplateTextId}`}>
                         With {buttons?.length} buttons or links in

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
@@ -63,7 +63,7 @@ export const getMessengerButtonTemplate = ({
             <MessengerButtonHeader {...divProps} color={color} className="webchat-buttons-template-root">
                 {text && <Text className="webchat-buttons-template-header" dangerouslySetInnerHTML={{ __html }} id={webchatButtonTemplateTextId} />}
 
-                {/* sr-only text with total number of buttons in the group*/}
+                {/* sr-only text with total number of buttons or urls in the group*/}
                 {hasMoreThanOnebutton && 
                     <span className="sr-only" id={`srOnly-${webchatButtonTemplateTextId}`}>
                         With {buttons?.length} buttons or links in

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
@@ -37,11 +37,12 @@ export const getMessengerButtonTemplate = ({
     }: IMessengerButtonTemplateProps & React.HTMLProps<HTMLDivElement>) => {
         const { text } = payload;
         const buttons = payload.buttons || [];
+        const hasMoreThanOnebutton = buttons && buttons.length > 1;
 
         const webchatButtonTemplateButtonId = useRandomId("webchatButtonTemplateButton");
         const webchatButtonTemplateTextId = useRandomId("webchatButtonTemplateHeader");
-        const buttonGroupAriaLabelledby = text ? webchatButtonTemplateTextId : undefined;
-        const a11yProps = buttons?.length > 1 ? {role: "group", "aria-labelledby": buttonGroupAriaLabelledby} : {};
+        const buttonGroupAriaLabelledby = text ? `${webchatButtonTemplateTextId} srOnly-${webchatButtonTemplateTextId}` : undefined;
+        const a11yProps = hasMoreThanOnebutton ? {role: "group", "aria-labelledby": buttonGroupAriaLabelledby} : {};
 
         useEffect(() => {
             const firstButton = document.getElementById(`${webchatButtonTemplateButtonId}-0`);
@@ -61,6 +62,14 @@ export const getMessengerButtonTemplate = ({
         return (
             <MessengerButtonHeader {...divProps} color={color} className="webchat-buttons-template-root">
                 {text && <Text className="webchat-buttons-template-header" dangerouslySetInnerHTML={{ __html }} id={webchatButtonTemplateTextId} />}
+
+                {/* sr-only text with total number of buttons in the group*/}
+                {hasMoreThanOnebutton && 
+                    <span className="sr-only" id={`srOnly-${webchatButtonTemplateTextId}`}>
+                        With {buttons?.length} buttons or links in
+                    </span>
+                }
+
                 <div {...a11yProps}>
 					{buttons.map((button, index) => (
 						<React.Fragment key={index}>

--- a/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
@@ -62,7 +62,7 @@ export const getMessengerTextWithQuickReplies = ({
         const hasMoreThanOneQuickReply = quick_replies && quick_replies.length > 1;
         const webchatQuickReplyTemplateButtonId = useRandomId("webchatQuickReplyTemplateButton");
         const webchatQuickReplyTemplateHeaderId = useRandomId("webchatQuickReplyTemplateHeader");
-        const buttonGroupAriaLabelledby = text ? webchatQuickReplyTemplateHeaderId : undefined;
+        const buttonGroupAriaLabelledby = text ? `${webchatQuickReplyTemplateHeaderId} srOnly-${webchatQuickReplyTemplateHeaderId}` : undefined;
         const a11yProps = hasMoreThanOneQuickReply ? 
             {role: "group", "aria-labelledby": buttonGroupAriaLabelledby } : {};
 
@@ -90,6 +90,13 @@ export const getMessengerTextWithQuickReplies = ({
                     messageColor={messageColor}
                     messageDirection={messageDirection}
                 ></BorderBubble>
+
+                {/* sr-only text for quick reply groups */}
+                {hasMoreThanOneQuickReply && 
+                    <span className="sr-only" id={`srOnly-${webchatQuickReplyTemplateHeaderId}`}>
+                        With {quick_replies?.length} items.
+                    </span>
+                }
 
                 {hasQuickReplies && (
                     <QuickReplies className="webchat-quick-reply-template-replies-container" {...a11yProps}>

--- a/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
@@ -91,10 +91,10 @@ export const getMessengerTextWithQuickReplies = ({
                     messageDirection={messageDirection}
                 ></BorderBubble>
 
-                {/* sr-only text for quick reply groups */}
+                {/* sr-only text with total number of quick replies in the group*/}
                 {hasMoreThanOneQuickReply && 
                     <span className="sr-only" id={`srOnly-${webchatQuickReplyTemplateHeaderId}`}>
-                        With {quick_replies?.length} items.
+                        With {quick_replies?.length} buttons in
                     </span>
                 }
 


### PR DESCRIPTION
This PR adds total number of buttons / links in a button or quick reply, to the group's aria-label.

Success criteria:
- When there is more than one button/link in a quick reply or text with buttons group, you should hear the screen reader announcing total number of buttons/ links.
- When there is only one button, there should be no change in the behavior.
- No layout regressions

How to test:
- Create a flow that has say nodes with output types Text with Buttons and Text with quick replies. Include more than one buttons or links. Alternatively, you can use this endpoint [https://endpoint-dev-v4.cognigy.ai/39d8ff845d0469d85be1c6d9b01cb435803cfede1b7dfb782e74f9343ec27fc7](https://endpoint-dev-v4.cognigy.ai/39d8ff845d0469d85be1c6d9b01cb435803cfede1b7dfb782e74f9343ec27fc7)
- Chat with the bot and use the screen reader while navigating through the messages and test the above success criteria
