### PR TITLE
Add e2e tests for the "rating" functionality

### DIFF
--- a/cypress/integration/rating.spec.ts
+++ b/cypress/integration/rating.spec.ts
@@ -1,0 +1,214 @@
+describe("Rating", () => {
+    beforeEach(() => {
+        cy.visitWebchat();
+    })
+
+    it("header button shouldn't show up by default", () => {
+        cy.initMockWebchat();
+        cy.openWebchat();
+
+        cy.contains("Cognigy Webchat").should("be.visible");
+        cy.get('[aria-label="Rate your chat"]').should('not.exist');
+    });
+
+    it("dialog should show up if requested", () => {
+        cy.initMockWebchat();
+        cy.openWebchat();
+
+        cy.receiveMessage(
+            "", 
+            {
+                _plugin: {
+                  type: "request-rating",
+                  data: {
+                    ratingTitleText: "rating title",
+                    ratingCommentText: "rating text"
+                  }
+                }
+              }, 
+            "bot"
+        );
+
+        cy.contains("rating title").should("be.visible");
+        cy.contains("rating text").should("be.visible");
+    });
+
+    it("submits a positive rating on request", () => {
+        cy.initMockWebchat();
+        cy.openWebchat();
+
+        cy.receiveMessage(
+            "", 
+            {
+                _plugin: {
+                  type: "request-rating",
+                  data: {
+                    ratingTitleText: "rating title",
+                    ratingCommentText: "rating text"
+                  }
+                }
+              }, 
+            "bot"
+        );
+
+        cy.get('[aria-label="Thumbs Up"]').click();
+        cy.get('[data-test="rating-input"]').type("I liked it");
+        cy.get('[aria-label="Send Rating and Comment"]').click();
+
+        cy.getMessageFromHistory({
+            data: {
+                _cognigy: {
+                    controlCommands: [
+                        {
+                            type: "setRating",
+                            parameters: {
+                                rating: 1,
+                                comment: "I liked it"
+                            }
+                        }
+                    ]
+                }
+            }
+        })
+    });
+
+    it("submits a negative rating on request", () => {
+        cy.initMockWebchat();
+        cy.openWebchat();
+
+        cy.receiveMessage(
+            "", 
+            {
+                _plugin: {
+                  type: "request-rating",
+                  data: {
+                    ratingTitleText: "rating title",
+                    ratingCommentText: "rating text"
+                  }
+                }
+              }, 
+            "bot"
+        );
+
+        cy.get('[aria-label="Thumbs Down"]').click();
+        cy.get('[data-test="rating-input"]').type("I didnt like it");
+        cy.get('[aria-label="Send Rating and Comment"]').click();
+
+        cy.getMessageFromHistory({
+            data: {
+                _cognigy: {
+                    controlCommands: [
+                        {
+                            type: "setRating",
+                            parameters: {
+                                rating: -1,
+                                comment: "I didnt like it"
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+    });
+
+    it("shows the rating button in the header if rating is set to always", () => {
+        cy.initMockWebchat({
+            settings: {
+                enableRating: "always"
+            }
+        });
+        cy.openWebchat();
+
+        cy.get("#webchatHeaderOpenRatingDialogButton").should("be.visible");
+    });
+
+    it("shows a dialog with default texts when clicking the rating button", () => {
+        cy.initMockWebchat({
+            settings: {
+                enableRating: "always"
+            }
+        });
+        cy.openWebchat();
+
+        cy.get("#webchatHeaderOpenRatingDialogButton").click();
+
+        cy.contains("Please rate your chat experience").should("be.visible");
+        cy.contains("Feel free to leave a comment.").should("be.visible");
+    });
+
+    it("submits a rating after clicking the rating button", () => {
+        cy.initMockWebchat({
+            settings: {
+                enableRating: "always"
+            }
+        });
+        cy.openWebchat();
+
+        cy.get("#webchatHeaderOpenRatingDialogButton").click();
+
+        cy.get('[aria-label="Thumbs Up"]').click();
+        cy.get('[data-test="rating-input"]').type("I loved it");
+        cy.get('[aria-label="Send Rating and Comment"]').click();
+
+        cy.getMessageFromHistory({
+            data: {
+                _cognigy: {
+                    controlCommands: [
+                        {
+                            type: "setRating",
+                            parameters: {
+                                rating: 1,
+                                comment: "I loved it"
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+    });
+
+    it("shows the rating button in the header if rating is set to once", () => {
+        cy.initMockWebchat({
+            settings: {
+                enableRating: "once"
+            }
+        });
+        cy.openWebchat();
+
+        cy.get("#webchatHeaderOpenRatingDialogButton").should("be.visible");
+    });
+
+    it("can't submit another rating when it was set to once", () => {
+        cy.initMockWebchat({
+            settings: {
+                enableRating: "once"
+            }
+        });
+        cy.openWebchat();
+
+        cy.get("#webchatHeaderOpenRatingDialogButton").click();
+
+        cy.get('[aria-label="Thumbs Up"]').click();
+        cy.get('[data-test="rating-input"]').type("I loved it");
+        cy.get('[aria-label="Send Rating and Comment"]').click();
+
+        cy.getMessageFromHistory({
+            data: {
+                _cognigy: {
+                    controlCommands: [
+                        {
+                            type: "setRating",
+                            parameters: {
+                                rating: 1,
+                                comment: "I loved it"
+                            }
+                        }
+                    ]
+                }
+            }
+        });
+
+        cy.get("#webchatHeaderOpenRatingDialogButton").should("not.exist");
+    });
+})
+

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -82,14 +82,11 @@ Cypress.Commands.add('openWebchat', () => {
 
 Cypress.Commands.add('receiveMessage', (text?: string, data?: Object, source: 'bot' | 'agent' = 'bot') => {
     cy.get('@webchat').then(webchat => {
-        (webchat as any).store.dispatch({
-            type: 'RECEIVE_MESSAGE',
-            message: {
-                id: `fakemessage-${Math.random()}-${Date.now()}`,
-                text,
-                data,
-                source
-            }
+        (webchat as any)._handleOutput({
+            id: `fakemessage-${Math.random()}-${Date.now()}`,
+            text,
+            data,
+            source
         });
     });
 

--- a/src/webchat-ui/components/presentational/RatingDialog.tsx
+++ b/src/webchat-ui/components/presentational/RatingDialog.tsx
@@ -267,6 +267,7 @@ class RatingDialog extends React.PureComponent<React.HTMLProps<HTMLDivElement> &
                     </RatingDialogMain>
                     <RatingToolbar>
                         <RatingInput
+                            data-test="rating-input"
                             type="text"
                             value={ratingText}
                             onChange={this.handleSetRatingText}

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -15,6 +15,7 @@ import { getEndpointBaseUrl, getEndpointUrlToken } from '../helper/endpoint';
 import { IWebchatSettings } from '../../common/interfaces/webchat-config';
 import { Options } from '@cognigy/socket-client/lib/interfaces/options';
 import { updateSettings } from '../store/config/config-reducer';
+import { createOutputHandler } from '../store/messages/message-handler';
 
 export interface WebchatProps extends FromProps {
     url: string;
@@ -27,6 +28,7 @@ export class Webchat extends React.PureComponent<WebchatProps> {
     public store: Store<StoreState>;
     public client: SocketClient;
     public analytics: EventEmitter = new EventEmitter();
+    public _handleOutput: (output: unknown) => void;
 
 
     // component lifecycle methods
@@ -47,6 +49,8 @@ export class Webchat extends React.PureComponent<WebchatProps> {
 
         const store = createWebchatStore(this, url, settings);
         this.store = store;
+
+        this._handleOutput = createOutputHandler(this.store);
     }
 
     componentDidMount() {

--- a/src/webchat/store/messages/message-handler.ts
+++ b/src/webchat/store/messages/message-handler.ts
@@ -13,42 +13,45 @@ export const receiveMessage = (message: IMessage, options: Partial<ISendMessageO
 });
 export type ReceiveMessageAction = ReturnType<typeof receiveMessage>;
 
+export const createOutputHandler = (store: Store) => (output) => {
+    // handle custom webchat actions
+    if (output.data && output.data._webchat) {
+        const { agentAvatarOverrideUrl, botAvatarOverrideUrl, userAvatarOverrideUrl } = output.data._webchat;
+
+        if (agentAvatarOverrideUrl !== undefined) {
+            store.dispatch(setAgentAvatarOverrideUrl(agentAvatarOverrideUrl));
+        }
+
+        if (botAvatarOverrideUrl !== undefined) {
+            store.dispatch(setBotAvatarOverrideUrl(botAvatarOverrideUrl));
+        }
+
+        if (userAvatarOverrideUrl !== undefined) {
+            store.dispatch(setUserAvatarOverrideUrl(userAvatarOverrideUrl))
+        }
+    }
+
+    // handle custom plugin actions
+    if (output.data && output.data._plugin) {
+        const { type, data } = output.data._plugin;
+
+        if (type === "request-rating") {
+            if (data && data.ratingCommentText) {
+                store.dispatch(setCustomRatingCommentText(data.ratingCommentText));
+            }
+
+            if (data && data.ratingTitleText) {
+                store.dispatch(setCustomRatingTitle(data.ratingTitleText));
+            }
+
+            store.dispatch(showRatingDialog(true));
+        }
+    }
+
+    store.dispatch(setTyping("remove"));
+    store.dispatch(receiveMessage(output));
+} 
+
 export const registerMessageHandler = (store: Store, client: SocketClient) => {
-    client.on('output', output => {
-        // handle custom webchat actions
-        if (output.data && output.data._webchat) {
-            const { agentAvatarOverrideUrl, botAvatarOverrideUrl, userAvatarOverrideUrl } = output.data._webchat;
-
-            if (agentAvatarOverrideUrl !== undefined) {
-                store.dispatch(setAgentAvatarOverrideUrl(agentAvatarOverrideUrl));
-            }
-
-            if (botAvatarOverrideUrl !== undefined) {
-                store.dispatch(setBotAvatarOverrideUrl(botAvatarOverrideUrl));
-            }
-
-            if (userAvatarOverrideUrl !== undefined) {
-                store.dispatch(setUserAvatarOverrideUrl(userAvatarOverrideUrl))
-            }
-        }
-
-        // handle custom plugin actions
-        if (output.data && output.data._plugin) {
-            const { type, data } = output.data._plugin;
-
-            if (type === "request-rating") {
-                if (data && data.ratingCommentText) {
-                    store.dispatch(setCustomRatingCommentText(data.ratingCommentText));
-                };
-                if (data && data.ratingTitleText) {
-                    store.dispatch(setCustomRatingTitle(data.ratingTitleText));
-                };
-
-                store.dispatch(showRatingDialog(true));
-            };
-        }
-
-        store.dispatch(setTyping("remove"));
-        store.dispatch(receiveMessage(output));
-    });
+    client.on('output', createOutputHandler(store));
 }


### PR DESCRIPTION
This PR adds automatic tests for the "rating" functionality.
Since we're handling raw socket events outside of `RECEIVE_MESSAGE` for that, I modified the `messageHandler.ts` code to expose a `createOutputHandler` function and expose an instance of that via `webchat._handleOutput`.

As this is an "internal" API, we won't document it.

The `cy.receiveMessage` method now uses `webchat._handleOutput` instead of `webchat.store.dispatch(/* RECEIVE_MESSAGE EVENT PAYLOAD */);

I wasn't able to find an issue with the "rating" functionality (which was the original goal to fix in this PR).