### PR TITLE
Fix scalability of non-popover webchat

### DIFF
--- a/src/webchat-embed/embedded-webchat-styles.css
+++ b/src/webchat-embed/embedded-webchat-styles.css
@@ -32,14 +32,14 @@
 
 @media screen and (min-width: 576px) {
     [data-cognigy-webchat-root] {
-        position: fixed;
+        position: relative;
 
         left: auto;
         top: auto;
 
         overflow: visible;
         width: auto;
-        height: auto;
+        height: 100%;
     }
 
     [data-cognigy-webchat-root] [data-cognigy-webchat] {


### PR DESCRIPTION
This PR fixes a issue where 'centered' webchat was not fully visible when zoomed in (upto 200%).

Success Criteria:
- The centered, 'non-popover' version of the webchat should be completely visible when the zoom percentage is increased up to 200. 
- You should be able to see the webchat title and enter input and send message even when zoomed in.
- The non-centered webchat layout should remain unaffected

NOTE: The PR has to be tested and merged along with the PR #9986 in Cognigy repo
