### PR TITLE
Bug/14769 handle phone number button type

### DIFF
--- a/cypress/integration/messages/buttons.spec.ts
+++ b/cypress/integration/messages/buttons.spec.ts
@@ -63,4 +63,12 @@ describe("Message with Buttons", () => {
             })
         })
     })
+
+    it("phone number button should be an anchor element with 'href' attribute", () => {
+        cy.withMessageFixture('buttons', () => {
+            cy.get('a[aria-label="Item 4 of 4: foobar005b4"]')
+            .invoke("attr", "href")
+            .should("contain", `tel:000111222`);
+        })
+    })
 })

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
@@ -50,7 +50,7 @@ export const getMessengerButton = ({ React, styled }: MessagePluginFactoryProps)
         const buttonType = button.type;
         const buttonPayload = button.payload;
         const isWebURL = buttonType === "web_url";
-        const isPhoneNumber = buttonType === "phone_number";
+        const isPhoneNumber = buttonPayload && buttonType === "phone_number";
         const buttonTitle = button.title ? button.title + ". " : "";
         const isWebURLButtonTargetBlank = button.target !== "_self";
         const buttonTitleWithTarget = isWebURL && isWebURLButtonTargetBlank ? buttonTitle + "Opens in new tab" : button.title;

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
@@ -67,7 +67,7 @@ export const getMessengerButton = ({ React, styled }: MessagePluginFactoryProps)
                 dangerouslySetInnerHTML={{__html}} 
                 role={isWebURL ? "link" : undefined} 
                 aria-label={ariaLabel}
-                href={isPhoneNumber && buttonPayload ? `tel:${buttonPayload}` : undefined}
+                href={isPhoneNumber ? `tel:${buttonPayload}` : undefined}
             />
         )
     }

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
@@ -14,7 +14,7 @@ interface IMessengerButtonProps {
 
 export const getMessengerButton = ({ React, styled }: MessagePluginFactoryProps) => {
 
-    const ComponentStyles = (({ theme }) => ({
+    const componentStyles = (({ theme }) => ({
         display: 'block',
         color: theme.primaryColor,
         border: 'none',
@@ -37,11 +37,11 @@ export const getMessengerButton = ({ React, styled }: MessagePluginFactoryProps)
         }
     }))
 
-    const Button = styled.button(ComponentStyles, {
+    const Button = styled.button(componentStyles, {
         width: '100%',
     });
 
-    const Link = styled.a(ComponentStyles, {
+    const Link = styled.a(componentStyles, {
         textDecoration: 'none',
         textAlign: 'center'
     });

--- a/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerButton/MessengerButton.tsx
@@ -14,12 +14,11 @@ interface IMessengerButtonProps {
 
 export const getMessengerButton = ({ React, styled }: MessagePluginFactoryProps) => {
 
-    const Button = styled.button(({ theme }) => ({
+    const ComponentStyles = (({ theme }) => ({
         display: 'block',
         color: theme.primaryColor,
         border: 'none',
         backgroundColor: 'white',
-        width: '100%',
         padding: `10px 20px`,
         fontSize: 15,
         cursor: 'pointer',
@@ -27,20 +26,31 @@ export const getMessengerButton = ({ React, styled }: MessagePluginFactoryProps)
 
         '&:hover': {
             backgroundColor: 'hsl(0, 0%, 97%)'
-		},
-		
-		'&:focus': {
+        },
+        
+        '&:focus': {
             backgroundColor: 'hsl(0, 0%, 92%)'
         },
 
         '&:active': {
             backgroundColor: 'hsl(0, 0%, 92%)'
         }
-    }));
+    }))
+
+    const Button = styled.button(ComponentStyles, {
+        width: '100%',
+    });
+
+    const Link = styled.a(ComponentStyles, {
+        textDecoration: 'none',
+        textAlign: 'center'
+    });
 
     const MessengerButton = ({ button, position, total, ...props }: IMessengerButtonProps & React.ComponentProps<typeof Button>) => {		
         const buttonType = button.type;
+        const buttonPayload = button.payload;
         const isWebURL = buttonType === "web_url";
+        const isPhoneNumber = buttonType === "phone_number";
         const buttonTitle = button.title ? button.title + ". " : "";
         const isWebURLButtonTargetBlank = button.target !== "_self";
         const buttonTitleWithTarget = isWebURL && isWebURLButtonTargetBlank ? buttonTitle + "Opens in new tab" : button.title;
@@ -49,12 +59,15 @@ export const getMessengerButton = ({ React, styled }: MessagePluginFactoryProps)
         const buttonLabel = getButtonLabel(button);
         const __html = props.config.settings.disableHtmlContentSanitization ? buttonLabel : sanitizeHTML(buttonLabel)
 
+        const Component = isPhoneNumber ? Link : Button;
+
         return (
-            <Button 
+            <Component
                 {...props} 
                 dangerouslySetInnerHTML={{__html}} 
                 role={isWebURL ? "link" : undefined} 
                 aria-label={ariaLabel}
+                href={isPhoneNumber && buttonPayload ? `tel:${buttonPayload}` : undefined}
             />
         )
     }


### PR DESCRIPTION
Success Criteria
- Clicking on a Phone number button should open the Phone app to place a call
- Phone number should rendered using an anchor element instead of button element
- Link is rendered without issues even if Phone number payload is missing
- Anchor element used to render phone number should look similar to the rest of the button elements
- The button elements should remain unchanged and work as before

How to test:
- Create a Flow and add a Say node of output type text with buttons
- Add a button of type phone number and enter the phone number as payload
- Create a webchat endpoint and use this to test the above success criteria