### PR TITLE
Adaptive card support for webchat

### DIFF
--- a/cypress/fixtures/messages/adaptivecard-webchat.json
+++ b/cypress/fixtures/messages/adaptivecard-webchat.json
@@ -1,0 +1,175 @@
+{
+  "text": null,
+  "data": {
+    "_cognigy": {
+      "_webchat": {
+        "adaptiveCard": {
+          "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+          "type": "AdaptiveCard",
+          "version": "1.0",
+          "body": [
+            {
+              "type": "TextBlock",
+              "text": "Your registration is almost complete",
+              "size": "medium",
+              "weight": "bolder"
+            },
+            {
+              "type": "TextBlock",
+              "text": "What type of food do you prefer?",
+              "wrap": true
+            },
+            {
+              "type": "ImageSet",
+              "imageSize": "medium",
+              "images": [
+                {
+                  "type": "Image",
+                  "url": "http://contososcubademo.azurewebsites.net/assets/steak.jpg"
+                },
+                {
+                  "type": "Image",
+                  "url": "http://contososcubademo.azurewebsites.net/assets/chicken.jpg"
+                },
+                {
+                  "type": "Image",
+                  "url": "http://contososcubademo.azurewebsites.net/assets/tofu.jpg"
+                }
+              ]
+            }
+          ],
+          "actions": [
+            {
+              "type": "Action.ShowCard",
+              "title": "Steak",
+              "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                  {
+                    "type": "TextBlock",
+                    "text": "How would you like your steak prepared?",
+                    "size": "medium",
+                    "wrap": true
+                  },
+                  {
+                    "type": "Input.ChoiceSet",
+                    "id": "SteakTemp",
+                    "style": "expanded",
+                    "choices": [
+                      {
+                        "title": "Rare",
+                        "value": "rare"
+                      },
+                      {
+                        "title": "Medium-Rare",
+                        "value": "medium-rare"
+                      },
+                      {
+                        "title": "Well-done",
+                        "value": "well-done"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Input.Text",
+                    "id": "SteakOther",
+                    "isMultiline": true,
+                    "placeholder": "Any other preparation requests?"
+                  }
+                ],
+                "actions": [
+                  {
+                    "type": "Action.Submit",
+                    "title": "OK",
+                    "data": {
+                      "FoodChoice": "Steak"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Action.ShowCard",
+              "title": "Chicken",
+              "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                  {
+                    "type": "TextBlock",
+                    "text": "Do you have any allergies?",
+                    "size": "medium",
+                    "wrap": true
+                  },
+                  {
+                    "type": "Input.ChoiceSet",
+                    "id": "ChickenAllergy",
+                    "style": "expanded",
+                    "isMultiSelect": true,
+                    "choices": [
+                      {
+                        "title": "I'm allergic to peanuts",
+                        "value": "peanut"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Input.Text",
+                    "id": "ChickenOther",
+                    "isMultiline": true,
+                    "placeholder": "Any other preparation requests?"
+                  }
+                ],
+                "actions": [
+                  {
+                    "type": "Action.Submit",
+                    "title": "OK",
+                    "data": {
+                      "FoodChoice": "Chicken"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Action.ShowCard",
+              "title": "Tofu",
+              "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                  {
+                    "type": "TextBlock",
+                    "text": "Would you like it prepared vegan?",
+                    "size": "medium",
+                    "wrap": true
+                  },
+                  {
+                    "type": "Input.Toggle",
+                    "id": "Vegetarian",
+                    "title": "Please prepare it vegan",
+                    "valueOn": "vegan",
+                    "valueOff": "notVegan"
+                  },
+                  {
+                    "type": "Input.Text",
+                    "id": "VegOther",
+                    "isMultiline": true,
+                    "placeholder": "Any other preparation requests?"
+                  }
+                ],
+                "actions": [
+                  {
+                    "type": "Action.Submit",
+                    "title": "OK",
+                    "data": {
+                      "FoodChoice": "Vegetarian"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/cypress/integration/messages/adaptivecard.spec.ts
+++ b/cypress/integration/messages/adaptivecard.spec.ts
@@ -12,9 +12,9 @@ describe("Message with AdaptiveCard", () => {
         });
     });
 
-    it.only("should render an adaptivecard from _webchat", () => {
+    it("should render an adaptivecard from _webchat", () => {
         cy.withMessageFixture('adaptivecard-webchat', () => {
-            cy.contains("Webchat Adaptive Card").should("be.visible");
+            cy.contains("Your registration is almost complete").should("be.visible");
         });
     });
 

--- a/cypress/integration/messages/adaptivecard.spec.ts
+++ b/cypress/integration/messages/adaptivecard.spec.ts
@@ -1,17 +1,39 @@
 describe("Message with AdaptiveCard", () => {
-    describe("", () => {
+    beforeEach(() => {
+        cy
+            .visitWebchat()
+            .initMockWebchat()
+            .openWebchat()
+    })
 
-        beforeEach(() => {
-            cy
-                .visitWebchat()
-                .initMockWebchat()
-                .openWebchat()
-        })
+    it("should render an adaptivecard from plugin", () => {
+        cy.withMessageFixture('adaptivecard', () => {
+            cy.contains("Your registration is almost complete").should("be.visible");
+        });
+    });
 
-        it("should render an adaptivecard", () => {
-            cy.withMessageFixture('adaptivecard', () => {
-                cy.contains("Your registration is almost complete").should("be.visible");
-            });
+    it.only("should render an adaptivecard from _webchat", () => {
+        cy.withMessageFixture('adaptivecard-webchat', () => {
+            cy.contains("Webchat Adaptive Card").should("be.visible");
+        });
+    });
+
+    it("submits a message through an adaptivecard form", () => {
+        cy.withMessageFixture('adaptivecard', () => {
+            cy.contains("Your registration is almost complete").should("be.visible");
+
+            cy.contains("Steak").click();
+            cy.contains("Medium-Rare").click();
+            cy.get("#SteakOther textarea").type("Tender, please!");
+            cy.contains("OK").click();
+
+            cy.getMessageFromHistory({ data: {
+                adaptivecards: {
+                    FoodChoice: "Steak",
+                    SteakTemp: "medium-rare",
+                    SteakOther: "Tender, please!"
+                }
+            }});
         });
 
         it("submits a message through an adaptivecard form", () => {

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -4,14 +4,22 @@ import { registerMessagePlugin } from '../helper';
 
 import { updateAdaptiveCardCSSCheaply } from './styles';
 
+const isAdaptiveCard = (message) => {
+    if (message.data?._cognigy?._webchat?.adaptiveCard || message.data?._plugin?.type === "adaptivecards") {
+        return true;
+    }
+    return false;
+}
+
 const AdaptiveCards = (props) => {
+
     const { theme, onSendMessage, message } = props;
 
     useEffect(() => {
         updateAdaptiveCardCSSCheaply(theme);
     }, []);
 
-    const cardPayload = message.data._plugin.payload;
+    const cardPayload = message.data?._plugin?.payload || message.data?._cognigy?._webchat?.adaptiveCard;
 
     const onExecuteAction = useCallback((action) => {
         switch (action._propertyBag?.type) {
@@ -54,7 +62,7 @@ const AdaptiveCards = (props) => {
 }
 
 const adaptivecardsPlugin = {
-    match: 'adaptivecards',
+    match: isAdaptiveCard,
     component: AdaptiveCards,
     options: {
         fullwidth: true

--- a/src/plugins/messenger/index.tsx
+++ b/src/plugins/messenger/index.tsx
@@ -10,6 +10,12 @@ import { sanitizeUrl } from "@braintree/sanitize-url";
 import { IFBMURLButton } from "./MessengerPreview/interfaces/Button.interface";
 
 const getMessengerPayload = (message: IMessage, config: IWebchatConfig) => {
+
+    //check if message uses messenger plugin
+    if (!message.data?._cognigy?._webchat?.message) {
+            return false;
+    }
+
     const cognigyData = (() => {
         if (!config.settings.disableDefaultReplyCompatiblityMode && message.data?._data?._cognigy) {
             return message.data?._data?._cognigy;


### PR DESCRIPTION
This PR adds adaptive card support for Webchat channel as a standard Webchat Output Type.

Acceptance criteria:
- Adaptive card configured with AI channel is rendered in Webchat 
- Adaptive card configured with Webchat channel is rendered in Webchat 
- Adaptive card configured in Say node Data with plugin is rendered in Webchat 
-  Other messages work well too

How to test:

1. In a flow create say node and configure adaptive card output type in Default channel
2. In a flow create another say node and configure adaptive card output type in the Webchat channel
3. In a flow create another say node and configure adaptive card in the Say node Data section with plugin
4. Talk to webchat Endpoint (use webchat.js build)
5. Test other Output types to check that everything works as before.
6. Run cypress tests
 