### PR TITLE
Add button count in group for screen reader

### DIFF
--- a/cypress/integration/messages/buttons.spec.ts
+++ b/cypress/integration/messages/buttons.spec.ts
@@ -53,4 +53,14 @@ describe("Message with Buttons", () => {
             
         });
     })
+
+    it("buttons in group should have 'aria-label' attribute with button position and name", () => {
+        cy.withMessageFixture('buttons', () => {
+            cy.wrap([1,2,3,4]).each(number => {
+                cy.contains(`foobar005b${number}`)
+                    .invoke("attr", "aria-label")
+                    .should("contain", `Item ${number} of 4: foobar005b${number}`);
+            })
+        })
+    })
 })

--- a/cypress/integration/messages/gallery.spec.ts
+++ b/cypress/integration/messages/gallery.spec.ts
@@ -118,4 +118,14 @@ describe("Message with Gallery", () => {
             });
         })
     });
+
+    it("gallery buttons should have 'aria-label' attribute with button position and name", () => {
+        cy.withMessageFixture('gallery', () => {
+            cy.wrap([1,2,3,4]).each(number => {
+                cy.contains(`foobar004g1b${number}`)
+                    .invoke("attr", "aria-label")
+                    .should("contain", `Item ${number} of 4: foobar004g1b${number}`);
+            })
+        })
+    })
 })

--- a/cypress/integration/messages/quickReplies.spec.ts
+++ b/cypress/integration/messages/quickReplies.spec.ts
@@ -67,4 +67,15 @@ describe("Message with Quick Replies", () => {
         }, reInit);
     })
 
+    it("quick reply button should have 'aria-label' attribute with button position and name", () => {
+        cy.withMessageFixture('quick-replies', () => {
+            cy.contains("foobar003qr01")
+                .invoke("attr", "aria-label")
+                .should("contain", "Item 1 of 2: foobar003qr01");
+            cy.contains("foobar003qr02")
+                .invoke("attr", "aria-label")
+                .should("contain", "Item 2 of 2: foobar003qr02");
+            
+        }, reInit);
+    })
 })

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
@@ -8,6 +8,8 @@ import { sanitizeHTML } from '../../../../../webchat/helper/sanitize';
 interface IMessengerButtonProps {
     button: IFBMButton;
     config: IWebchatConfig;
+    position?: number;
+    total?: number
 }
 
 export const getMessengerButton = ({ React, styled }: MessagePluginFactoryProps) => {
@@ -36,12 +38,13 @@ export const getMessengerButton = ({ React, styled }: MessagePluginFactoryProps)
         }
     }));
 
-    const MessengerButton = ({ button, ...props }: IMessengerButtonProps & React.ComponentProps<typeof Button>) => {		
+    const MessengerButton = ({ button, position, total, ...props }: IMessengerButtonProps & React.ComponentProps<typeof Button>) => {		
         const buttonType = button.type;
         const isWebURL = buttonType === "web_url";
         const buttonTitle = button.title ? button.title + ". " : "";
         const isWebURLButtonTargetBlank = button.target !== "_self";
-        const ariaLabel = isWebURL && isWebURLButtonTargetBlank ? buttonTitle + "Opens in new tab" : undefined;
+        const buttonTitleWithTarget = isWebURL && isWebURLButtonTargetBlank ? buttonTitle + "Opens in new tab" : button.title;
+        const ariaLabel = total > 1 ? `Item ${position} of ${total}: ${buttonTitleWithTarget}` : buttonTitleWithTarget;
     
         const buttonLabel = getButtonLabel(button);
         const __html = props.config.settings.disableHtmlContentSanitization ? buttonLabel : sanitizeHTML(buttonLabel)

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButtonTemplate/MessengerButtonTemplate.tsx
@@ -79,7 +79,9 @@ export const getMessengerButtonTemplate = ({
 								onClick={e => onAction(e, button)}
 								className="webchat-buttons-template-button"
                                 config={config}
-								id={`${webchatButtonTemplateButtonId}-${index}`}
+                                id={`${webchatButtonTemplateButtonId}-${index}`}
+                                position={index + 1}
+                                total={buttons.length}
 							/>
 						</React.Fragment>
 					))}

--- a/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
@@ -133,7 +133,7 @@ export const getMessengerGenericTemplate = ({
                     firstButton?.focus();
                 }, 200);
             }             
-		}
+        }
 
         // Change the selectedItem state, in order to scroll the card with a focused element into view
         handleScrollToView = (index) => {
@@ -189,21 +189,21 @@ export const getMessengerGenericTemplate = ({
                 "aria-label": listItemCount ? carouselAriaLabel : undefined, "aria-describedby": carouselAriaDescribedby};
             const carouselTitle = title ? title + ". " : "";
             const carouselHeaderA11yProps = default_action?.url ? {"aria-label": carouselTitle + "Opens in new tab"} :
-                {"aria-labelledby": carouselAriaLabelledby}		
+                {"aria-labelledby": carouselAriaLabelledby}
 
-			
+            
             const image = image_url ? (
                 this.props.config.settings.dynamicImageAspectRatio ? (
                     <FlexImage
-						src={image_url}
-						alt={image_alt_text || ""}
+                        src={image_url}
+                        alt={image_alt_text || ""}
                     />
                 ) : (
                         <FixedImage
                             style={{ backgroundImage: getBackgroundImage(image_url) }}
                         > 
-							<span role="img" aria-label={image_alt_text || "Attachment Image"}> </span>
-						</FixedImage>
+                            <span role="img" aria-label={image_alt_text || "Attachment Image"}> </span>
+                        </FixedImage>
                     )
             ) : null;
 
@@ -239,23 +239,23 @@ export const getMessengerGenericTemplate = ({
                             <MessengerTitle className="webchat-carousel-template-title" dangerouslySetInnerHTML={{ __html: titleHtml }} id={carouselTitleId} />
                             <MessengerSubtitle className="webchat-carousel-template-title" dangerouslySetInnerHTML={{ __html: subtitleHtml }} config={this.props.config} id={carouselSubtitleId} />
                         </GenericContent>
-						<div>
-							{buttons &&
-								buttons.map((button, i) => (
-									<React.Fragment key={i}>
-										<Divider />
-										<MessengerButton
-											button={button}
-											onClick={e => onAction(e, button)}
-											className="webchat-carousel-template-button"
+                        <div>
+                            {buttons &&
+                                buttons.map((button, i) => (
+                                <React.Fragment key={i}>
+                                        <Divider />
+                                        <MessengerButton
+                                            button={button}
+                                            onClick={e => onAction(e, button)}
+                                            className="webchat-carousel-template-button"
                                             config={this.props.config}
                                             id={`${this.carouselButtonId}-${index}${i}`}
                                             position={i + 1}
                                             total={buttons.length}
-										/>
-									</React.Fragment>
-								))}
-						</div>
+                                        />
+                                </React.Fragment>
+                                ))}
+                        </div>
                     </Frame>
                 </ElementRoot>
             );

--- a/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerGenericTemplate/MessengerGenericTemplate.tsx
@@ -249,7 +249,9 @@ export const getMessengerGenericTemplate = ({
 											onClick={e => onAction(e, button)}
 											className="webchat-carousel-template-button"
                                             config={this.props.config}
-											id={`${this.carouselButtonId}-${index}${i}`}
+                                            id={`${this.carouselButtonId}-${index}${i}`}
+                                            position={i + 1}
+                                            total={buttons.length}
 										/>
 									</React.Fragment>
 								))}

--- a/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
@@ -130,7 +130,7 @@ export const getMessengerTextWithQuickReplies = ({
                             }
 
                             const __html = config.settings.disableHtmlContentSanitization ? label : sanitizeHTML(label);
-                            const ariaLabel = hasMoreThanOneQuickReply ? `item ${index + 1} of ${quick_replies?.length}: ${__html}` : undefined;
+                            const ariaLabel = hasMoreThanOneQuickReply ? `Item ${index + 1} of ${quick_replies?.length}: ${__html}` : undefined;
 
                             return (
                                 <MessengerQuickReply

--- a/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
@@ -130,6 +130,7 @@ export const getMessengerTextWithQuickReplies = ({
                             }
 
                             const __html = config.settings.disableHtmlContentSanitization ? label : sanitizeHTML(label);
+                            const ariaLabel = hasMoreThanOneQuickReply ? `item ${index + 1} of ${quick_replies?.length}: ${__html}` : undefined;
 
                             return (
                                 <MessengerQuickReply
@@ -137,6 +138,7 @@ export const getMessengerTextWithQuickReplies = ({
                                     onClick={e => onAction(e, quickReply)}
                                     className="webchat-quick-reply-template-reply"
                                     id={`${webchatQuickReplyTemplateButtonId}-${index}`}
+                                    aria-label={ariaLabel}
                                 >
                                     {image}
                                     <span dangerouslySetInnerHTML={{ __html }} />


### PR DESCRIPTION
This PR adds to position of a button in a group of buttons to help screen reader users.

Success Criteria:
- In addition to the total number of buttons, the screen reader should also announce the position of the button.
Example: If a quick reply has three buttons, focusing on the second button should read '_Item 2 of 3 : <BUTTON_LABEL> button_'
- Links that open in a new tab should still have an aria-label that includes 'Opens in a new tab' 

How to test: 
- You can use this endpoint to test this PR: https://endpoint-dev-v4.cognigy.ai/39d8ff845d0469d85be1c6d9b01cb435803cfede1b7dfb782e74f9343ec27fc7 
- Navigate the webacht using keyboard and screen reader and see if the success criteria is satisfied