### PR TITLE
Bug/35074 fix phone number quick reply button

### DIFF
--- a/src/plugins/messenger/MessengerPreview/components/MessengerQuickReply.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerQuickReply.tsx
@@ -1,35 +1,47 @@
 import { MessagePluginFactoryProps } from '../../../../common/interfaces/message-plugin';
 
+const componentStyles = (({ theme }) => ({
+    backgroundColor: 'transparent',
+    border: `1px solid ${theme.primaryColor}`,
+    borderRadius: theme.unitSize * 5,
+    padding: `${theme.unitSize / 2}px ${theme.unitSize * 2}px`,
+    minHeight: theme.unitSize * 5,
+    minWidth: theme.unitSize * 5,
+    fontSize: 15,
+    color: theme.primaryColor,
+    cursor: 'pointer',
+    outline: 'none',
+    transition: 'transform .1s ease-out',
+
+    '&:hover': {
+        borderColor: theme.primaryStrongColor,
+        color: theme.primaryStrongColor,
+        transform: 'translate(0px, -1px)'
+    },
+    
+    '&:focus': {
+        outline: 'none',
+        boxShadow: `0 0 3px 1px ${theme.primaryWeakColor}`,
+    },
+
+    '&:active': {
+        transform: 'translate(0px, 0px)'
+    }
+}));
+
 export const getMessengerQuickReply = ({ React, styled }: MessagePluginFactoryProps) => {
 
-    const MessengerQuickReply = styled.button(({ theme }) => ({
-        backgroundColor: 'transparent',
-        border: `1px solid ${theme.primaryColor}`,
-        borderRadius: theme.unitSize * 5,
-        padding: `${theme.unitSize / 2}px ${theme.unitSize * 2}px`,
-        minHeight: theme.unitSize * 5,
-        minWidth: theme.unitSize * 5,
-        fontSize: 15,
-        color: theme.primaryColor,
-        cursor: 'pointer',
-        outline: 'none',
-        transition: 'transform .1s ease-out',
-
-        '&:hover': {
-            borderColor: theme.primaryStrongColor,
-            color: theme.primaryStrongColor,
-            transform: 'translate(0px, -1px)'
-		},
-		
-		'&:focus': {
-			outline: 'none',
-			boxShadow: `0 0 3px 1px ${theme.primaryWeakColor}`,
-        },
-
-        '&:active': {
-            transform: 'translate(0px, 0px)'
-        }
-    }));
+    const MessengerQuickReply = styled.button(componentStyles);
 
     return MessengerQuickReply;
+}
+
+export const getMessengerPhoneNumberQuickReply = ({ React, styled }: MessagePluginFactoryProps) => {
+
+    const MessengerPhoneNumberQuickReply = styled.a(componentStyles, {
+        display: 'inline-flex',
+        textDecoration: 'none',
+    });
+
+    return MessengerPhoneNumberQuickReply;
 }

--- a/src/plugins/messenger/MessengerPreview/components/MessengerQuickReply.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerQuickReply.tsx
@@ -31,8 +31,8 @@ const componentStyles = (({ theme }) => ({
 export const getMessengerQuickReply = ({ React, styled }: MessagePluginFactoryProps) => {
 
     const MessengerQuickReply = styled.button(componentStyles, {
-		minHeight: 40,
-	});
+        minHeight: 40,
+    });
 
     return MessengerQuickReply;
 }
@@ -40,11 +40,11 @@ export const getMessengerQuickReply = ({ React, styled }: MessagePluginFactoryPr
 export const getMessengerPhoneNumberQuickReply = ({ React, styled }: MessagePluginFactoryProps) => {
 
     const MessengerPhoneNumberQuickReply = styled.a(componentStyles, {
-		minHeight: 30,
+        minHeight: 30,
         display: 'inline-flex',
         textDecoration: 'none',
-		justifyContent: 'center',
-		alignItems: 'center'
+        justifyContent: 'center',
+        alignItems: 'center'
     });
 
     return MessengerPhoneNumberQuickReply;

--- a/src/plugins/messenger/MessengerPreview/components/MessengerQuickReply.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerQuickReply.tsx
@@ -5,7 +5,6 @@ const componentStyles = (({ theme }) => ({
     border: `1px solid ${theme.primaryColor}`,
     borderRadius: theme.unitSize * 5,
     padding: `${theme.unitSize / 2}px ${theme.unitSize * 2}px`,
-    minHeight: theme.unitSize * 5,
     minWidth: theme.unitSize * 5,
     fontSize: 15,
     color: theme.primaryColor,
@@ -31,7 +30,9 @@ const componentStyles = (({ theme }) => ({
 
 export const getMessengerQuickReply = ({ React, styled }: MessagePluginFactoryProps) => {
 
-    const MessengerQuickReply = styled.button(componentStyles);
+    const MessengerQuickReply = styled.button(componentStyles, {
+		minHeight: 40,
+	});
 
     return MessengerQuickReply;
 }
@@ -39,8 +40,11 @@ export const getMessengerQuickReply = ({ React, styled }: MessagePluginFactoryPr
 export const getMessengerPhoneNumberQuickReply = ({ React, styled }: MessagePluginFactoryProps) => {
 
     const MessengerPhoneNumberQuickReply = styled.a(componentStyles, {
+		minHeight: 30,
         display: 'inline-flex',
         textDecoration: 'none',
+		justifyContent: 'center',
+		alignItems: 'center'
     });
 
     return MessengerPhoneNumberQuickReply;

--- a/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
@@ -25,7 +25,7 @@ export const getMessengerTextWithQuickReplies = ({
     styled
 }: MessagePluginFactoryProps) => {
     const MessengerQuickReply = getMessengerQuickReply({ React, styled });
-	const MessengerPhoneNumberQuickReply = getMessengerPhoneNumberQuickReply({ React, styled });
+    const MessengerPhoneNumberQuickReply = getMessengerPhoneNumberQuickReply({ React, styled });
     const MessengerBubble = getMessengerBubble({ React, styled });
 
     const BorderBubble = styled(MessengerBubble)(({ theme }) => ({
@@ -115,7 +115,7 @@ export const getMessengerTextWithQuickReplies = ({
                                     break;
                                 }
 
-								case "phone_number":
+                                case "phone_number":
                                 case "text": {
                                     const { title, image_url, image_alt_text } = quickReply as IFBMTextQuickReply;
                                     label = title;
@@ -131,21 +131,21 @@ export const getMessengerTextWithQuickReplies = ({
 
                             const __html = config.settings.disableHtmlContentSanitization ? label : sanitizeHTML(label);
                             const ariaLabel = hasMoreThanOneQuickReply ? `Item ${index + 1} of ${quick_replies?.length}: ${__html}` : undefined;
-							
-							if(content_type === "phone_number") {
-								return (
-									<MessengerPhoneNumberQuickReply
-										key={index}	
-										href={`tel:${payload}`}
-										className="webchat-quick-reply-template-reply"
-										id={`${webchatQuickReplyTemplateButtonId}-${index}`}
-										aria-label={ariaLabel}
+                            
+                            if(content_type === "phone_number") {
+                                return (
+                                    <MessengerPhoneNumberQuickReply
+                                        key={index}	
+                                        href={`tel:${payload}`}
+                                        className="webchat-quick-reply-template-reply"
+                                        id={`${webchatQuickReplyTemplateButtonId}-${index}`}
+                                        aria-label={ariaLabel}
                                 >
                                     {image}
                                     <span dangerouslySetInnerHTML={{ __html }} />
                                 </MessengerPhoneNumberQuickReply>
-								)
-							}
+                                )
+                            }
                             return (
                                 <MessengerQuickReply
                                     key={index}

--- a/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
@@ -4,7 +4,7 @@ import {
     IFBMTextQuickReply,
     IFBMQuickReply
 } from '../../interfaces/QuickReply.interface';
-import { getMessengerQuickReply } from '../MessengerQuickReply';
+import { getMessengerPhoneNumberQuickReply, getMessengerQuickReply } from '../MessengerQuickReply';
 import { IWithFBMActionEventHandler } from '../../MessengerPreview.interface';
 import { MessagePluginFactoryProps } from '../../../../../common/interfaces/message-plugin';
 import { IWebchatConfig } from '../../../../../common/interfaces/webchat-config';
@@ -25,6 +25,7 @@ export const getMessengerTextWithQuickReplies = ({
     styled
 }: MessagePluginFactoryProps) => {
     const MessengerQuickReply = getMessengerQuickReply({ React, styled });
+	const MessengerPhoneNumberQuickReply = getMessengerPhoneNumberQuickReply({ React, styled });
     const MessengerBubble = getMessengerBubble({ React, styled });
 
     const BorderBubble = styled(MessengerBubble)(({ theme }) => ({
@@ -104,8 +105,8 @@ export const getMessengerTextWithQuickReplies = ({
                 {hasQuickReplies && (
                     <QuickReplies className="webchat-quick-reply-template-replies-container" {...a11yProps}>
                         {(quick_replies as IFBMQuickReply[]).map((quickReply, index) => {
-                            const { content_type } = quickReply;
-                            let label: string = "";
+                            const { content_type, payload } = quickReply;
+                            let label = "";
                             let image: React.ReactNode;
 
                             switch (content_type) {
@@ -114,6 +115,7 @@ export const getMessengerTextWithQuickReplies = ({
                                     break;
                                 }
 
+								case "phone_number":
                                 case "text": {
                                     const { title, image_url, image_alt_text } = quickReply as IFBMTextQuickReply;
                                     label = title;
@@ -125,16 +127,25 @@ export const getMessengerTextWithQuickReplies = ({
                                     label = "Send Email-Address";
                                     break;
                                 }
-
-                                case "user_phone_number": {
-                                    label = "Send Phone Number";
-                                    break;
-                                }
                             }
 
                             const __html = config.settings.disableHtmlContentSanitization ? label : sanitizeHTML(label);
                             const ariaLabel = hasMoreThanOneQuickReply ? `Item ${index + 1} of ${quick_replies?.length}: ${__html}` : undefined;
-
+							
+							if(content_type === "phone_number") {
+								return (
+									<MessengerPhoneNumberQuickReply
+										key={index}	
+										href={`tel:${payload}`}
+										className="webchat-quick-reply-template-reply"
+										id={`${webchatQuickReplyTemplateButtonId}-${index}`}
+										aria-label={ariaLabel}
+                                >
+                                    {image}
+                                    <span dangerouslySetInnerHTML={{ __html }} />
+                                </MessengerPhoneNumberQuickReply>
+								)
+							}
                             return (
                                 <MessengerQuickReply
                                     key={index}

--- a/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
+++ b/src/plugins/messenger/MessengerPreview/components/MessengerTextWithQuickReplies/MessengerTextWithQuickReplies.tsx
@@ -115,7 +115,7 @@ export const getMessengerTextWithQuickReplies = ({
                                     break;
                                 }
 
-                                case "phone_number":
+                                case "user_phone_number":
                                 case "text": {
                                     const { title, image_url, image_alt_text } = quickReply as IFBMTextQuickReply;
                                     label = title;
@@ -132,7 +132,7 @@ export const getMessengerTextWithQuickReplies = ({
                             const __html = config.settings.disableHtmlContentSanitization ? label : sanitizeHTML(label);
                             const ariaLabel = hasMoreThanOneQuickReply ? `Item ${index + 1} of ${quick_replies?.length}: ${__html}` : undefined;
                             
-                            if(content_type === "phone_number") {
+                            if(content_type === "user_phone_number") {
                                 return (
                                     <MessengerPhoneNumberQuickReply
                                         key={index}	

--- a/src/plugins/messenger/MessengerPreview/interfaces/QuickReply.interface.ts
+++ b/src/plugins/messenger/MessengerPreview/interfaces/QuickReply.interface.ts
@@ -3,7 +3,7 @@ export type IFBMQuickReply = IFBMTextQuickReply
     | IFBMEmailQuickReply;
 
 export interface IFBMTextQuickReply {
-    content_type: 'text' | 'phone_number';
+    content_type: 'text' | 'user_phone_number';
     title: string;
     payload: string;
     image_url?: string;

--- a/src/plugins/messenger/MessengerPreview/interfaces/QuickReply.interface.ts
+++ b/src/plugins/messenger/MessengerPreview/interfaces/QuickReply.interface.ts
@@ -1,10 +1,9 @@
 export type IFBMQuickReply = IFBMTextQuickReply
     | IFBMLocationQuickReply
-    | IFBMPhoneQuickReply
     | IFBMEmailQuickReply;
 
 export interface IFBMTextQuickReply {
-    content_type: 'text';
+    content_type: 'text' | 'phone_number';
     title: string;
     payload: string;
     image_url?: string;
@@ -13,10 +12,6 @@ export interface IFBMTextQuickReply {
 
 export interface IFBMLocationQuickReply {
     content_type: 'location';
-}
-
-export interface IFBMPhoneQuickReply {
-    content_type: 'user_phone_number';
 }
 
 export interface IFBMEmailQuickReply {


### PR DESCRIPTION
Success Criteria

- Clicking on a Phone number button in quick replies should open the Phone app to place a call
- Phone number should rendered using an anchor element instead of button element
- Link is rendered without issues even if Phone number payload is missing
- Anchor element used to render phone number should look similar to the rest of the button elements in quick replies
- The button elements should remain unchanged and work as before
- The layout of quick replies is not broken when there are multiple buttons of if button title is multiline

How to test:

- Create a Flow and add a Say node of output type text with quick replies
- Add a button of type phone number and enter the phone number as payload
- Create a webchat endpoint and use this to test the above success criteria