### PR TITLE
Add adaptive cards plugin to message-renderer

### DIFF
--- a/cypress/integration/message-renderer/adaptiveCard.spec.ts
+++ b/cypress/integration/message-renderer/adaptiveCard.spec.ts
@@ -1,0 +1,135 @@
+describe('Message Renderer Theme', () => {
+    before(() => {
+        cy.visitMessageRenderer();
+    });
+
+    const adaptiveCard = {
+        "_plugin": {
+            "type": "adaptivecards",
+            "payload": {
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "type": "AdaptiveCard",
+                "version": "1.0",
+                "body": [
+                  {
+                    "type": "Container",
+                    "items": [
+                      {
+                        "type": "TextBlock",
+                        "text": "Publish Adaptive Card schema",
+                        "weight": "bolder",
+                        "size": "medium"
+                      },
+                      {
+                        "type": "ColumnSet",
+                        "columns": [
+                          {
+                            "type": "Column",
+                            "width": "auto",
+                            "items": [
+                              {
+                                "type": "Image",
+                                "url": "https://pbs.twimg.com/profile_images/3647943215/d7f12830b3c17a5a9e4afcc370e3a37e_400x400.jpeg",
+                                "altText": "Matt Hidinger",
+                                "size": "small",
+                                "style": "person"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "Column",
+                            "width": "stretch",
+                            "items": [
+                              {
+                                "type": "TextBlock",
+                                "text": "Matt Hidinger",
+                                "weight": "bolder",
+                                "wrap": true
+                              },
+                              {
+                                "type": "TextBlock",
+                                "spacing": "none",
+                                "text": "Created {{DATE(2017-02-14T06:08:39Z, SHORT)}}",
+                                "isSubtle": true,
+                                "wrap": true
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Container",
+                    "items": [
+                      {
+                        "type": "TextBlock",
+                        "text": "Now that we have defined the main rules and features of the format, we need to produce a schema and publish it to GitHub. The schema will be the starting point of our reference documentation.",
+                        "wrap": true
+                      },
+                      {
+                        "type": "FactSet",
+                        "facts": [
+                          {
+                            "title": "Board:",
+                            "value": "Adaptive Card"
+                          },
+                          {
+                            "title": "List:",
+                            "value": "Backlog"
+                          },
+                          {
+                            "title": "Assigned to:",
+                            "value": "Matt Hidinger"
+                          },
+                          {
+                            "title": "Due date:",
+                            "value": "Not set"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "actions": [
+                  {
+                    "type": "Action.ShowCard",
+                    "title": "Comment",
+                    "card": {
+                      "type": "AdaptiveCard",
+                      "body": [
+                        {
+                          "type": "Input.Text",
+                          "id": "comment",
+                          "isMultiline": true,
+                          "placeholder": "Enter your comment"
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": "Action.Submit",
+                          "title": "OK"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }              
+        }
+    }
+      
+
+    it('uses an alternate theme for messages when providing colorScheme setting', () => {
+        cy.renderMessage(null, adaptiveCard, 'bot', {
+            settings: {
+                colorScheme: "#FFAABB"
+            }
+        });
+
+        cy.get('.adaptivecard-wrapper').should('exist');
+        cy.get('.ac-adaptiveCard').should('exist');
+        cy.get('.ac-image').should("be.visible");
+        cy.get('.ac-textBlock').contains('Publish Adaptive Card schema');
+        cy.get('.ac-actionSet').should('exist').children('button').contains('Comment');
+    });
+});

--- a/src/message-renderer/embed.ts
+++ b/src/message-renderer/embed.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import { MessageRenderer } from ".";
-import "../plugins/messenger"
+import "../plugins/messenger";
+import "../plugins/adaptivecards";
 // @ts-ignore
 window.MessageRenderer = MessageRenderer;
 


### PR DESCRIPTION
This PR is adding an adaptive cards plugin to the message-renderer to enable the rendering of adaptive cards.

## How to test:
1. Start server for testing with `npm run cypress:serve`
2. Start the specific test for adaptive cards rendering in another terminal instance: `npm run cypress:open` start the message-renderer/adaptiveCard.spec.ts test to take a look yourself that the adaptive cards is rendered.

3. Run all tests to make sure everything else is also intact with `npm run test:cypress:`