### PR TITLE
date picker styling

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -8,9 +8,9 @@
 <body>
     <script src="./webchat.js"></script>
     <script>
-        initWebchat('https://egle.eu.ngrok.io/46468d856cba0b37b4e6721208948e10bc8fcf057e1eb7e0006487bc8f6de633', {
+        initWebchat('https://endpoint-trial.cognigy.ai/325a1e29b99441f4640ba659706763fb77006e00dc0e3720600f523557d7afaa', {
             userId: "user",
-            sessionId: "session5656",
+            sessionId: "session",
             settings: {
                 // colorScheme: '#FAB'
                 enableUnreadMessageSound: true,

--- a/dist/index.html
+++ b/dist/index.html
@@ -8,9 +8,9 @@
 <body>
     <script src="./webchat.js"></script>
     <script>
-        initWebchat('https://endpoint-trial.cognigy.ai/325a1e29b99441f4640ba659706763fb77006e00dc0e3720600f523557d7afaa', {
+        initWebchat('https://egle.eu.ngrok.io/46468d856cba0b37b4e6721208948e10bc8fcf057e1eb7e0006487bc8f6de633', {
             userId: "user",
-            sessionId: "session",
+            sessionId: "session5656",
             settings: {
                 // colorScheme: '#FAB'
                 enableUnreadMessageSound: true,

--- a/src/plugins/date-picker/flatpickr.css
+++ b/src/plugins/date-picker/flatpickr.css
@@ -185,6 +185,13 @@
      fill: rgba(0, 0, 0, 0.9);
  }
 
+ [data-cognigy-webchat-root] .flatpickr-disabled.flatpickr-day {
+    color: rgba(57, 57, 57, 0.3);
+    background: transparent;
+    border-color: transparent;
+}
+
+
  [data-cognigy-webchat-root] .flatpickr-months .flatpickr-prev-month.disabled, [data-cognigy-webchat-root] .flatpickr-months .flatpickr-next-month.disabled {
      display: none;
  }

--- a/src/plugins/date-picker/flatpickr.css
+++ b/src/plugins/date-picker/flatpickr.css
@@ -185,13 +185,6 @@
      fill: rgba(0, 0, 0, 0.9);
  }
 
- [data-cognigy-webchat-root] .flatpickr-disabled.flatpickr-day {
-    color: rgba(57, 57, 57, 0.3);
-    background: transparent;
-    border-color: transparent;
-}
-
-
  [data-cognigy-webchat-root] .flatpickr-months .flatpickr-prev-month.disabled, [data-cognigy-webchat-root] .flatpickr-months .flatpickr-next-month.disabled {
      display: none;
  }
@@ -579,7 +572,7 @@
      box-shadow: -5px 0 0 #e6e6e6, 5px 0 0 #e6e6e6;
  }
 
- [data-cognigy-webchat-root] .flatpickr-day.disabled, [data-cognigy-webchat-root] .flatpickr-day.disabled:hover, [data-cognigy-webchat-root] .flatpickr-day.prevMonthDay, [data-cognigy-webchat-root] .flatpickr-day.nextMonthDay, [data-cognigy-webchat-root] .flatpickr-day.notAllowed, [data-cognigy-webchat-root] .flatpickr-day.notAllowed.prevMonthDay, [data-cognigy-webchat-root] .flatpickr-day.notAllowed.nextMonthDay {
+ [data-cognigy-webchat-root] .flatpickr-day.disabled, .flatpickr-disabled.flatpickr-day, [data-cognigy-webchat-root] .flatpickr-day.disabled:hover, [data-cognigy-webchat-root] .flatpickr-day.prevMonthDay, [data-cognigy-webchat-root] .flatpickr-day.nextMonthDay, [data-cognigy-webchat-root] .flatpickr-day.notAllowed, [data-cognigy-webchat-root] .flatpickr-day.notAllowed.prevMonthDay, [data-cognigy-webchat-root] .flatpickr-day.notAllowed.nextMonthDay {
      color: rgba(57, 57, 57, 0.3);
      background: transparent;
      border-color: transparent;


### PR DESCRIPTION
This PR adds styling for disabled dates in the date-picker plugin.

Acceptance criteria:
- Disabled dates are clearly seen

How to test:
Send this payload in the data field of the Say node and see that only dates between min and max date are available and July 5 and 6 are disabled.
``
{
		"_plugin": {
			"type": "date-picker",
			"data": {
				"eventName": "foobar012",
				"locale": "en",
				"enableTime": false,
				"mode": "single",
				"wantDisable": true,
                               "enable_disable": ["2022-07-05", "2022-07-06"],
				"minDate": "2022-07-02",
				"maxDate": "2022-07-23",
				"openPickerButtonText": "foobar012b1",
				"cancelButtonText": "foobar012b2",
				"submitButtonText": "foobar012b3",
				"time_24hr": true,
				"dateFormat": ""
			}
        }
		}

``