### PR TITLE
Update datepicker, add possibility to disable or enable dates by fn

### DIFF
--- a/cypress/fixtures/messages/date-picker-function-invalid.json
+++ b/cypress/fixtures/messages/date-picker-function-invalid.json
@@ -1,0 +1,24 @@
+{
+	"text": "",
+	"data": {
+		"_plugin": {
+			"type": "date-picker",
+			"data": {
+				"eventName": "foobar012",
+				"locale": "en",
+				"enableTime": false,
+				"mode": "single",
+				"wantDisable": true,
+				"enable_disable": null,
+				"function_enable_disable": "(date) => { return date.invalidFunction() }",
+				"minDate": "",
+				"maxDate": "",
+				"openPickerButtonText": "foobar012b1",
+				"cancelButtonText": "foobar012b2",
+				"submitButtonText": "foobar012b3",
+				"time_24hr": true,
+				"dateFormat": ""
+			}
+		}
+	}
+}

--- a/cypress/fixtures/messages/date-picker-function.json
+++ b/cypress/fixtures/messages/date-picker-function.json
@@ -1,0 +1,24 @@
+{
+	"text": "",
+	"data": {
+		"_plugin": {
+			"type": "date-picker",
+			"data": {
+				"eventName": "foobar012",
+				"locale": "en",
+				"enableTime": false,
+				"mode": "single",
+				"wantDisable": true,
+				"enable_disable": null,
+				"function_enable_disable": "(date) => { return date.getDay() %2 === 0; }",
+				"minDate": "",
+				"maxDate": "",
+				"openPickerButtonText": "foobar012b1",
+				"cancelButtonText": "foobar012b2",
+				"submitButtonText": "foobar012b3",
+				"time_24hr": true,
+				"dateFormat": ""
+			}
+		}
+	}
+}

--- a/cypress/fixtures/messages/date-picker.json
+++ b/cypress/fixtures/messages/date-picker.json
@@ -12,6 +12,7 @@
 				"enable_disable": null,
 				"minDate": "today",
 				"maxDate": "tomorrow",
+				"function_enable_disable": "",
 				"openPickerButtonText": "foobar012b1",
 				"cancelButtonText": "foobar012b2",
 				"submitButtonText": "foobar012b3",

--- a/cypress/integration/messages/datePicker.spec.ts
+++ b/cypress/integration/messages/datePicker.spec.ts
@@ -101,31 +101,34 @@ describe("Date Picker", () => {
         })
     })
 
-    it("should have class disabled for %2 dates from today", () => {                
-        const today = moment().format("D");       
-        const yesterday = moment().subtract(1, "days").format("D");        
-        const tomorrow = moment().add(1, "days").format("D");        
-        const theDayBeforeYesterday = moment().subtract(2, "days").format("D");        
-        const theDayAfterTomorrow = moment().add(2, "days").format("D");
+    it.only("should have class disabled for %2 weekdays", () => {                
+        /* Calculate the days via moment */
+        const today = moment();       
+        const yesterday = moment().subtract(1, "days");        
+        const tomorrow = moment().add(1, "days");        
+        const theDayBeforeYesterday = moment().subtract(2, "days");        
+        const theDayAfterTomorrow = moment().add(2, "days");
         
-        /* When today %2 is true, the date is enable > not.have.class flatpickr-disabled */                
-        const getDisabledOrEnabledClass = (day: string) => {
-            return parseInt(day) %2 === 0 ? "not.have.class" : "have.class";
+        /* When the weekday %2 is true, the date is disabled > "have.class" "flatpickr-disabled" */                
+        const getDisabledOrEnabledClass = (date) => {           
+           /* get the weekday 0-6 of the date */ 
+            const weekday = new Date(date).getDay();                        
+            return weekday %2 === 0 ?  "have.class": "not.have.class";
         };
-
+               
         cy.withMessageFixture('date-picker-function', () => {
             cy
                 .contains("foobar012b1").click();
             cy
-                .contains(".flatpickr-day", today).should(getDisabledOrEnabledClass(today), "flatpickr-day today flatpickr-disabled");
+                .contains(".flatpickr-day", today.format("D")).should(getDisabledOrEnabledClass(today), "flatpickr-day flatpickr-disabled");
             cy
-                .contains(".flatpickr-day", yesterday).should(getDisabledOrEnabledClass(yesterday), "flatpickr-day yesterday flatpickr-disabled");
+                .contains(".flatpickr-day", yesterday.format("D")).should(getDisabledOrEnabledClass(yesterday), "flatpickr-day flatpickr-disabled");
             cy
-                .contains(".flatpickr-day", tomorrow,).should(getDisabledOrEnabledClass(tomorrow), "flatpickr-day tomorrow flatpickr-disabled");
+                .contains(".flatpickr-day", tomorrow.format("D")).should(getDisabledOrEnabledClass(tomorrow), "flatpickr-day flatpickr-disabled");
             cy
-                .contains(".flatpickr-day", theDayBeforeYesterday).should(getDisabledOrEnabledClass(theDayBeforeYesterday), "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", theDayBeforeYesterday.format("D")).should(getDisabledOrEnabledClass(theDayBeforeYesterday), "flatpickr-day flatpickr-disabled");
             cy
-                .contains(".flatpickr-day", theDayAfterTomorrow).should(getDisabledOrEnabledClass(theDayAfterTomorrow), "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", theDayAfterTomorrow.format("D")).should(getDisabledOrEnabledClass(theDayAfterTomorrow), "flatpickr-day flatpickr-disabled");
         })
     })
 

--- a/cypress/integration/messages/datePicker.spec.ts
+++ b/cypress/integration/messages/datePicker.spec.ts
@@ -108,20 +108,24 @@ describe("Date Picker", () => {
         const theDayBeforeYesterday = moment().subtract(2, "days").format("D");        
         const theDayAfterTomorrow = moment().add(2, "days").format("D");
         
+        /* When today %2 is true, the date is enable > not.have.class flatpickr-disabled */                
+        const getDisabledOrEnabledClass = (day: string) => {
+            return parseInt(day) %2 === 0 ? "not.have.class" : "have.class";
+        };
+
         cy.withMessageFixture('date-picker-function', () => {
             cy
                 .contains("foobar012b1").click();
             cy
-                .contains(".flatpickr-day", today).should("not.have.class", "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", today).should(getDisabledOrEnabledClass(today), "flatpickr-day today flatpickr-disabled");
             cy
-                .contains(".flatpickr-day", yesterday).should("have.class", "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", yesterday).should(getDisabledOrEnabledClass(yesterday), "flatpickr-day yesterday flatpickr-disabled");
             cy
-                .contains(".flatpickr-day", tomorrow,).should("have.class", "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", tomorrow,).should(getDisabledOrEnabledClass(tomorrow), "flatpickr-day tomorrow flatpickr-disabled");
             cy
-                .contains(".flatpickr-day", theDayBeforeYesterday).should("not.have.class", "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", theDayBeforeYesterday).should(getDisabledOrEnabledClass(theDayBeforeYesterday), "flatpickr-day flatpickr-disabled");
             cy
-                .contains(".flatpickr-day", theDayAfterTomorrow).should("not.have.class", "flatpickr-day flatpickr-disabled");
-
+                .contains(".flatpickr-day", theDayAfterTomorrow).should(getDisabledOrEnabledClass(theDayAfterTomorrow), "flatpickr-day flatpickr-disabled");
         })
     })
 

--- a/cypress/integration/messages/datePicker.spec.ts
+++ b/cypress/integration/messages/datePicker.spec.ts
@@ -124,4 +124,11 @@ describe("Date Picker", () => {
 
         })
     })
+
+    it("should render the date picker even if the provided function throws a TypeError", () => {                        
+        cy.withMessageFixture('date-picker-function-invalid', () => {
+            cy
+                .contains("foobar012b1").click();
+        })
+    })
 })

--- a/cypress/integration/messages/datePicker.spec.ts
+++ b/cypress/integration/messages/datePicker.spec.ts
@@ -84,7 +84,7 @@ describe("Date Picker", () => {
                 .should("be.focused");
         })
     })
-    
+
     it("should trap focus", () => {
         cy.withMessageFixture('date-picker', () => {
             cy
@@ -101,22 +101,27 @@ describe("Date Picker", () => {
         })
     })
 
-    it.only("should have class disabled for %2 dates from today", () => {
-        const today = new Date().getDate();
-                        
+    it("should have class disabled for %2 dates from today", () => {                
+        const today = moment().format("D");       
+        const yesterday = moment().subtract(1, "days").format("D");        
+        const tomorrow = moment().add(1, "days").format("D");        
+        const theDayBeforeYesterday = moment().subtract(2, "days").format("D");        
+        const theDayAfterTomorrow = moment().add(2, "days").format("D");
+        
         cy.withMessageFixture('date-picker-function', () => {
             cy
-                .contains("foobar012b1").click();       
+                .contains("foobar012b1").click();
             cy
-                .contains(`${today}`).should("not.have.class", "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", today).should("not.have.class", "flatpickr-day flatpickr-disabled");
             cy
-                .contains(`${today - 1}`).should("have.class", "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", yesterday).should("have.class", "flatpickr-day flatpickr-disabled");
             cy
-                .contains(`${today + 1}`).should("have.class", "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", tomorrow,).should("have.class", "flatpickr-day flatpickr-disabled");
             cy
-                .contains(`${today + 2}`).should("not.have.class", "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", theDayBeforeYesterday).should("not.have.class", "flatpickr-day flatpickr-disabled");
             cy
-                .contains(`${today - 2}`).should("not.have.class", "flatpickr-day flatpickr-disabled");
+                .contains(".flatpickr-day", theDayAfterTomorrow).should("not.have.class", "flatpickr-day flatpickr-disabled");
+
         })
     })
 })

--- a/cypress/integration/messages/datePicker.spec.ts
+++ b/cypress/integration/messages/datePicker.spec.ts
@@ -100,4 +100,23 @@ describe("Date Picker", () => {
                 .get(".flatpickr-calendar ").should("be.focused");
         })
     })
+
+    it.only("should have class disabled for %2 dates from today", () => {
+        const today = new Date().getDate();
+                        
+        cy.withMessageFixture('date-picker-function', () => {
+            cy
+                .contains("foobar012b1").click();       
+            cy
+                .contains(`${today}`).should("not.have.class", "flatpickr-day flatpickr-disabled");
+            cy
+                .contains(`${today - 1}`).should("have.class", "flatpickr-day flatpickr-disabled");
+            cy
+                .contains(`${today + 1}`).should("have.class", "flatpickr-day flatpickr-disabled");
+            cy
+                .contains(`${today + 2}`).should("not.have.class", "flatpickr-day flatpickr-disabled");
+            cy
+                .contains(`${today - 2}`).should("not.have.class", "flatpickr-day flatpickr-disabled");
+        })
+    })
 })

--- a/cypress/integration/messages/datePicker.spec.ts
+++ b/cypress/integration/messages/datePicker.spec.ts
@@ -101,7 +101,7 @@ describe("Date Picker", () => {
         })
     })
 
-    it.only("should have class disabled for %2 weekdays", () => {                
+    it("should have class disabled for %2 weekdays", () => {                
         /* Calculate the days via moment */
         const today = moment();       
         const yesterday = moment().subtract(1, "days");        

--- a/src/plugins/date-picker/index.tsx
+++ b/src/plugins/date-picker/index.tsx
@@ -352,7 +352,7 @@ const datePickerPlugin: MessagePluginFactory = ({ styled }) => {
         .map(DatePicker.transformNamedDate);
         
 	  // the code in function_enable_disable was executed in a vm to check that its return value is from type boolean
-      if (data.function_enable_disable.length > 0) {
+      if (data?.function_enable_disable?.length > 0) {
         const fn = new Function(`"use strict"; return  ${data.function_enable_disable}`)();        
         mask.push(fn);                        
        }

--- a/src/plugins/date-picker/index.tsx
+++ b/src/plugins/date-picker/index.tsx
@@ -322,8 +322,8 @@ const datePickerPlugin: MessagePluginFactory = ({ styled }) => {
         weekNumbers: data.weekNumbers || false,
         dateFormat: enableTime ? `${dateFormat} ${timeFormat}` : dateFormat,
         defaultDate,
-        disable: [] as string[],
-        enable: [] as string[],
+        disable: [] as any[],
+        enable: [] as any[],
         enableTime,
         event: data.eventName,
         inline: true,
@@ -340,7 +340,7 @@ const datePickerPlugin: MessagePluginFactory = ({ styled }) => {
           : undefined
       };
 
-      const mask: string[] = [...(data.enable_disable || [])]
+      const mask: any[] = [...(data.enable_disable || [])]
         // add special rule for weekends
         .map(dateString => {
           if (dateString === 'weekends')
@@ -350,6 +350,12 @@ const datePickerPlugin: MessagePluginFactory = ({ styled }) => {
         })
         // resolve relative date names like today, tomorrow or yesterday
         .map(DatePicker.transformNamedDate);
+        
+	  // the code in function_enable_disable was executed in a vm to check that its return value is from type boolean
+      if (data.function_enable_disable.length > 0) {
+        const fn = new Function(`"use strict"; return  ${data.function_enable_disable}`)();        
+        mask.push(fn);                        
+       }
 
       if (!!data.wantDisable) {
         // add date mask as blacklist

--- a/src/plugins/date-picker/index.tsx
+++ b/src/plugins/date-picker/index.tsx
@@ -353,8 +353,13 @@ const datePickerPlugin: MessagePluginFactory = ({ styled }) => {
         
 	  // the code in function_enable_disable was executed in a vm to check that its return value is from type boolean
       if (data?.function_enable_disable?.length > 0) {
-        const fn = new Function(`"use strict"; return  ${data.function_enable_disable}`)();        
-        mask.push(fn);                        
+        try {
+          const flatpickrFn = new Function(`"use strict"; return  ${data.function_enable_disable}`)();        
+          /* The Flatpickr function takes in a Date object */
+          if (typeof flatpickrFn(new Date()) === "boolean") {            
+            mask.push(flatpickrFn);                  
+          }
+        } catch (e) { }     
        }
 
       if (!!data.wantDisable) {


### PR DESCRIPTION
This PR adds the possibility to disable or enable dates by function.

* This functions was executed before in service-ai in a VM to ensure that the function does not contain any malformed code.
* The function is forced to return a boolen or null
* Added a cypress test where each date is alternately deactivated. Starting with the next | previous day.