### PR TITLE
bug/21904 get content from pointer

### DIFF
--- a/cypress/fixtures/messages/intent-default-reply-with-quick-replies.json
+++ b/cypress/fixtures/messages/intent-default-reply-with-quick-replies.json
@@ -1,0 +1,112 @@
+{
+	"text": null,
+	"data": {
+		"_cognigy": {
+			"_webchat": {
+				"_pointer": "quick-replies",
+				"quick-replies": {
+					"message": {
+						"text": "Regarding Insurance I have the following topics.",
+						"quick_replies": [
+							{
+								"content_type": "text",
+								"title": "Insurance overview",
+								"payload": "Insurance overview"
+							},
+							{
+								"content_type": "text",
+								"title": "Hospitalization claim",
+								"payload": "Hospitalization claim"
+							},
+							{
+								"content_type": "text",
+								"title": "Travel insurance claim ",
+								"payload": "Travel insurance claim "
+							},
+							{
+								"content_type": "text",
+								"title": "Specialist Claim",
+								"payload": "Specialist Claim"
+							},
+							{
+								"content_type": "text",
+								"title": "List of panel doctor/specialist clinic",
+								"payload": "List of panel doctor/specialist clinic"
+							},
+							{
+								"content_type": "text",
+								"title": "A&E Claim",
+								"payload": "A&E Claim"
+							},
+							{
+								"content_type": "text",
+								"title": "Supreme (insurance) card",
+								"payload": "Supreme (insurance) card"
+							},
+							{
+								"content_type": "text",
+								"title": "Non-panel clinic",
+								"payload": "Non-panel clinic"
+							}
+						]
+					}
+				}
+			}
+		},
+		"_data": {
+			"_cognigy": {
+				"_webchat": {
+					"message": {
+						"text": "Regarding Insurance I have the following topics.",
+						"quick_replies": [
+							{
+								"content_type": "text",
+								"title": "Insurance overview",
+								"payload": "Insurance overview"
+							},
+							{
+								"content_type": "text",
+								"title": "Hospitalization claim",
+								"payload": "Hospitalization claim"
+							},
+							{
+								"content_type": "text",
+								"title": "Travel insurance claim ",
+								"payload": "Travel insurance claim "
+							},
+							{
+								"content_type": "text",
+								"title": "Specialist Claim",
+								"payload": "Specialist Claim"
+							},
+							{
+								"content_type": "text",
+								"title": "List of panel doctor/specialist clinic",
+								"payload": "List of panel doctor/specialist clinic"
+							},
+							{
+								"content_type": "text",
+								"title": "A&E Claim",
+								"payload": "A&E Claim"
+							},
+							{
+								"content_type": "text",
+								"title": "Supreme (insurance) card",
+								"payload": "Supreme (insurance) card"
+							},
+							{
+								"content_type": "text",
+								"title": "Non-panel clinic",
+								"payload": "Non-panel clinic"
+							}
+						]
+					}
+				}
+			}
+		}
+	},
+	"traceId": "endpoint-realtimeClient-51c02efc-32b7-40ca-b413-6eacd50c28fb",
+	"disableSensitiveLogging": false,
+	"source": "bot",
+	"avatarUrl": ""
+}

--- a/cypress/integration/messages/quickReplies.spec.ts
+++ b/cypress/integration/messages/quickReplies.spec.ts
@@ -48,4 +48,37 @@ describe("Message with Quick Replies", () => {
             
         }, reInit);
     })
+
+    it("should render message with quick replies stored behind a pointer", () => {
+        cy.withMessageFixture('intent-default-reply-with-quick-replies', () => {
+            cy
+                .contains("Regarding Insurance I have the following topics.");
+            cy
+                .contains("Insurance overview")
+                cy
+                .contains("Hospitalization claim")
+                cy
+                .contains("Travel insurance claim")
+                cy
+                .contains("Specialist Claim")
+                cy
+                .contains("List of panel doctor/specialist clinic")
+                cy
+                .contains("A&E Claim")
+                cy
+                .contains("Supreme (insurance) card")
+                cy
+                .contains("Non-panel clinic")
+        }, reInit)
+    })
+
+    it("should click the quick reply stored behind a pointer and post as user message", () => {
+        cy.withMessageFixture('intent-default-reply-with-quick-replies', () => {
+            cy
+                .contains("Insurance overview").click()
+            cy
+                .get(".regular-message.user")
+                .contains("Insurance overview");
+        }, reInit);
+    })
 })

--- a/src/plugins/messenger/helpers.ts
+++ b/src/plugins/messenger/helpers.ts
@@ -1,0 +1,22 @@
+type TPointedObject =
+    | {
+        [key: string]: any;
+    }
+    | {
+        _pointer?: string;
+    };
+
+export const transformPointers = (obj: TPointedObject) => {
+    if (Array.isArray(obj) || typeof obj !== "object" || obj === null) return obj;
+
+    // eslint-disable-next-line no-prototype-builtins
+    if (obj.hasOwnProperty("_pointer")) {
+        obj = obj[obj["_pointer"]];
+        return transformPointers(obj);
+    }
+
+    Object.keys(obj).forEach(key => {
+        obj[key] = transformPointers(obj[key]);
+    });
+    return obj;
+};

--- a/src/plugins/messenger/index.tsx
+++ b/src/plugins/messenger/index.tsx
@@ -8,6 +8,7 @@ import { IMessage } from "../../common/interfaces/message";
 import { IWebchatConfig } from "../../common/interfaces/webchat-config";
 import { sanitizeUrl } from "@braintree/sanitize-url";
 import { IFBMURLButton } from "./MessengerPreview/interfaces/Button.interface";
+import { transformPointers } from "./helpers";
 
 const getMessengerPayload = (message: IMessage, config: IWebchatConfig) => {
     const cognigyData = message.data?._cognigy;
@@ -22,10 +23,10 @@ const getMessengerPayload = (message: IMessage, config: IWebchatConfig) => {
             return _facebook;
         }
 
-        return _webchat;
+        return transformPointers(_webchat);
     }
 
-    return _webchat || _facebook;
+    return transformPointers(_webchat) || _facebook;
 }
 
 const isMessengerPayload = (message: IMessage, config: IWebchatConfig) => {


### PR DESCRIPTION
This PR fixes a bug from a customer causing the Webchat Widget to crash if quick replies are hidden behind a pointer which might happen if an intent has a default reply with quick replies.

How to test:
1. Create a flow with a say node, add the fixture data object to the data payload and try it with a previous version of the webchat widget, it should break.
2. Try it with this version, it should work.

Added tests as well