### PR TITLE
Feature/28694 default preview

### DIFF
--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -272,6 +272,55 @@ describe("Channel Rendering Priorities", {
 
                 cy.contains("DEFAULT ADAPTIVECARDS").should('be.visible');
             });
+
+            it('should prefer text from the default tab over quick replies from the webchat tab', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("DEFAULT TEXT", {
+                    _cognigy: {
+                        _webchat: {
+                            message: {
+                                text: "WEBCHAT QUICK REPLIES"
+                            }
+                        },
+                    }
+                }, "bot", {
+                    settings: {
+                        enableDefaultPreview: true
+                    }
+                });
+
+                cy.contains("DEFAULT TEXT").should('be.visible');
+            });
+
+            it('should prefer text from the default tab over adaptivecards from the webchat tab', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("DEFAULT TEXT", {
+                    _cognigy: {
+                        _webchat: {
+                            adaptiveCard: {
+                                type: "AdaptiveCard",
+                                $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                version: "1.5",
+                                body: [
+                                    {
+                                        type: "TextBlock",
+                                        text: "DEFAULT ADAPTIVECARDS",
+                                        wrap: true
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }, "bot", {
+                    settings: {
+                        enableDefaultPreview: true
+                    }
+                });
+
+                cy.contains("DEFAULT TEXT").should('be.visible');
+            });
         });
     });
 });

--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -273,6 +273,40 @@ describe("Channel Rendering Priorities", {
                 cy.contains("DEFAULT ADAPTIVECARDS").should('be.visible');
             });
 
+            it('should prefer quick replies from the webchat tab over adaptivecards from the default tab', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("", {
+                    _cognigy: {
+                        _defaultPreview: {
+                            adaptiveCard: {
+                                type: "AdaptiveCard",
+                                $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                version: "1.5",
+                                body: [
+                                    {
+                                        type: "TextBlock",
+                                        text: "DEFAULT ADAPTIVECARDS",
+                                        wrap: true
+                                    }
+                                ]
+                            }
+                        },
+                        _webchat: {
+                            message: {
+                                text: "WEBCHAT QUICK REPLIES"
+                            }
+                        }
+                    }
+                }, "bot", {
+                    settings: {
+                        enableDefaultPreview: false
+                    }
+                });
+
+                cy.contains("WEBCHAT QUICK REPLIES").should('be.visible');
+            });
+
             it('should prefer text from the default tab over quick replies from the webchat tab', () => {
                 cy.visitMessageRenderer();
 
@@ -291,6 +325,26 @@ describe("Channel Rendering Priorities", {
                 });
 
                 cy.contains("DEFAULT TEXT").should('be.visible');
+            });
+
+            it('should prefer quick replies from the webchat tab over text from the default tab', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("DEFAULT TEXT", {
+                    _cognigy: {
+                        _webchat: {
+                            message: {
+                                text: "WEBCHAT QUICK REPLIES"
+                            }
+                        },
+                    }
+                }, "bot", {
+                    settings: {
+                        enableDefaultPreview: false
+                    }
+                });
+
+                cy.contains("WEBCHAT QUICK REPLIES").should('be.visible');
             });
 
             it('should prefer text from the default tab over adaptivecards from the webchat tab', () => {
@@ -319,7 +373,35 @@ describe("Channel Rendering Priorities", {
                     }
                 });
 
-                cy.contains("DEFAULT TEXT").should('be.visible');
+            });
+
+                it('should prefer aptivecards from the webchat tab over text from the default tab over', () => {
+                    cy.visitMessageRenderer();
+    
+                    cy.renderMessage("DEFAULT TEXT", {
+                        _cognigy: {
+                            _webchat: {
+                                adaptiveCard: {
+                                    type: "AdaptiveCard",
+                                    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                    version: "1.5",
+                                    body: [
+                                        {
+                                            type: "TextBlock",
+                                            text: "DEFAULT TEXT ADAPTIVE CARD",
+                                            wrap: true
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, "bot", {
+                        settings: {
+                            enableDefaultPreview: false
+                        }
+                    });
+
+                cy.contains("DEFAULT TEXT ADAPTIVE CARD").should('be.visible');
             });
         });
     });

--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -390,6 +390,40 @@ describe("Channel Rendering Priorities", {
                 cy.contains("WEBCHAT ADAPTIVE CARD").should('be.visible');
             });
 
+            it('should prefer default quick replies tab over webchat adaptive card', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("", {
+                    _cognigy: {
+                        _webchat: {
+                            adaptiveCard: {
+                                type: "AdaptiveCard",
+                                $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                version: "1.5",
+                                body: [
+                                    {
+                                        type: "TextBlock",
+                                        text: "WEBCHAT ADAPTIVE CARD",
+                                        wrap: true
+                                    }
+                                ]
+                            }
+                        },
+                        _defaultPreview: {
+                            message: {
+                                text: "DEFAULT QUICK REPLIES"
+                            }
+                        },
+                    }
+                }, "bot", {
+                    settings: {
+                        enableDefaultPreview: true
+                    }
+                });
+
+            cy.contains("DEFAULT QUICK REPLIES").should('be.visible');
+        });
+
             it('should prefer text from the default tab over adaptivecards from the webchat tab', () => {
                 cy.visitMessageRenderer();
 
@@ -418,7 +452,7 @@ describe("Channel Rendering Priorities", {
 
             });
 
-                it('should prefer aptivecards from the webchat tab over text from the default tab over', () => {
+                it('should prefer adaptive cards from the webchat tab over text from the default tab ', () => {
                     cy.visitMessageRenderer();
     
                     cy.renderMessage("DEFAULT TEXT", {

--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -14,7 +14,8 @@ const renderMessageWithParams = (params: IGenerateTestCaseParams) => {
 
     const config = {
         settings: {
-            enableStrictMessengerSync: params.enableStrictMessengerSync
+            enableStrictMessengerSync: params.enableStrictMessengerSync,
+            enableDefaultPreview: params.defaultPreviewTabConfigured
         }
     };
 
@@ -35,6 +36,9 @@ const renderMessageWithParams = (params: IGenerateTestCaseParams) => {
     };
 
 
+    cy.log(JSON.stringify(messageData));
+    cy.log(JSON.stringify(config ));
+    
     cy.renderMessage("", messageData, 'bot', config);
 }
 
@@ -80,7 +84,7 @@ const getTestDescriptionFromParams = (params: IGenerateTestCaseParams) => {
             params.enableDefaultPreview && 'enableDefaultPreview',
         ].filter(a => !!a);
 
-        if (!flagNames)
+        if (flagNames.length === 0)
             return 'no flags are set.';
 
         if (flagNames.length === 1)
@@ -213,7 +217,7 @@ describe("Channel Rendering Priorities", {
 
                 cy.renderMessage("", {
                     _cognigy: {
-                        _default: {
+                        _defaultPreview: {
                             message: {
                                 text: "DEFAULT QUICK REPLIES"
                             }
@@ -236,10 +240,8 @@ describe("Channel Rendering Priorities", {
 
                 cy.renderMessage("", {
                     _cognigy: {
-                        _default: {
-                            _adaptiveCard: {
-                                type: "adaptiveCard",
-                                adaptiveCard: {
+                        _defaultPreview: {
+                            adaptiveCard: {
                                     type: "AdaptiveCard",
                                     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
                                     version: "1.5",
@@ -251,7 +253,6 @@ describe("Channel Rendering Priorities", {
                                         }
                                     ]
                                 }
-                            }
                         },
                         _webchat: {
                             message: {

--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -37,8 +37,8 @@ const renderMessageWithParams = (params: IGenerateTestCaseParams) => {
 
 
     cy.log(JSON.stringify(messageData));
-    cy.log(JSON.stringify(config ));
-    
+    cy.log(JSON.stringify(config));
+
     cy.renderMessage("", messageData, 'bot', config);
 }
 
@@ -206,7 +206,9 @@ describe("Channel Rendering Priorities", {
                         }
                     }
                 }, "bot", {
-                    enableDefaultPreview: true
+                    settings: {
+                        enableDefaultPreview: true
+                    }
                 });
 
                 cy.contains("DEFAULT TEXT").should('be.visible');
@@ -229,7 +231,9 @@ describe("Channel Rendering Priorities", {
                         },
                     }
                 }, "bot", {
-                    enableDefaultPreview: true
+                    settings: {
+                        enableDefaultPreview: true
+                    }
                 });
 
                 cy.contains("DEFAULT QUICK REPLIES").should('be.visible');
@@ -242,17 +246,17 @@ describe("Channel Rendering Priorities", {
                     _cognigy: {
                         _defaultPreview: {
                             adaptiveCard: {
-                                    type: "AdaptiveCard",
-                                    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                                    version: "1.5",
-                                    body: [
-                                        {
-                                            type: "TextBlock",
-                                            text: "DEFAULT ADAPTIVECARDS",
-                                            wrap: true
-                                        }
-                                    ]
-                                }
+                                type: "AdaptiveCard",
+                                $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                version: "1.5",
+                                body: [
+                                    {
+                                        type: "TextBlock",
+                                        text: "DEFAULT ADAPTIVECARDS",
+                                        wrap: true
+                                    }
+                                ]
+                            }
                         },
                         _webchat: {
                             message: {
@@ -261,7 +265,9 @@ describe("Channel Rendering Priorities", {
                         }
                     }
                 }, "bot", {
-                    enableDefaultPreview: true
+                    settings: {
+                        enableDefaultPreview: true
+                    }
                 });
 
                 cy.contains("DEFAULT ADAPTIVECARDS").should('be.visible');

--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -15,7 +15,7 @@ const renderMessageWithParams = (params: IGenerateTestCaseParams) => {
     const config = {
         settings: {
             enableStrictMessengerSync: params.enableStrictMessengerSync,
-            enableDefaultPreview: params.defaultPreviewTabConfigured
+            enableDefaultPreview: params.enableDefaultPreview
         }
     };
 

--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -306,7 +306,7 @@ describe("Channel Rendering Priorities", {
                                 body: [
                                     {
                                         type: "TextBlock",
-                                        text: "DEFAULT ADAPTIVECARDS",
+                                        text: "DEFAULT TEXT",
                                         wrap: true
                                     }
                                 ]

--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -1,15 +1,17 @@
 
 interface IGenerateTestCaseParams {
-    webchatTabConfigured: boolean;
-    facebookTabConfigured: boolean;
-    syncWebchatWithFacebookConfigured: boolean;
+    defaultPreviewTabConfigured?: boolean;
+    webchatTabConfigured?: boolean;
+    facebookTabConfigured?: boolean;
+    syncWebchatWithFacebookConfigured?: boolean;
     enableStrictMessengerSync: boolean;
-    expectedOutcome: 'webchat' | 'facebook' | 'none';
+    enableDefaultPreview?: boolean;
+    expectedOutcome: 'default' | 'webchat' | 'facebook' | 'none' | null;
 }
 
 const renderMessageWithParams = (params: IGenerateTestCaseParams) => {
     cy.visitMessageRenderer();
-    
+
     const config = {
         settings: {
             enableStrictMessengerSync: params.enableStrictMessengerSync
@@ -25,6 +27,7 @@ const renderMessageWithParams = (params: IGenerateTestCaseParams) => {
 
     const messageData = {
         _cognigy: {
+            _defaultPreview: params.defaultPreviewTabConfigured ? getDummyMessage('RENDER DEFAULTPREVIEW') : null,
             _webchat: params.webchatTabConfigured ? getDummyMessage('RENDER WEBCHAT') : null,
             _facebook: params.facebookTabConfigured ? getDummyMessage("RENDER FACEBOOK") : null,
             syncWebchatWithFacebook: params.syncWebchatWithFacebookConfigured
@@ -43,17 +46,50 @@ const expectOutcomeFromParams = (params: IGenerateTestCaseParams) => {
         case 'webchat':
             return cy.contains('RENDER WEBCHAT').should('be.visible');
 
+        case 'default':
+            return cy.contains('RENDER DEFAULTPREVIEW').should('be.visible');
+
         case 'none':
-            return cy.contains('RENDER').should('not.be.visible');
+        case null:
+            return cy.contains('RENDER').should('not.exist');
     }
 }
 
 const getTestDescriptionFromParams = (params: IGenerateTestCaseParams) => {
-    return `If _webchat: ${params.webchatTabConfigured},
-    _facebook: ${params.facebookTabConfigured}, 
-    enableStrictMessengerSync: ${params.enableStrictMessengerSync},
-    syncWebchatWithFacebookConfigured: ${params.syncWebchatWithFacebookConfigured}
-    Should render ${params.expectedOutcome}`; // generated test tescription from params
+    const expectedResult = (() => {
+        if (params.expectedOutcome === 'none' || params.expectedOutcome === null)
+            return 'should not render anything';
+
+        return `expecting a "${params.expectedOutcome}" message.`;
+    })();
+
+    const messageProperties = (() => {
+        const tabNames = [
+            params.defaultPreviewTabConfigured && 'default',
+            params.webchatTabConfigured && 'webchat',
+            params.facebookTabConfigured && 'facebook',
+            params.syncWebchatWithFacebookConfigured && 'syncWebchatWithFacebook'
+        ].filter(a => !!a);
+
+        return `message has ${tabNames.join(', ')}.`
+    })();
+
+    const flags = (() => {
+        const flagNames = [
+            params.enableStrictMessengerSync && 'enableStrictMessengerSync',
+            params.enableDefaultPreview && 'enableDefaultPreview',
+        ].filter(a => !!a);
+
+        if (!flagNames)
+            return 'no flags are set.';
+
+        if (flagNames.length === 1)
+            return `flag ${flagNames[0]} is set.`;
+
+        return `flags ${flagNames.join(', ')} are set.`;
+    })();
+
+    return `${messageProperties} ${flags} ${expectedResult}`;
 }
 
 const generateTestCase = (params: IGenerateTestCaseParams) => {
@@ -68,47 +104,169 @@ const generateTestCase = (params: IGenerateTestCaseParams) => {
     });
 }
 
-type GenerateTestCaseParamsArray = [boolean, boolean, boolean, boolean, IGenerateTestCaseParams['expectedOutcome']];
-
-const getTestCaseObject = ([webchatTabConfigured, facebookTabConfigured, syncWebchatWithFacebookConfigured, enableStrictMessengerSync, expectedOutcome]: GenerateTestCaseParamsArray): IGenerateTestCaseParams => ({
-    webchatTabConfigured,
-    facebookTabConfigured,
-    syncWebchatWithFacebookConfigured,
-    enableStrictMessengerSync,
-    expectedOutcome
-});
-
-describe("Channel Rendering Priorities", () => {
+describe("Channel Rendering Priorities", {
+    defaultCommandTimeout: 500
+}, () => {
     describe("Messenger Plugin", () => {
+        type GenerateTestCaseParamsArray = [boolean, boolean, boolean, boolean, IGenerateTestCaseParams['expectedOutcome']];
+
+        const getTestCaseObject = ([webchatTabConfigured, facebookTabConfigured, syncWebchatWithFacebookConfigured, enableStrictMessengerSync, expectedOutcome]: GenerateTestCaseParamsArray): IGenerateTestCaseParams => ({
+            webchatTabConfigured,
+            facebookTabConfigured,
+            syncWebchatWithFacebookConfigured,
+            enableStrictMessengerSync,
+            expectedOutcome
+        });
+
         describe("Without strict Messenger Sync", () => {
             const testcases = [
                 // [_webchat, _facebook, syncWebchatWithFacebook, enableStrictMessengerSync, expectedResult]
-                [   false,    false,     false,                   false,                     null          ],
-                [   true,     false,     false,                   false,                     'webchat'     ],
-                [   false,    true,      false,                   false,                     'facebook'    ],
-                [   true,     true,      false,                   false,                     'webchat'     ],
+                [false, false, false, false, null],
+                [true, false, false, false, 'webchat'],
+                [false, true, false, false, 'facebook'],
+                [true, true, false, false, 'webchat'],
             ];
-            
+
             testcases.map(getTestCaseObject).forEach(generateTestCase);
         });
 
         describe("With strict Messenger Sync", () => {
             const testcases = [
                 // [_webchat, _facebook, syncWebchatWithFacebook, enableStrictMessengerSync, expectedResult]
-                [   true,     false,     false,                   true,                      'webchat'     ],
-                [   false,    true,      false,                   true,                      null          ],
-                [   true,     true,      false,                   true,                      'webchat'     ],
-                [   false,    false,     false,                   true,                      null          ],
-                [   false,    false,     true,                    true,                      null          ],
-                [   true,     false,     true,                    true,                      null          ],
-                [   false,    true,      true,                    true,                      'facebook'    ],
-                [   true,     true,      true,                    true,                      'facebook'    ],
+                [true, false, false, true, 'webchat'],
+                [false, true, false, true, null],
+                [true, true, false, true, 'webchat'],
+                [false, false, false, true, null],
+                [false, false, true, true, null],
+                [true, false, true, true, null],
+                [false, true, true, true, 'facebook'],
+                [true, true, true, true, 'facebook'],
             ];
-            
+
             testcases.map(getTestCaseObject).forEach(generateTestCase);
         });
     });
 
+    describe("Default Previews", () => {
+        describe('_defaultPreview is always preferred over _webchat and _facebook if enableDefaultPreview is set', () => {
+            // _defaultPreview, _webchat, _facebook, enableDefaultPreview, expectedResult
+            const cases = [
+                [0, 0, 0, 0, 'none'],
+                [1, 0, 0, 0, 'none'],
+                [0, 1, 0, 0, 'webchat'],
+                [1, 1, 0, 0, 'webchat'],
+                [0, 0, 1, 0, 'facebook'],
+                [1, 0, 1, 0, 'facebook'],
+                [0, 1, 1, 0, 'webchat'],
+                [1, 1, 1, 0, 'webchat'],
+                [0, 0, 0, 1, 'none'],
+                [1, 0, 0, 1, 'default'],
+                [0, 1, 0, 1, 'webchat'],
+                [1, 1, 0, 1, 'default'],
+                [0, 0, 1, 1, 'facebook'],
+                [1, 0, 1, 1, 'default'],
+                [0, 1, 1, 1, 'webchat'],
+                [1, 1, 1, 1, 'default'],
+            ];
+
+            cases
+                .map(([
+                    _defaultPreview,
+                    _webchat,
+                    _facebook,
+                    enableDefaultPreview,
+                    expectedOutcome
+                ]): IGenerateTestCaseParams => ({
+                    enableStrictMessengerSync: false,
+                    expectedOutcome: expectedOutcome as any,
+                    defaultPreviewTabConfigured: !!_defaultPreview,
+                    facebookTabConfigured: !!_facebook,
+                    webchatTabConfigured: !!_webchat,
+                    enableDefaultPreview: !!enableDefaultPreview,
+                    syncWebchatWithFacebookConfigured: false
+                }))
+                .forEach(generateTestCase);
+        });
+
+
+        describe('_defaultPreview is preferred for all builtin message plugins if enableDefaultPreview is set', () => {
+            it('should prefer a text from the default tab over quick replies from the webchat tab', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("DEFAULT TEXT", {
+                    _cognigy: {
+                        _webchat: {
+                            message: {
+                                text: "WEBCHAT QUICK REPLIES"
+                            }
+                        }
+                    }
+                }, "bot", {
+                    enableDefaultPreview: true
+                });
+
+                cy.contains("DEFAULT TEXT").should('be.visible');
+            });
+
+            it('should prefer quick replies from the default tab over quick replies from the webchat tab', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("", {
+                    _cognigy: {
+                        _default: {
+                            message: {
+                                text: "DEFAULT QUICK REPLIES"
+                            }
+                        },
+                        _webchat: {
+                            message: {
+                                text: "WEBCHAT QUICK REPLIES"
+                            }
+                        },
+                    }
+                }, "bot", {
+                    enableDefaultPreview: true
+                });
+
+                cy.contains("DEFAULT QUICK REPLIES").should('be.visible');
+            });
+
+            it('should prefer adaptivecards from the default tab over quick replies from the webchat tab', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("", {
+                    _cognigy: {
+                        _default: {
+                            _adaptiveCard: {
+                                type: "adaptiveCard",
+                                adaptiveCard: {
+                                    type: "AdaptiveCard",
+                                    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                    version: "1.5",
+                                    body: [
+                                        {
+                                            type: "TextBlock",
+                                            text: "DEFAULT ADAPTIVECARDS",
+                                            wrap: true
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        _webchat: {
+                            message: {
+                                text: "WEBCHAT QUICK REPLIES"
+                            }
+                        }
+                    }
+                }, "bot", {
+                    enableDefaultPreview: true
+                });
+
+                cy.contains("DEFAULT ADAPTIVECARDS").should('be.visible');
+            });
+        });
+    });
 });
 
 

--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -1,0 +1,115 @@
+
+interface IGenerateTestCaseParams {
+    webchatTabConfigured: boolean;
+    facebookTabConfigured: boolean;
+    syncWebchatWithFacebookConfigured: boolean;
+    enableStrictMessengerSync: boolean;
+    expectedOutcome: 'webchat' | 'facebook' | 'none';
+}
+
+const renderMessageWithParams = (params: IGenerateTestCaseParams) => {
+    cy.visitMessageRenderer();
+    
+    const config = {
+        settings: {
+            enableStrictMessengerSync: params.enableStrictMessengerSync
+        }
+    };
+
+    const getDummyMessage = (text: string) => ({
+        message: {
+            text,
+            quick_replies: []
+        }
+    });
+
+    const messageData = {
+        _cognigy: {
+            _webchat: params.webchatTabConfigured ? getDummyMessage('RENDER WEBCHAT') : null,
+            _facebook: params.facebookTabConfigured ? getDummyMessage("RENDER FACEBOOK") : null,
+            syncWebchatWithFacebook: params.syncWebchatWithFacebookConfigured
+        }
+    };
+
+
+    cy.renderMessage("", messageData, 'bot', config);
+}
+
+const expectOutcomeFromParams = (params: IGenerateTestCaseParams) => {
+    switch (params.expectedOutcome) {
+        case 'facebook':
+            return cy.contains('RENDER FACEBOOK').should('be.visible');
+
+        case 'webchat':
+            return cy.contains('RENDER WEBCHAT').should('be.visible');
+
+        case 'none':
+            return cy.contains('RENDER').should('not.be.visible');
+    }
+}
+
+const getTestDescriptionFromParams = (params: IGenerateTestCaseParams) => {
+    return `If _webchat: ${params.webchatTabConfigured},
+    _facebook: ${params.facebookTabConfigured}, 
+    enableStrictMessengerSync: ${params.enableStrictMessengerSync},
+    syncWebchatWithFacebookConfigured: ${params.syncWebchatWithFacebookConfigured}
+    Should render ${params.expectedOutcome}`; // generated test tescription from params
+}
+
+const generateTestCase = (params: IGenerateTestCaseParams) => {
+    const description = getTestDescriptionFromParams(params);
+
+    it(description, () => {
+        // launch webchat with settings
+        renderMessageWithParams(params);
+
+        // expect rendered outcome
+        expectOutcomeFromParams(params);
+    });
+}
+
+type GenerateTestCaseParamsArray = [boolean, boolean, boolean, boolean, IGenerateTestCaseParams['expectedOutcome']];
+
+const getTestCaseObject = ([webchatTabConfigured, facebookTabConfigured, syncWebchatWithFacebookConfigured, enableStrictMessengerSync, expectedOutcome]: GenerateTestCaseParamsArray): IGenerateTestCaseParams => ({
+    webchatTabConfigured,
+    facebookTabConfigured,
+    syncWebchatWithFacebookConfigured,
+    enableStrictMessengerSync,
+    expectedOutcome
+});
+
+describe("Channel Rendering Priorities", () => {
+    describe("Messenger Plugin", () => {
+        describe("Without strict Messenger Sync", () => {
+            const testcases = [
+                // [_webchat, _facebook, syncWebchatWithFacebook, enableStrictMessengerSync, expectedResult]
+                [   false,    false,     false,                   false,                     null          ],
+                [   true,     false,     false,                   false,                     'webchat'     ],
+                [   false,    true,      false,                   false,                     'facebook'    ],
+                [   true,     true,      false,                   false,                     'webchat'     ],
+            ];
+            
+            testcases.map(getTestCaseObject).forEach(generateTestCase);
+        });
+
+        describe("With strict Messenger Sync", () => {
+            const testcases = [
+                // [_webchat, _facebook, syncWebchatWithFacebook, enableStrictMessengerSync, expectedResult]
+                [   true,     false,     false,                   true,                      'webchat'     ],
+                [   false,    true,      false,                   true,                      null          ],
+                [   true,     true,      false,                   true,                      'webchat'     ],
+                [   false,    false,     false,                   true,                      null          ],
+                [   false,    false,     true,                    true,                      null          ],
+                [   true,     false,     true,                    true,                      null          ],
+                [   false,    true,      true,                    true,                      'facebook'    ],
+                [   true,     true,      true,                    true,                      'facebook'    ],
+            ];
+            
+            testcases.map(getTestCaseObject).forEach(generateTestCase);
+        });
+    });
+
+});
+
+
+

--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -347,6 +347,49 @@ describe("Channel Rendering Priorities", {
                 cy.contains("WEBCHAT QUICK REPLIES").should('be.visible');
             });
 
+            it('should prefer adaptivecard from the webchat tab over adaptivecard from the default tab', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("", {
+                    _cognigy: {
+                        _webchat: {
+                            adaptiveCard: {
+                                type: "AdaptiveCard",
+                                $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                version: "1.5",
+                                body: [
+                                    {
+                                        type: "TextBlock",
+                                        text: "WEBCHAT ADAPTIVE CARD",
+                                        wrap: true
+                                    }
+                                ]
+                            }
+                        },
+                        _defaultPreview: {
+                            adaptiveCard: {
+                                type: "AdaptiveCard",
+                                $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                version: "1.5",
+                                body: [
+                                    {
+                                        type: "TextBlock",
+                                        text: "DEFAULT ADAPTIVE CARD",
+                                        wrap: true
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }, "bot", {
+                    settings: {
+                        enableDefaultPreview: false
+                    }
+                });
+
+                cy.contains("WEBCHAT ADAPTIVE CARD").should('be.visible');
+            });
+
             it('should prefer text from the default tab over adaptivecards from the webchat tab', () => {
                 cy.visitMessageRenderer();
 

--- a/cypress/integration/priorities.spec.ts
+++ b/cypress/integration/priorities.spec.ts
@@ -307,26 +307,6 @@ describe("Channel Rendering Priorities", {
                 cy.contains("WEBCHAT QUICK REPLIES").should('be.visible');
             });
 
-            it('should prefer text from the default tab over quick replies from the webchat tab', () => {
-                cy.visitMessageRenderer();
-
-                cy.renderMessage("DEFAULT TEXT", {
-                    _cognigy: {
-                        _webchat: {
-                            message: {
-                                text: "WEBCHAT QUICK REPLIES"
-                            }
-                        },
-                    }
-                }, "bot", {
-                    settings: {
-                        enableDefaultPreview: true
-                    }
-                });
-
-                cy.contains("DEFAULT TEXT").should('be.visible');
-            });
-
             it('should prefer quick replies from the webchat tab over text from the default tab', () => {
                 cy.visitMessageRenderer();
 
@@ -421,8 +401,67 @@ describe("Channel Rendering Priorities", {
                     }
                 });
 
-            cy.contains("DEFAULT QUICK REPLIES").should('be.visible');
-        });
+                cy.contains("DEFAULT QUICK REPLIES").should('be.visible');
+            });
+
+            it('should prefer webchat adaptive card over default Quick reply', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("", {
+                    _cognigy: {
+                        _webchat: {
+                            adaptiveCard: {
+                                type: "AdaptiveCard",
+                                $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                version: "1.5",
+                                body: [
+                                    {
+                                        type: "TextBlock",
+                                        text: "WEBCHAT ADAPTIVE CARD",
+                                        wrap: true
+                                    }
+                                ]
+                            }
+                        },
+                        _defaultPreview: {
+                            message: {
+                                text: "DEFAULT QUICK REPLIES"
+                            }
+                        },
+                    }
+                }, "bot", {
+                    settings: {
+                        enableDefaultPreview: false
+                    }
+                });
+
+                cy.contains("WEBCHAT ADAPTIVE CARD").should('be.visible');
+            });
+
+            it('should prefer webchat quick replies over default quick replies', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("", {
+                    _cognigy: {
+                        _webchat: {
+                            message: {
+                                text: "WEBCHAT QUICK REPLIES"
+                            }
+                        },
+                        _defaultPreview: {
+                            message: {
+                                text: "DEFAULT QUICK REPLIES"
+                            }
+                        },
+                    }
+                }, "bot", {
+                    settings: {
+                        enableDefaultPreview: false
+                    }
+                });
+
+                cy.contains("WEBCHAT QUICK REPLIES").should('be.visible');
+            });
 
             it('should prefer text from the default tab over adaptivecards from the webchat tab', () => {
                 cy.visitMessageRenderer();
@@ -452,35 +491,79 @@ describe("Channel Rendering Priorities", {
 
             });
 
-                it('should prefer adaptive cards from the webchat tab over text from the default tab ', () => {
-                    cy.visitMessageRenderer();
-    
-                    cy.renderMessage("DEFAULT TEXT", {
-                        _cognigy: {
-                            _webchat: {
-                                adaptiveCard: {
-                                    type: "AdaptiveCard",
-                                    $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                                    version: "1.5",
-                                    body: [
-                                        {
-                                            type: "TextBlock",
-                                            text: "DEFAULT TEXT ADAPTIVE CARD",
-                                            wrap: true
-                                        }
-                                    ]
-                                }
+            it('should prefer adaptive cards from the webchat tab over text from the default tab ', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("DEFAULT TEXT", {
+                    _cognigy: {
+                        _webchat: {
+                            adaptiveCard: {
+                                type: "AdaptiveCard",
+                                $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                version: "1.5",
+                                body: [
+                                    {
+                                        type: "TextBlock",
+                                        text: "DEFAULT TEXT ADAPTIVE CARD",
+                                        wrap: true
+                                    }
+                                ]
                             }
                         }
-                    }, "bot", {
-                        settings: {
-                            enableDefaultPreview: false
+                    }
+                }, "bot", {
+                    settings: {
+                        enableDefaultPreview: false
+                    }
+                });
+
+                cy.contains("DEFAULT TEXT ADAPTIVE CARD").should('be.visible');
+            });
+
+            it('should prefer adaptive cards from the default tab over adaptivecard from the webchat tab ', () => {
+                cy.visitMessageRenderer();
+
+                cy.renderMessage("", {
+                    _cognigy: {
+                        _webchat: {
+                            adaptiveCard: {
+                                type: "AdaptiveCard",
+                                $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                version: "1.5",
+                                body: [
+                                    {
+                                        type: "TextBlock",
+                                        text: "WEBCHAT TEXT ADAPTIVE CARD",
+                                        wrap: true
+                                    }
+                                ]
+                            }
+                        },
+                        _defaultPreview: {
+                            adaptiveCard: {
+                                type: "AdaptiveCard",
+                                $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                                version: "1.5",
+                                body: [
+                                    {
+                                        type: "TextBlock",
+                                        text: "DEFAULT TEXT ADAPTIVE CARD",
+                                        wrap: true
+                                    }
+                                ]
+                            }
                         }
-                    });
+                    }
+                }, "bot", {
+                    settings: {
+                        enableDefaultPreview: true
+                    }
+                });
 
                 cy.contains("DEFAULT TEXT ADAPTIVE CARD").should('be.visible');
             });
         });
+
     });
 });
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -10,7 +10,7 @@
     <script>
         initWebchat('https://endpoint-trial.cognigy.ai/325a1e29b99441f4640ba659706763fb77006e00dc0e3720600f523557d7afaa', {
             userId: "user",
-            sessionId: "session666",
+            sessionId: "session",
             settings: {
                 // colorScheme: '#FAB'
                 enableUnreadMessageSound: true,
@@ -21,51 +21,11 @@
                 getStartedText: "",
                 engagementMessageText: "Hi there!",
                 engagementMessageDelay: 5000,
-                enableDefaultPreview: false
             }
         }).then(function (webchat) {
             window.cognigyWebchat = webchat;
             // webchat.open();
-            webchat.sendMessage("", {
-                _cognigy: {
-                    _webchat: {
-                        // message: {
-                        //     text: "WEBCHAT QUICK REPLIES"
-                        // },
-                        adaptiveCard: {
-                            type: "AdaptiveCard",
-                            $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                            version: "1.5",
-                            body: [
-                                {
-                                    type: "TextBlock",
-                                    text: "WEBCHAT ADAPTIVECARDS",
-                                    wrap: true
-                                }
-                            ]
-                        }
-                    },
-                    _defaultPreview: {
-                        message: {
-                            text: "DEFAULT PREVIEW MESSAGE"
-                        }
-                    },
-                    //     adaptiveCard: {
-                    //         type: "AdaptiveCard",
-                    //         $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                    //         version: "1.5",
-                    //         body: [
-                    //             {
-                    //                 type: "TextBlock",
-                    //                 text: "DEFAULT ADAPTIVECARDS",
-                    //                 wrap: true
-                    //             }
-                    //         ]
-                    //     },
-                    // },
-                }
-            })
-        });
+        })
     </script>
 </body>
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -10,7 +10,7 @@
     <script>
         initWebchat('https://endpoint-trial.cognigy.ai/325a1e29b99441f4640ba659706763fb77006e00dc0e3720600f523557d7afaa', {
             userId: "user",
-            sessionId: "session",
+            sessionId: "session666",
             settings: {
                 // colorScheme: '#FAB'
                 enableUnreadMessageSound: true,
@@ -20,11 +20,51 @@
                 showEngagementMessagesInChat: true,
                 getStartedText: "",
                 engagementMessageText: "Hi there!",
-                engagementMessageDelay: 5000
+                engagementMessageDelay: 5000,
+                enableDefaultPreview: false
             }
-        }).then(function(webchat) {
+        }).then(function (webchat) {
             window.cognigyWebchat = webchat;
             // webchat.open();
+            webchat.sendMessage("", {
+                _cognigy: {
+                    _webchat: {
+                        // message: {
+                        //     text: "WEBCHAT QUICK REPLIES"
+                        // },
+                        adaptiveCard: {
+                            type: "AdaptiveCard",
+                            $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                            version: "1.5",
+                            body: [
+                                {
+                                    type: "TextBlock",
+                                    text: "WEBCHAT ADAPTIVECARDS",
+                                    wrap: true
+                                }
+                            ]
+                        }
+                    },
+                    _defaultPreview: {
+                        message: {
+                            text: "DEFAULT PREVIEW MESSAGE"
+                        }
+                    },
+                    //     adaptiveCard: {
+                    //         type: "AdaptiveCard",
+                    //         $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                    //         version: "1.5",
+                    //         body: [
+                    //             {
+                    //                 type: "TextBlock",
+                    //                 text: "DEFAULT ADAPTIVECARDS",
+                    //                 wrap: true
+                    //             }
+                    //         ]
+                    //     },
+                    // },
+                }
+            })
         });
     </script>
 </body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -20,47 +20,11 @@
                 showEngagementMessagesInChat: true,
                 getStartedText: "",
                 engagementMessageText: "Hi there!",
-                engagementMessageDelay: 5000,
-                enableDefaultPreview: false
+                engagementMessageDelay: 5000
             }
         }).then(function(webchat) {
             window.cognigyWebchat = webchat;
             // webchat.open();
-            webchat.sendMessage("", {
-            _cognigy: {
-                _defaultPreview: {
-                    adaptiveCard: {
-                        type: "AdaptiveCard",
-                        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                        version: "1.5",
-                        body: [
-                            {
-                                type: "TextBlock",
-                                text: "DEFAULT ADAPTIVECARDS",
-                                wrap: true
-                            }
-                        ]
-                    }
-                },
-                _webchat: {
-                    message: {
-                        text: "WEBCHAT QUICK REPLIES"
-                    }
-                    // adaptiveCard: {
-                    //     type: "AdaptiveCard",
-                    //     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                    //     version: "1.5",
-                    //     body: [
-                    //         {
-                    //             type: "TextBlock",
-                    //             text: "WEBCHAT ADAPTIVECARDS",
-                    //             wrap: true
-                    //         }
-                    //     ]
-                    // }
-                }
-            }
-        })
         });
     </script>
 </body>

--- a/dist/index.html
+++ b/dist/index.html
@@ -20,11 +20,47 @@
                 showEngagementMessagesInChat: true,
                 getStartedText: "",
                 engagementMessageText: "Hi there!",
-                engagementMessageDelay: 5000
+                engagementMessageDelay: 5000,
+                enableDefaultPreview: false
             }
         }).then(function(webchat) {
             window.cognigyWebchat = webchat;
             // webchat.open();
+            webchat.sendMessage("", {
+            _cognigy: {
+                _defaultPreview: {
+                    adaptiveCard: {
+                        type: "AdaptiveCard",
+                        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                        version: "1.5",
+                        body: [
+                            {
+                                type: "TextBlock",
+                                text: "DEFAULT ADAPTIVECARDS",
+                                wrap: true
+                            }
+                        ]
+                    }
+                },
+                _webchat: {
+                    message: {
+                        text: "WEBCHAT QUICK REPLIES"
+                    }
+                    // adaptiveCard: {
+                    //     type: "AdaptiveCard",
+                    //     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                    //     version: "1.5",
+                    //     body: [
+                    //         {
+                    //             type: "TextBlock",
+                    //             text: "WEBCHAT ADAPTIVECARDS",
+                    //             wrap: true
+                    //         }
+                    //     ]
+                    // }
+                }
+            }
+        })
         });
     </script>
 </body>

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -41,6 +41,7 @@ export interface IWebchatSettings {
   enableUnreadMessagePreview: boolean;
   enableUnreadMessageSound: boolean;
   enableUnreadMessageTitleIndicator: boolean;
+  enableDefaultPreview: boolean;
   engagementMessageDelay: number;
   engagementMessageText: string;
   focusInputAfterPostback: boolean;

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import AdaptiveCard from './components/Adaptivecard'
 import { registerMessagePlugin } from '../helper';
-
 import { updateAdaptiveCardCSSCheaply } from './styles';
 
 const isAdaptiveCard = (message) => {
-    if (message.data?._cognigy?._webchat?.adaptiveCard || message.data?._plugin?.type === "adaptivecards") {
+    if (message.data?._cognigy?._defaultPreview?.adaptiveCard || 
+        message.data?._cognigy?._webchat?.adaptiveCard || 
+        message.data?._plugin?.type === "adaptivecards") {
         return true;
     }
     return false;
@@ -13,13 +14,20 @@ const isAdaptiveCard = (message) => {
 
 const AdaptiveCards = (props) => {
 
+    const getCardPayload = (message) => {
+        if (message.data?._cognigy?._defaultPreview?.adaptiveCard){
+            return message.data?._cognigy?._defaultPreview?.adaptiveCard
+        }
+        return message.data?._plugin?.payload || message.data?._cognigy?._webchat?.adaptiveCard
+    }
+
     const { theme, onSendMessage, message } = props;
 
     useEffect(() => {
         updateAdaptiveCardCSSCheaply(theme);
     }, []);
 
-    const cardPayload = message.data?._plugin?.payload || message.data?._cognigy?._webchat?.adaptiveCard;
+    const cardPayload = getCardPayload(message);
 
     const onExecuteAction = useCallback((action) => {
         switch (action._propertyBag?.type) {

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -14,12 +14,11 @@ const isAdaptiveCard = (message: IMessage, config: IWebchatConfig) => {
     const _plugin = message.data?._plugin?.type === "adaptivecards";
     const defaultPreviewEnabled = config.settings.enableDefaultPreview;
 
-    // if (message.data?._cognigy?._defaultPreview?.message && defaultPreviewEnabled){
-    //     return false;
-    // }
+    if (message.data?._cognigy?._defaultPreview?.message && defaultPreviewEnabled){
+        return false;
+    }
 
-    if (!(message.data?._cognigy?._defaultPreview?.message && defaultPreviewEnabled) ||
-        _defaultPreview && defaultPreviewEnabled ||
+    if (_defaultPreview && defaultPreviewEnabled ||
         _webchat && _defaultPreview && !defaultPreviewEnabled || 
         _webchat || 
         _plugin){

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -5,13 +5,26 @@ import { IMessage } from "../../common/interfaces/message";
 import { IWebchatConfig } from "../../common/interfaces/webchat-config";
 import { updateAdaptiveCardCSSCheaply } from './styles';
 
+
 const isAdaptiveCard = (message: IMessage, config: IWebchatConfig) => {
-    if (message.data?._cognigy?._webchat?.adaptiveCard || 
-        !(message.data?._cognigy?._defaultPreview?.adaptiveCard && !config.settings.enableDefaultPreview) &&
-        message.data?._cognigy?._defaultPreview?.adaptiveCard || 
-        message.data?._plugin?.type === "adaptivecards") {
+
+    // configurations that should use adaptive cards plugin 
+    const _webchat = message.data?._cognigy?._webchat?.adaptiveCard;
+    const _defaultPreview = message.data?._cognigy?._defaultPreview?.adaptiveCard;
+    const _plugin = message.data?._plugin?.type === "adaptivecards";
+    const defaultPreviewEnabled = config.settings.enableDefaultPreview;
+
+    if (message.data?._cognigy?._defaultPreview?.message && defaultPreviewEnabled){
+        return false;
+    }
+
+    if (_defaultPreview && defaultPreviewEnabled ||
+        _webchat && _defaultPreview && !defaultPreviewEnabled || 
+        _webchat || 
+        _plugin){
         return true;
     }
+    
     return false;
 }
 
@@ -20,11 +33,21 @@ const AdaptiveCards = (props) => {
     const { theme, onSendMessage, message, config } = props;
 
     const getCardPayload = (message: IMessage) => {
-        if (message.data?._cognigy?._defaultPreview?.adaptiveCard && config.settings.enableDefaultPreview){
-            return message.data?._cognigy?._defaultPreview?.adaptiveCard
+
+        const _webchat = message.data?._cognigy?._webchat?.adaptiveCard;
+        const _defaultPreview = message.data?._cognigy?._defaultPreview?.adaptiveCard;
+        const _plugin = message.data?._plugin?.payload;
+        const defaultPreviewEnabled = config.settings.enableDefaultPreview;
+
+        if (_webchat && _defaultPreview  && !defaultPreviewEnabled){
+            return _webchat
         }
-        return message.data?._plugin?.payload || message.data?._cognigy?._webchat?.adaptiveCard
+        if (_defaultPreview && defaultPreviewEnabled){
+            return _defaultPreview
+        }
+        return _plugin || _webchat
     }
+    
 
     useEffect(() => {
         updateAdaptiveCardCSSCheaply(theme);

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -17,21 +17,21 @@ const isAdaptiveCard = (message: IMessage, config: IWebchatConfig) => {
 
 const AdaptiveCards = (props) => {
 
+    const { theme, onSendMessage, message, config } = props;
+
     const getCardPayload = (message: IMessage) => {
-        if (message.data?._cognigy?._defaultPreview?.adaptiveCard){
+        if (message.data?._cognigy?._defaultPreview?.adaptiveCard && config.settings.enableDefaultPreview){
             return message.data?._cognigy?._defaultPreview?.adaptiveCard
         }
         return message.data?._plugin?.payload || message.data?._cognigy?._webchat?.adaptiveCard
     }
 
-    const { theme, onSendMessage, message, config} = props;
-
     useEffect(() => {
         updateAdaptiveCardCSSCheaply(theme);
     }, []);
 
-    const cardPayload = getCardPayload(message, config);
-console.log("message", message)
+    const cardPayload = getCardPayload(message);
+
     const onExecuteAction = useCallback((action) => {
         switch (action._propertyBag?.type) {
             case "Action.Submit": {

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -1,11 +1,14 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
 import AdaptiveCard from './components/Adaptivecard'
 import { registerMessagePlugin } from '../helper';
+import { IMessage } from "../../common/interfaces/message";
+import { IWebchatConfig } from "../../common/interfaces/webchat-config";
 import { updateAdaptiveCardCSSCheaply } from './styles';
 
-const isAdaptiveCard = (message) => {
-    if (message.data?._cognigy?._defaultPreview?.adaptiveCard || 
-        message.data?._cognigy?._webchat?.adaptiveCard || 
+const isAdaptiveCard = (message: IMessage, config: IWebchatConfig) => {
+    if (message.data?._cognigy?._webchat?.adaptiveCard || 
+        !(message.data?._cognigy?._defaultPreview?.adaptiveCard && !config.settings.enableDefaultPreview) &&
+        message.data?._cognigy?._defaultPreview?.adaptiveCard || 
         message.data?._plugin?.type === "adaptivecards") {
         return true;
     }
@@ -14,21 +17,21 @@ const isAdaptiveCard = (message) => {
 
 const AdaptiveCards = (props) => {
 
-    const getCardPayload = (message) => {
+    const getCardPayload = (message: IMessage) => {
         if (message.data?._cognigy?._defaultPreview?.adaptiveCard){
             return message.data?._cognigy?._defaultPreview?.adaptiveCard
         }
         return message.data?._plugin?.payload || message.data?._cognigy?._webchat?.adaptiveCard
     }
 
-    const { theme, onSendMessage, message } = props;
+    const { theme, onSendMessage, message, config} = props;
 
     useEffect(() => {
         updateAdaptiveCardCSSCheaply(theme);
     }, []);
 
-    const cardPayload = getCardPayload(message);
-
+    const cardPayload = getCardPayload(message, config);
+console.log("message", message)
     const onExecuteAction = useCallback((action) => {
         switch (action._propertyBag?.type) {
             case "Action.Submit": {

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -14,11 +14,12 @@ const isAdaptiveCard = (message: IMessage, config: IWebchatConfig) => {
     const _plugin = message.data?._plugin?.type === "adaptivecards";
     const defaultPreviewEnabled = config.settings.enableDefaultPreview;
 
-    if (message.data?._cognigy?._defaultPreview?.message && defaultPreviewEnabled){
-        return false;
-    }
+    // if (message.data?._cognigy?._defaultPreview?.message && defaultPreviewEnabled){
+    //     return false;
+    // }
 
-    if (_defaultPreview && defaultPreviewEnabled ||
+    if (!(message.data?._cognigy?._defaultPreview?.message && defaultPreviewEnabled) ||
+        _defaultPreview && defaultPreviewEnabled ||
         _webchat && _defaultPreview && !defaultPreviewEnabled || 
         _webchat || 
         _plugin){

--- a/src/plugins/messenger/index.tsx
+++ b/src/plugins/messenger/index.tsx
@@ -44,18 +44,24 @@ const getMessengerPayload = (message: IMessage, config: IWebchatConfig) => {
     const { _facebook, _webchat, _defaultPreview } = cognigyData;
 
     if (config.settings.enableDefaultPreview) {
-
-        if (message?.data?.text && !_defaultPreview) {
-            return message.data.text
+        if (_defaultPreview) {
+            return _defaultPreview;
+        } else if (message.text) {
+            // supposed to be rendered with regular text plugin
+            // not handled by the "messenger plugin"
+            return null;
+        } else if (_webchat) {
+            return _webchat;
+        } else if (_facebook) {
+            return _facebook
         }
-        return _defaultPreview;
+
+        return null;
     }
     
     if (config.settings.enableStrictMessengerSync){
         return preferFacebook(cognigyData, config.settings.enableStrictMessengerSync);
     }
-
-    preferFacebook(cognigyData, config.settings.enableStrictMessengerSync);
 
     return _webchat || _facebook;
 }

--- a/src/plugins/messenger/index.tsx
+++ b/src/plugins/messenger/index.tsx
@@ -18,10 +18,9 @@ const preferFacebook = (conigyData, enableStrictMessengerSync) => {
     }
 };
 
-
 const getMessengerPayload = (message: IMessage, config: IWebchatConfig) => {
 
-    //check if message uses messenger plugin
+    // conditions to not use messenger plugin
     if (!message.data?._cognigy?._webchat?.message &&
         !message.data?._data?._cognigy?._webchat?.message &&
         !message.data?._cognigy?._facebook?.message &&

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -44,6 +44,7 @@ export const getInitialState = (): ConfigState => ({
     enableUnreadMessagePreview: false,
     enableUnreadMessageSound: false,
     enableUnreadMessageTitleIndicator: false,
+    enableDefaultPreview: false,
     engagementMessageDelay: 5000,
     engagementMessageText: "",
     focusInputAfterPostback: false,


### PR DESCRIPTION
This PR is adding a new setting to WebchatWidget enableDefaultPreview, that allows choosing preference to a new field for rendering _defaultPreview.
This setting should not affect any previous behaviour when disabled. but when enabled should take prefer _defaultPreview for rendering with message-renderer, messenger plugin and adaptive cards plugins. 

There were extensive tests written to make sure that we do not miss the most logical and used cases. Spec file related is priorites.spec.ts

How to test:
1. Run Automated tests with `npm run test`
To test manually:
1. Run `npm run dev`
2.  in the index.html add the new setting flag
3. send a webchat.sendMessage() with different payloads to check