### PR TITLE
Feature/26013 focus trap for non popover webchat

### DIFF
--- a/cypress/integration/chatLog.spec.ts
+++ b/cypress/integration/chatLog.spec.ts
@@ -3,8 +3,14 @@ describe('Chat Log', () => {
         cy.visitWebchat().initMockWebchat().openWebchat();;
     });
 
-    it('is chat log region focusable', () => {
-        cy.get('#webchatChatHistoryWrapperLiveLogPanel').should("have.attr", "tabindex", 0);
+    it('is chat log region non-focusable when no messages in log', () => {
+        cy.get('#webchatChatHistoryWrapperLiveLogPanel').should("have.attr", "tabindex", -1);
+    });
+
+    it('is chat log region focusable when there are messages in log', () => {
+        cy.withMessageFixture('text', () => {
+            cy.get('#webchatChatHistoryWrapperLiveLogPanel').should("have.attr", "tabindex", 0);
+        })       
     });
 
     it('is chat log region accessible', () => {

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -332,6 +332,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         );
     }
 
+    // Handler for SHIFT+TAB Navigation in webchat
     handleReverseTabNavigation = () => {
         const webchatHistoryPanel = document.getElementById("webchatChatHistoryWrapperLiveLogPanel");
         const textMessageInput = document.getElementById("webchatInputMessageInputInTextMode");
@@ -348,6 +349,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         }
     }
 
+    // Handler for TAB Navigation in webchat
     handleTabNavigation = (event, hasRatingButton) => {
         if (hasRatingButton) {
             event.preventDefault();
@@ -360,6 +362,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         }
     }
 
+    // Key down handler
     handleKeydown = (event) => {
         const { enableFocusTrap, enableRating } = this.props.config.settings;
         const { open, hasGivenRating } = this.props;

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -397,8 +397,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             }
             /**
              * If chat toggle button is available and focused or if chat toggle button is not available and 
-             * text input or get-started button is focused, the focus moves to some element 
-             * outside chat window on 'Tab' navigation.
+             * text input (when send message btn is disabled) or send button or get-started button is focused, 
+             * the focus moves to some element outside chat window on 'Tab' navigation.
              * 
              * In order to trap focus, move the focus back to the chat history panel(if rating not enabled) or
              * thumbs up/down rating button (if rating enabled) on Tab navigation.
@@ -409,6 +409,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             const chatToggleButton = this.chatToggleButtonRef?.current;
             const textMessageInput = document.getElementById("webchatInputMessageInputInTextMode");
             const getStartedButton = document.getElementById("webchatGetStartedButton");
+            const sendMessageButton = document.getElementById("webchatInputMessageSendMessageButton") as HTMLButtonElement | null;
+            const isSendButtonDisabled = sendMessageButton?.disabled;
 
             if (chatToggleButton) {
                 if (target === chatToggleButton) {
@@ -419,7 +421,12 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                         this.handleTabNavigation(event, hasRatingButton);
                     }
                 }
-            } else if ((target === textMessageInput || target === getStartedButton) && tabKeyPress) {
+            } else if (
+                ((isSendButtonDisabled && target === textMessageInput) || 
+                target === sendMessageButton || 
+                target === getStartedButton) && 
+                tabKeyPress) 
+            {
                 this.handleTabNavigation(event, hasRatingButton);
             }
         }
@@ -553,7 +560,6 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                                                 </UnreadMessagePreview>
                                             )
                                         }
-
                                         <FAB
                                             data-cognigy-webchat-toggle
                                             onClick={onToggle}

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -349,7 +349,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
     }
 
     handleTabNavigation = (event, hasRatingButton) => {
-        if(hasRatingButton) {
+        if (hasRatingButton) {
             event.preventDefault();
             const webchatHeaderRatingButton = document.getElementById("webchatHeaderOpenRatingDialogButton");
             webchatHeaderRatingButton?.focus();
@@ -363,13 +363,17 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
     handleKeydown = (event) => {
         const { enableFocusTrap, enableRating } = this.props.config.settings;
         const { open, hasGivenRating } = this.props;
+        const { target, key, shiftKey } = event;
+        const shiftTabKeyPress = shiftKey && key === "Tab";
+        const tabKeyPress = !shiftKey && key === "Tab";        
 
         const hasRatingButton = enableRating && (enableRating === "always" || (enableRating === "once" && hasGivenRating === false));
 
         if (enableFocusTrap && open) {
             /**
              * If the current focused element is the close button(if rating not enabled) or 
-             * rating thumbs up/down button (if rating enabled) in chat header, the focus moves
+             * rating thumbs up/down button (if rating enabled) in chat header or 
+             * chat history panel (if neither rating nor close button is present), the focus moves
              * to some element outside chat window on 'Shift + Tab' navigation.
              * 
              * In order to trap focus, move focus back to the first element (from the bottom) within chat window 
@@ -377,22 +381,23 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
              * 
              */
             const closeButton = this.closeButtonInHeaderRef?.current;
-        	const isCloseButtonAsTarget = event.target === closeButton;
-            const isRatingButtonAsTarget = event.target ===  this.ratingButtonInHeaderRef?.current;
-            const isHistoryPanelAsTarget = event.target === document.getElementById("webchatChatHistoryWrapperLiveLogPanel");
+        	const isCloseButtonAsTarget = target === closeButton;
+            const isRatingButtonAsTarget = target ===  this.ratingButtonInHeaderRef?.current;
+            const isHistoryPanelAsTarget = target === document.getElementById("webchatChatHistoryWrapperLiveLogPanel");
    
             if (
                 (!closeButton && !hasRatingButton && isHistoryPanelAsTarget) ||
                 (closeButton && !hasRatingButton && isCloseButtonAsTarget) ||
                 (hasRatingButton && isRatingButtonAsTarget)
             ) {
-                if (event.shiftKey && event.key === "Tab") {
+                if (shiftTabKeyPress) {
                     event.preventDefault();
                     this.handleReverseTabNavigation();
                 }
             }
             /**
-             * If the current focused element is the chat toggle button, the focus moves to some element 
+             * If chat toggle button is available and focused or if chat toggle button is not available and 
+             * text input or get-started button is focused, the focus moves to some element 
              * outside chat window on 'Tab' navigation.
              * 
              * In order to trap focus, move the focus back to the chat history panel(if rating not enabled) or
@@ -406,15 +411,15 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             const getStartedButton = document.getElementById("webchatGetStartedButton");
 
             if (chatToggleButton) {
-                if(event.target === chatToggleButton) {
-                    if (event.shiftKey && event.key === "Tab") {
+                if (target === chatToggleButton) {
+                    if (shiftTabKeyPress) {
                         event.preventDefault();
                         this.handleReverseTabNavigation();
-                    } else if (event.key === "Tab") {
+                    } else if (tabKeyPress) {
                         this.handleTabNavigation(event, hasRatingButton);
                     }
                 }
-            } else if((event.target === textMessageInput || event.target === getStartedButton) && !event.shiftKey && event.key === "Tab") {
+            } else if ((target === textMessageInput || target === getStartedButton) && tabKeyPress) {
                 this.handleTabNavigation(event, hasRatingButton);
             }
         }

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -537,6 +537,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             config,
             hasGivenRating,
             onShowRatingDialog,
+            messages
         } = this.props;
 
         const { enableRating } = config.settings;
@@ -560,6 +561,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                     disableBranding={config.settings.disableBranding}
                     ref={this.history as any}
                     className="webchat-chat-history"
+                    tabIndex={messages?.length === 0 ? -1 : 0} // When no messages, remove chat history from tab order
                 >
                     <h2 className="sr-only" id="webchatChatHistoryHeading">Chat History</h2>
                     {this.renderHistory()}

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -126,6 +126,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
     chatToggleButtonRef: React.RefObject<HTMLButtonElement>;
     closeButtonInHeaderRef: React.RefObject<HTMLButtonElement>;
     ratingButtonInHeaderRef: React.RefObject<HTMLButtonElement>;
+    webchatWindowRef: React.RefObject<HTMLDivElement>;
 
     private unreadTitleIndicatorInterval: ReturnType<typeof setInterval> | null = null;
     private originalTitle: string = window.document.title;
@@ -140,6 +141,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         this.chatToggleButtonRef = React.createRef();
         this.closeButtonInHeaderRef = React.createRef();
         this.ratingButtonInHeaderRef = React.createRef();
+        this.webchatWindowRef = React.createRef();
     }
 
     static getDerivedStateFromProps(props: WebchatUIProps, state: WebchatUIState): WebchatUIState | null {
@@ -342,8 +344,9 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         const tabKeyPress = !shiftKey && key === "Tab";        
 
         if (enableFocusTrap && open) {
-            // Get the first and last focusable elements within the list and add focus
-            const { firstFocusable, lastFocusable } = getKeyboardFocusableElements();
+            // Get the first and last focusable elements within the webchat window and add focus
+            const webchatWindowEl = this.webchatWindowRef?.current as HTMLElement;
+            const { firstFocusable, lastFocusable } = getKeyboardFocusableElements(webchatWindowEl);
             const chatToggleButton = this.chatToggleButtonRef?.current;   
 
             /**
@@ -465,6 +468,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                                         {...webchatRootProps}
                                         className="webchat"
                                         id="webchatWindow"
+                                        ref={this.webchatWindowRef}
                                     >
                                         {!fullscreenMessage
                                             ? this.renderRegularLayout()

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -348,11 +348,23 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         }
     }
 
+    handleTabNavigation = (event, hasRatingButton) => {
+        if(hasRatingButton) {
+            event.preventDefault();
+            const webchatHeaderRatingButton = document.getElementById("webchatHeaderOpenRatingDialogButton");
+            webchatHeaderRatingButton?.focus();
+        } else {
+            event.preventDefault();
+            const webchatHistoryPanel = document.getElementById("webchatChatHistoryWrapperLiveLogPanel");
+            webchatHistoryPanel?.focus();
+        }
+    }
+
     handleKeydown = (event) => {
         const { enableFocusTrap, enableRating } = this.props.config.settings;
         const { open, hasGivenRating } = this.props;
 
-        const showRatingButton = enableRating && (enableRating === "always" || (enableRating === "once" && hasGivenRating === false));
+        const hasRatingButton = enableRating && (enableRating === "always" || (enableRating === "once" && hasGivenRating === false));
 
         if (enableFocusTrap && open) {
             /**
@@ -370,9 +382,9 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             const isHistoryPanelAsTarget = event.target === document.getElementById("webchatChatHistoryWrapperLiveLogPanel");
    
             if (
-                (!closeButton && !showRatingButton && isHistoryPanelAsTarget) ||
-                (closeButton && !showRatingButton && isCloseButtonAsTarget) ||
-                (showRatingButton && isRatingButtonAsTarget)
+                (!closeButton && !hasRatingButton && isHistoryPanelAsTarget) ||
+                (closeButton && !hasRatingButton && isCloseButtonAsTarget) ||
+                (hasRatingButton && isRatingButtonAsTarget)
             ) {
                 if (event.shiftKey && event.key === "Tab") {
                     event.preventDefault();
@@ -389,22 +401,21 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
              * On Shift + Tab navigation, the focus should move to the first element (from the bottom) within chat window.
              * 
              */
-            if (event.target === this.chatToggleButtonRef?.current) {
-                if (event.shiftKey && event.key === "Tab") {
-                    event.preventDefault();
-                    this.handleReverseTabNavigation();
-                } else if (event.key === "Tab") {
-                    const hasRatingButton = enableRating && (enableRating === "always" || (enableRating === "once" && this.props.hasGivenRating === false));
-                    if(hasRatingButton) {
+            const chatToggleButton = this.chatToggleButtonRef?.current;
+            const textMessageInput = document.getElementById("webchatInputMessageInputInTextMode");
+            const getStartedButton = document.getElementById("webchatGetStartedButton");
+
+            if (chatToggleButton) {
+                if(event.target === chatToggleButton) {
+                    if (event.shiftKey && event.key === "Tab") {
                         event.preventDefault();
-                        const webchatHeaderRatingButton = document.getElementById("webchatHeaderOpenRatingDialogButton");
-                        webchatHeaderRatingButton?.focus();
-                    } else {
-                        event.preventDefault();
-                        const webchatHistoryPanel = document.getElementById("webchatChatHistoryWrapperLiveLogPanel");
-                        webchatHistoryPanel?.focus();
+                        this.handleReverseTabNavigation();
+                    } else if (event.key === "Tab") {
+                        this.handleTabNavigation(event, hasRatingButton);
                     }
                 }
+            } else if((event.target === textMessageInput || event.target === getStartedButton) && !event.shiftKey && event.key === "Tab") {
+                this.handleTabNavigation(event, hasRatingButton);
             }
         }
     }

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -384,7 +384,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
              * 
              */
             const closeButton = this.closeButtonInHeaderRef?.current;
-        	const isCloseButtonAsTarget = target === closeButton;
+            const isCloseButtonAsTarget = target === closeButton;
             const isRatingButtonAsTarget = target ===  this.ratingButtonInHeaderRef?.current;
             const isHistoryPanelAsTarget = target === document.getElementById("webchatChatHistoryWrapperLiveLogPanel");
    

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -552,6 +552,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                     title={config.settings.title || 'Cognigy Webchat'}
                     ratingButtonRef={this.ratingButtonInHeaderRef}
                     closeButtonRef={this.closeButtonInHeaderRef}
+                    chatToggleButtonRef={this.chatToggleButtonRef}
                     showRatingButton={showRatingButton}
                     onRatingButtonClick={() => onShowRatingDialog(true)}
                 />

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -364,10 +364,16 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
              * on Shift + Tab navigation.
              * 
              */
-        	const isCloseButtonAsTarget = event.target === this.closeButtonInHeaderRef?.current;
-            const isRatingButtonAsTarget = event.target === this.ratingButtonInHeaderRef?.current;
-            
-            if ((!showRatingButton && isCloseButtonAsTarget) || (showRatingButton && isRatingButtonAsTarget)) {
+            const closeButton = this.closeButtonInHeaderRef?.current;
+        	const isCloseButtonAsTarget = event.target === closeButton;
+            const isRatingButtonAsTarget = event.target ===  this.ratingButtonInHeaderRef?.current;
+            const isHistoryPanelAsTarget = event.target === document.getElementById("webchatChatHistoryWrapperLiveLogPanel");
+   
+            if (
+                (!closeButton && !showRatingButton && isHistoryPanelAsTarget) ||
+                (closeButton && !showRatingButton && isCloseButtonAsTarget) ||
+                (showRatingButton && isRatingButtonAsTarget)
+            ) {
                 if (event.shiftKey && event.key === "Tab") {
                     event.preventDefault();
                     this.handleReverseTabNavigation();
@@ -570,8 +576,6 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
     renderRegularLayout() {
         const {
             config,
-            messages,
-            typingIndicator,
             hasGivenRating,
             onShowRatingDialog,
         } = this.props;

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -6,7 +6,8 @@ const CLIENT_HEIGHT_OFFSET = 16 + 70; // banner + typing indicator
 
 export interface OuterProps extends React.HTMLProps<HTMLDivElement> {
     disableBranding: boolean;
-    showFocusOutline: boolean; 
+    showFocusOutline: boolean;
+    tabIndex: 0 | -1;
  }
 
 type InnerProps = OuterProps;
@@ -94,7 +95,7 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
     }
 
     render() {
-        const { children, disableBranding, showFocusOutline, ...restProps } = this.props;
+        const { children, disableBranding, showFocusOutline, tabIndex, ...restProps } = this.props;
 
         return (
             <ChatLogWrapper ref={this.rootRef} showFocusOutline={this.state.isChatLogFocused} {...restProps}>
@@ -102,7 +103,7 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
                 <ChatLog
                     ref={this.innerRef}
                     id="webchatChatHistoryWrapperLiveLogPanel"
-                    tabIndex={0}
+                    tabIndex={tabIndex}
                     role="log"
                     aria-live="polite"
                     onFocus={this.handleFocus}

--- a/src/webchat-ui/components/plugins/input/text/TextInput.tsx
+++ b/src/webchat-ui/components/plugins/input/text/TextInput.tsx
@@ -340,11 +340,11 @@ export class TextInput extends React.PureComponent<InputComponentProps, TextInpu
                         )}
                         
                         <SubmitButton
-							disabled={this.state.text === ''}
-							className="webchat-input-button-send"
-							aria-label="Send Message"
-							id="webchatInputMessageSendMessageButton"
-						>
+                            disabled={this.state.text === ''}
+                            className="webchat-input-button-send"
+                            aria-label="Send Message"
+                            id="webchatInputMessageSendMessageButton"
+                        >
                             <SendIcon />
                         </SubmitButton>
                     </>

--- a/src/webchat-ui/components/plugins/input/text/TextInput.tsx
+++ b/src/webchat-ui/components/plugins/input/text/TextInput.tsx
@@ -339,7 +339,12 @@ export class TextInput extends React.PureComponent<InputComponentProps, TextInpu
                             />
                         )}
                         
-                        <SubmitButton disabled={this.state.text === ''} className="webchat-input-button-send" aria-label="Send Message">
+                        <SubmitButton
+							disabled={this.state.text === ''}
+							className="webchat-input-button-send"
+							aria-label="Send Message"
+							id="webchatInputMessageSendMessageButton"
+						>
                             <SendIcon />
                         </SubmitButton>
                     </>

--- a/src/webchat-ui/components/presentational/Header.tsx
+++ b/src/webchat-ui/components/presentational/Header.tsx
@@ -38,31 +38,40 @@ interface HeaderProps {
     onClose: () => void;
     closeButtonRef?: React.RefObject<HTMLButtonElement>;
     ratingButtonRef?: React.RefObject<HTMLButtonElement>;
+    chatToggleButtonRef?: React.RefObject<HTMLButtonElement>;
 }
 
-export default ({ logoUrl, connected, title, showRatingButton, onRatingButtonClick, onClose, closeButtonRef, ratingButtonRef, ...props }: HeaderProps) => (
-    <HeaderBar color='primary' {...props} className="webchat-header-bar">
-        {logoUrl && <Logo src={logoUrl} className="webchat-header-logo" aria-hidden="true" />}
-        <span style={{ flexGrow: 1 }} className="webchat-header-title" role="heading" aria-level={1} id="webchatHeaderTitle">{title}</span>
-        {
+export default ({ logoUrl, connected, title, showRatingButton, onRatingButtonClick, onClose, closeButtonRef, ratingButtonRef, chatToggleButtonRef, ...props }: HeaderProps) => {
+    // Close webchat window and restore focus
+    const handleCloseClick = () => {
+        onClose();
+        chatToggleButtonRef?.current?.focus();  // Restore focus to chat toggle button
+    }
+
+    return (
+        <HeaderBar color='primary' {...props} className="webchat-header-bar">
+            {logoUrl && <Logo src={logoUrl} className="webchat-header-logo" aria-hidden="true" />}
+            <span style={{ flexGrow: 1 }} className="webchat-header-title" role="heading" aria-level={1} id="webchatHeaderTitle">{title}</span>
+            {
             showRatingButton &&
             <HeaderIconButton
                 onClick={onRatingButtonClick}
                 aria-label="Rate your chat"
                 id="webchatHeaderOpenRatingDialogButton"
                 ref={ratingButtonRef}
-            >
+                >
                 <ThumbsUpDownIcon />
+                </HeaderIconButton>
+            }
+            <HeaderIconButton
+                data-header-close-button
+                onClick={handleCloseClick}
+                className="webchat-header-close-button"
+                aria-label="Close Chat"
+                ref={closeButtonRef}
+            >
+                <CloseIcon />
             </HeaderIconButton>
-        }
-        <HeaderIconButton
-            data-header-close-button
-            onClick={onClose}
-            className="webchat-header-close-button"
-            aria-label="Close Chat"
-            ref={closeButtonRef}
-        >
-            <CloseIcon />
-        </HeaderIconButton>
-    </HeaderBar>
-);
+        </HeaderBar>
+    );
+};

--- a/src/webchat-ui/utils/find-focusable.ts
+++ b/src/webchat-ui/utils/find-focusable.ts
@@ -1,12 +1,11 @@
 /**
- * Gets keyboard-focusable elements within the webchat
+ * Gets keyboard-focusable elements within a given element
+ * @param {HTMLElement} element
  * @returns {Array}
  */
-const getKeyboardFocusableElements = () => {
-	const webchatWindow = document.getElementById("webchatWindow");
-
-	// Get all interactive elements in webchat
-	const interactiveEls = webchatWindow?.querySelectorAll(
+const getKeyboardFocusableElements = (element: HTMLElement) => {
+	// Get all interactive elements in given element
+	const interactiveEls = element?.querySelectorAll(
 		'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
 	);
 	const interactiveElsArray = interactiveEls && Array.from(interactiveEls);

--- a/src/webchat-ui/utils/find-focusable.ts
+++ b/src/webchat-ui/utils/find-focusable.ts
@@ -1,0 +1,23 @@
+/**
+ * Gets keyboard-focusable elements within the webchat
+ * @returns {Array}
+ */
+const getKeyboardFocusableElements = () => {
+	const webchatWindow = document.getElementById("webchatWindow");
+
+	// Get all interactive elements in webchat
+	const interactiveEls = webchatWindow?.querySelectorAll(
+		'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
+	);
+	const interactiveElsArray = interactiveEls && Array.from(interactiveEls);
+
+	// Filter all the interactive elements that are not disabled or have aria-hidden 'true'
+	const focusable = interactiveElsArray?.filter(el => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden'));
+
+	const firstFocusable = focusable && focusable[0] as HTMLElement;
+	const lastFocusable = focusable && focusable[focusable.length-1] as HTMLElement;
+
+	return {firstFocusable, lastFocusable};		
+}
+
+export default getKeyboardFocusableElements;


### PR DESCRIPTION
Implement Focus trap even if the both close chat buttons(Close Toggle button and close button in chat header) are absent.

**Success Criteria:**
- When `enableFocusTrap` setting is set to true, the keyboard focus should always not leave the chat window under the following conditions:
1. Even when the 'Rating' button is present or absent in webchat header.
2. Even if the 'Persistent Menu' button is present or absent to the left of the text input field.
3. Even when the 'Send message' button is enabled or disabled.
4. Even if there is 'Get started' button instead of the Text field.
5. Even when 'Close' button is present or absent in webchat header.
6. Even if the 'Chat toggle' button is present or absent.

**How to test:**
1. Enable `enableFocusTrap` setting in webchat and navigate the webchat using TAB and SHIFT+TAB keys
2. Test the success criteria 1 to 4 by enabling/ disabling the individual feature in the webchat settings
3. Success criteria 5 and 6 can be tested by removing the Close/Chat toggle button in the code

