### PR TITLE
Add "Inner Socket Handshake"

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -50,17 +50,18 @@ You can pass [Webchat Options](#webchat-options) as an additional argument to th
 
 ### Webchat Options
 
-| Name              | Type                                    | Default                                          | Description                                                                                                      |
-| ----------------- | --------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| userId            | string                                  | random string[<sup>1</sup>](#persistent-user-id) | The user's id                                                                                                    |
-| sessionId         | string                                  | random string                                    | The session's id                                                                                                 |
-| channel           | string                                  | `"webchat-client"`                               | The name of your client. Can be useful for analytics                                                             |
-| reconnection      | boolean                                 | `true`                                           | If `true`, will try to re-establish the connection after losing it                                               |
-| reconnectionLimit | number                                  | `5`                                              | Limit the maximum number of reconnection attempts, `0` means no limit                                            |
-| interval          | number                                  | `10000`                                          | Interval time in miliseconds the webchat will wait inbetween polls when falling back to HTTP polling.            |
-| forceWebsockets   | boolean                                 | auto-determined by runtime-environment           | If `true`, the client will only use websockets and not fall back to http polling (wins over `disableWebsockets`) |
-| disableWebsockets | boolean                                 | false                                            | If `true`, the client will only use http polling and will not try to upgrade to websockets                       |
-| settings          | [Endpoint Settings](#endpoint-settings) | -                                                | Can be used to (partially) override certain Settings from the Webchat Endpoint                                   |
+| Name                       | Type                                    | Default                                          | Description                                                                                                               |
+| -------------------------- | --------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| userId                     | string                                  | random string[<sup>1</sup>](#persistent-user-id) | The user's id                                                                                                             |
+| sessionId                  | string                                  | random string                                    | The session's id                                                                                                          |
+| channel                    | string                                  | `"webchat-client"`                               | The name of your client. Can be useful for analytics                                                                      |
+| reconnection               | boolean                                 | `true`                                           | If `true`, will try to re-establish the connection after losing it                                                        |
+| reconnectionLimit          | number                                  | `5`                                              | Limit the maximum number of reconnection attempts, `0` means no limit                                                     |
+| interval                   | number                                  | `10000`                                          | Interval time in miliseconds the webchat will wait inbetween polls when falling back to HTTP polling.                     |
+| forceWebsockets            | boolean                                 | auto-determined by runtime-environment           | If `true`, the client will only use websockets and not fall back to http polling (wins over `disableWebsockets`)          |
+| disableWebsockets          | boolean                                 | false                                            | If `true`, the client will only use http polling and will not try to upgrade to websockets                                |
+| enableInnerSocketHandshake | boolean                                 | false                                            | If `true`, the client will pass `userId`, `sessionId` and `URLToken` through a socket handshake instead of via URL params |
+| settings                   | [Endpoint Settings](#endpoint-settings) | -                                                | Can be used to (partially) override certain Settings from the Webchat Endpoint                                            |
 
 <sup id="persistent-user-id">1</sup> The `userId` will be randomly generated on first page load and then persisted user via `LocalStorage`. When that user reloads the page, the Webchat will re-use the `userId` from `LocalStorage`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
-        "@cognigy/socket-client": "4.6.0",
+        "@cognigy/socket-client": "4.6.3",
         "@emotion/cache": "^10.0.29",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -1998,9 +1998,9 @@
       }
     },
     "node_modules/@cognigy/socket-client": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.6.0.tgz",
-      "integrity": "sha512-fWGovE50H/eGJzIsmPsiuM5ZpgMMe4p46tk7HjrIRW9i+Zrmbg7ZX4CGMdcAMvev2UaGi7X7WbiLW3fPrM1A2w==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.6.3.tgz",
+      "integrity": "sha512-lS2vcOpyrryIbRLttLmkYadYelmq6X61iz9NvemP/bGeMZdexViFGsw84/ObuDuOaOeXtIpjYF9Zg3zChDwhdQ==",
       "dependencies": {
         "detect-browser": "^4.8.0",
         "socket.io-client": "^2.4.0",
@@ -14083,9 +14083,9 @@
       }
     },
     "@cognigy/socket-client": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.6.0.tgz",
-      "integrity": "sha512-fWGovE50H/eGJzIsmPsiuM5ZpgMMe4p46tk7HjrIRW9i+Zrmbg7ZX4CGMdcAMvev2UaGi7X7WbiLW3fPrM1A2w==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.6.3.tgz",
+      "integrity": "sha512-lS2vcOpyrryIbRLttLmkYadYelmq6X61iz9NvemP/bGeMZdexViFGsw84/ObuDuOaOeXtIpjYF9Zg3zChDwhdQ==",
       "requires": {
         "detect-browser": "^4.8.0",
         "socket.io-client": "^2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
-        "@cognigy/socket-client": "^4.5.4",
+        "@cognigy/socket-client": "4.6.0",
         "@emotion/cache": "^10.0.29",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -1998,9 +1998,9 @@
       }
     },
     "node_modules/@cognigy/socket-client": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.5.5.tgz",
-      "integrity": "sha512-4OC+9jequOvtsVj6WoUGwoStZY74qG5UAVw7wDxWD+bb14g2/qYxFJZnFWdG11Rkiq4lwkYV0WHOXG9V8wGLYw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.6.0.tgz",
+      "integrity": "sha512-fWGovE50H/eGJzIsmPsiuM5ZpgMMe4p46tk7HjrIRW9i+Zrmbg7ZX4CGMdcAMvev2UaGi7X7WbiLW3fPrM1A2w==",
       "dependencies": {
         "detect-browser": "^4.8.0",
         "socket.io-client": "^2.4.0",
@@ -14083,9 +14083,9 @@
       }
     },
     "@cognigy/socket-client": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.5.5.tgz",
-      "integrity": "sha512-4OC+9jequOvtsVj6WoUGwoStZY74qG5UAVw7wDxWD+bb14g2/qYxFJZnFWdG11Rkiq4lwkYV0WHOXG9V8wGLYw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.6.0.tgz",
+      "integrity": "sha512-fWGovE50H/eGJzIsmPsiuM5ZpgMMe4p46tk7HjrIRW9i+Zrmbg7ZX4CGMdcAMvev2UaGi7X7WbiLW3fPrM1A2w==",
       "requires": {
         "detect-browser": "^4.8.0",
         "socket.io-client": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.0",
-    "@cognigy/socket-client": "4.6.0",
+    "@cognigy/socket-client": "4.6.3",
     "@emotion/cache": "^10.0.29",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.0",
-    "@cognigy/socket-client": "^4.5.4",
+    "@cognigy/socket-client": "4.6.0",
     "@emotion/cache": "^10.0.29",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",


### PR DESCRIPTION
...by upgrading @cognigy/socket-client to v4.6.3.

If the `innerSocketHandshake` option is set in `initWebchat`, the connection should be established in a way that `userId`, `sessionId` and `URLToken` are not passed through URL params, but through the websocket after the connection.