### PR TITLE
Fix incomplete submission of AdaptiveCard form payloads

### DIFF
--- a/cypress/integration/messages/adaptivecard.spec.ts
+++ b/cypress/integration/messages/adaptivecard.spec.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../support/index.d.ts" />
-
 describe("Message with AdaptiveCard", () => {
     beforeEach(() => {
         cy
@@ -24,10 +22,12 @@ describe("Message with AdaptiveCard", () => {
             cy.contains("OK").click();
 
             cy.getMessageFromHistory({ data: {
-                "adaptivecards": {
-                    "FoodChoice": "Steak"
+                adaptivecards: {
+                    FoodChoice: "Steak",
+                    SteakTemp: "medium-rare",
+                    SteakOther: "Tender, please!"
                 }
-            }})
+            }});
         });
     });
 });

--- a/src/plugins/adaptivecards/components/Adaptivecard.tsx
+++ b/src/plugins/adaptivecards/components/Adaptivecard.tsx
@@ -1,7 +1,7 @@
-import React, { memo, useCallback, useMemo, useState } from 'react';
+import React, { memo, useCallback} from 'react';
 
 import { FC, useEffect, useRef } from "react";
-import { Action, AdaptiveCard as MSAdaptiveCard, CardElement, HostConfig, OpenUrlAction, ShowCardAction, SubmitAction } from 'adaptivecards';
+import { Action, AdaptiveCard as MSAdaptiveCard, HostConfig } from 'adaptivecards';
 
 interface IAdaptiveCardProps {
     hostConfig?: Partial<HostConfig>;
@@ -22,7 +22,7 @@ const AdaptiveCard: FC<IAdaptiveCardProps> = (props) => {
     );
     const executeAction = useCallback(
         (a: Action) => {
-            onExecuteAction?.(a.toJSON());
+            onExecuteAction?.(a);
         },
         [onExecuteAction]
     );

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -3,7 +3,6 @@ import AdaptiveCard from './components/Adaptivecard'
 import { registerMessagePlugin } from '../helper';
 
 import { updateAdaptiveCardCSSCheaply } from './styles';
-import { Action, SubmitAction } from 'adaptivecards';
 
 const AdaptiveCards = (props) => {
     const { theme, onSendMessage, message } = props;
@@ -15,10 +14,10 @@ const AdaptiveCards = (props) => {
     const cardPayload = message.data._plugin.payload;
 
     const onExecuteAction = useCallback((action) => {
-        switch (action.type) {
+        switch (action._propertyBag?.type) {
             case "Action.Submit": {
                 onSendMessage("", {
-                    adaptivecards: action.data
+                    adaptivecards: action._processedData
                 });
 
                 return;


### PR DESCRIPTION
This PR fixes an issue where submission payloads from adaptivecards via the "native adaptivecard" plugin would be incomplete.
I checked the message payload from the "old adaptivecards" plugin, modified the test to match that format and then fixed the issue.