### PR TITLE
Bug/27520 adaptive cards not scrolling

### DIFF
--- a/src/common/interfaces/message-plugin.ts
+++ b/src/common/interfaces/message-plugin.ts
@@ -15,6 +15,7 @@ export interface MessageComponentProps {
     onEmitAnalytics: (name: string, data?: any) => void;
     onSendMessage: MessageSender;
     onSetFullscreen?: () => void;
+    setCardOffsetTop?: (position: number) => void;
     theme: IWebchatTheme;
 }
 

--- a/src/plugins/adaptivecards/components/Adaptivecard.tsx
+++ b/src/plugins/adaptivecards/components/Adaptivecard.tsx
@@ -8,7 +8,7 @@ import { sanitizeHTML } from '../../../webchat/helper/sanitize';
 interface IAdaptiveCardProps {
     hostConfig?: Partial<HostConfig>;
     onExecuteAction?: (actionJson: any) => void;
-    afterRenderCallback?: () => void
+    setForceScrollingTo?: (offsetTop: number) => void;
     payload?: boolean;
 }
 
@@ -37,7 +37,7 @@ MSAdaptiveCard.onProcessMarkdown = (text, result) => {
  * https://github.com/microsoft/AdaptiveCards/blob/5b66a52e0e0cee5074a42dcbe688d608e0327ae4/source/nodejs/adaptivecards-react/src/adaptive-card.tsx
  */
 const AdaptiveCard: FC<IAdaptiveCardProps> = (props) => {
-    const { payload, hostConfig, onExecuteAction, afterRenderCallback } = props;
+    const { payload, hostConfig, onExecuteAction, setForceScrollingTo } = props;
 
     const targetRef = useRef<HTMLDivElement>(null);
     const cardRef = useRef<MSAdaptiveCard>(
@@ -69,7 +69,8 @@ const AdaptiveCard: FC<IAdaptiveCardProps> = (props) => {
             const result = card.render() as HTMLElement;
             targetRef.current.innerHTML = '';
             targetRef.current.appendChild(result);
-            afterRenderCallback && afterRenderCallback();
+            const offsetTop = targetRef.current.offsetTop;
+            setForceScrollingTo && offsetTop && setForceScrollingTo(offsetTop);
         } catch (cardRenderError) {
             console.error('Unable to render Card', cardRenderError);
         }

--- a/src/plugins/adaptivecards/components/Adaptivecard.tsx
+++ b/src/plugins/adaptivecards/components/Adaptivecard.tsx
@@ -8,6 +8,7 @@ import { sanitizeHTML } from '../../../webchat/helper/sanitize';
 interface IAdaptiveCardProps {
     hostConfig?: Partial<HostConfig>;
     onExecuteAction?: (actionJson: any) => void;
+    afterRenderCallback?: () => void
     payload?: boolean;
 }
 
@@ -36,7 +37,7 @@ MSAdaptiveCard.onProcessMarkdown = (text, result) => {
  * https://github.com/microsoft/AdaptiveCards/blob/5b66a52e0e0cee5074a42dcbe688d608e0327ae4/source/nodejs/adaptivecards-react/src/adaptive-card.tsx
  */
 const AdaptiveCard: FC<IAdaptiveCardProps> = (props) => {
-    const { payload, hostConfig, onExecuteAction } = props;
+    const { payload, hostConfig, onExecuteAction, afterRenderCallback } = props;
 
     const targetRef = useRef<HTMLDivElement>(null);
     const cardRef = useRef<MSAdaptiveCard>(
@@ -68,6 +69,7 @@ const AdaptiveCard: FC<IAdaptiveCardProps> = (props) => {
             const result = card.render() as HTMLElement;
             targetRef.current.innerHTML = '';
             targetRef.current.appendChild(result);
+            afterRenderCallback && afterRenderCallback();
         } catch (cardRenderError) {
             console.error('Unable to render Card', cardRenderError);
         }

--- a/src/plugins/adaptivecards/components/Adaptivecard.tsx
+++ b/src/plugins/adaptivecards/components/Adaptivecard.tsx
@@ -8,7 +8,7 @@ import { sanitizeHTML } from '../../../webchat/helper/sanitize';
 interface IAdaptiveCardProps {
     hostConfig?: Partial<HostConfig>;
     onExecuteAction?: (actionJson: any) => void;
-    setForceScrollingTo?: (offsetTop: number) => void;
+    setCardOffsetTop?: (offsetTop: number) => void;
     payload?: boolean;
 }
 
@@ -37,7 +37,7 @@ MSAdaptiveCard.onProcessMarkdown = (text, result) => {
  * https://github.com/microsoft/AdaptiveCards/blob/5b66a52e0e0cee5074a42dcbe688d608e0327ae4/source/nodejs/adaptivecards-react/src/adaptive-card.tsx
  */
 const AdaptiveCard: FC<IAdaptiveCardProps> = (props) => {
-    const { payload, hostConfig, onExecuteAction, setForceScrollingTo } = props;
+    const { payload, hostConfig, onExecuteAction, setCardOffsetTop } = props;
 
     const targetRef = useRef<HTMLDivElement>(null);
     const cardRef = useRef<MSAdaptiveCard>(
@@ -69,8 +69,7 @@ const AdaptiveCard: FC<IAdaptiveCardProps> = (props) => {
             const result = card.render() as HTMLElement;
             targetRef.current.innerHTML = '';
             targetRef.current.appendChild(result);
-            const offsetTop = targetRef.current.offsetTop;
-            setForceScrollingTo && offsetTop && setForceScrollingTo(offsetTop);
+            setCardOffsetTop && setCardOffsetTop(targetRef.current.offsetTop);
         } catch (cardRenderError) {
             console.error('Unable to render Card', cardRenderError);
         }

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -30,7 +30,7 @@ const isAdaptiveCard = (message: IMessage, config: IWebchatConfig) => {
 
 const AdaptiveCards = (props) => {
 
-    const { theme, onSendMessage, message, config, afterRenderCallback } = props;
+    const { theme, onSendMessage, message, config, setForceScrollingTo } = props;
 
     const getCardPayload = (message: IMessage) => {
 
@@ -84,7 +84,7 @@ const AdaptiveCards = (props) => {
                 payload={cardPayload}
                 onExecuteAction={onExecuteAction}
                 hostConfig={hostConfig}
-                afterRenderCallback={() => afterRenderCallback()}
+                setForceScrollingTo={offsetTop => setForceScrollingTo(offsetTop)}
             />
         );
     }, [cardPayload]);

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -30,7 +30,7 @@ const isAdaptiveCard = (message: IMessage, config: IWebchatConfig) => {
 
 const AdaptiveCards = (props) => {
 
-    const { theme, onSendMessage, message, config } = props;
+    const { theme, onSendMessage, message, config, afterRenderCallback } = props;
 
     const getCardPayload = (message: IMessage) => {
 
@@ -84,6 +84,7 @@ const AdaptiveCards = (props) => {
                 payload={cardPayload}
                 onExecuteAction={onExecuteAction}
                 hostConfig={hostConfig}
+                afterRenderCallback={() => afterRenderCallback()}
             />
         );
     }, [cardPayload]);

--- a/src/plugins/adaptivecards/index.tsx
+++ b/src/plugins/adaptivecards/index.tsx
@@ -30,7 +30,7 @@ const isAdaptiveCard = (message: IMessage, config: IWebchatConfig) => {
 
 const AdaptiveCards = (props) => {
 
-    const { theme, onSendMessage, message, config, setForceScrollingTo } = props;
+    const { theme, onSendMessage, message, config, setCardOffsetTop } = props;
 
     const getCardPayload = (message: IMessage) => {
 
@@ -84,7 +84,7 @@ const AdaptiveCards = (props) => {
                 payload={cardPayload}
                 onExecuteAction={onExecuteAction}
                 hostConfig={hostConfig}
-                setForceScrollingTo={offsetTop => setForceScrollingTo(offsetTop)}
+                setCardOffsetTop={setCardOffsetTop}
             />
         );
     }, [cardPayload]);

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -57,8 +57,8 @@ export interface WebchatUIProps {
     onClose: () => void;
     onConnect: () => void;
     onToggle: () => void;
-    onSetForceScrollingTo: (offsetTop: number) => void;
-    forceScrollingTo: number;
+    onSetScrollToPosition: (position: number) => void;
+    scrollToPosition: number;
 
     onEmitAnalytics: (event: string, payload?: any) => void;
     onTriggerEngagementMessage: () => void;
@@ -417,8 +417,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             onDismissFullscreenMessage,
             onClose,
             onToggle,
-            onSetForceScrollingTo,
-            forceScrollingTo,
+            onSetScrollToPosition,
+            scrollToPosition,
             onTriggerEngagementMessage,
             webchatRootProps,
             webchatToggleProps,
@@ -546,8 +546,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             hasGivenRating,
             onShowRatingDialog,
             messages,
-            forceScrollingTo,
-            onSetForceScrollingTo
+            scrollToPosition,
+            onSetScrollToPosition
         } = this.props;
 
         const { enableRating } = config.settings;
@@ -569,8 +569,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                 />
                 <HistoryWrapper
                     disableBranding={config.settings.disableBranding}
-                    forceScrollingTo={forceScrollingTo}
-                    setForceScrollingTo={(offsetTop: number) => onSetForceScrollingTo(offsetTop)}
+                    scrollToPosition={scrollToPosition}
+                    setScrollToPosition={onSetScrollToPosition}
                     ref={this.history as any}
                     className="webchat-chat-history"
                     tabIndex={messages?.length === 0 ? -1 : 0} // When no messages, remove chat history from tab order
@@ -608,7 +608,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
     }
 
     renderHistory() {
-        const { messages, typingIndicator, config, onEmitAnalytics } = this.props;
+        const { messages, typingIndicator, config, onEmitAnalytics, onSetScrollToPosition } = this.props;
         const { messagePlugins = [] } = this.state;
 
         const { enableTypingIndicator } = config.settings;
@@ -621,7 +621,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                         key={index}
                         message={message}
                         onSendMessage={this.sendMessage}
-                        setForceScrollingTo={offsetTop => this.props.onSetForceScrollingTo(offsetTop)}
+                        setScrollToPosition={onSetScrollToPosition}
                         onSetFullscreen={() => this.props.onSetFullscreenMessage(message)}
                         onDismissFullscreen={() => { }}
                         config={config}

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -57,8 +57,8 @@ export interface WebchatUIProps {
     onClose: () => void;
     onConnect: () => void;
     onToggle: () => void;
-    onToggleForceScrolling: () => void;
-    forceScrolling: boolean;
+    onSetForceScrollingTo: (offsetTop: number) => void;
+    forceScrollingTo: number;
 
     onEmitAnalytics: (event: string, payload?: any) => void;
     onTriggerEngagementMessage: () => void;
@@ -417,8 +417,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             onDismissFullscreenMessage,
             onClose,
             onToggle,
-            onToggleForceScrolling,
-            forceScrolling,
+            onSetForceScrollingTo,
+            forceScrollingTo,
             onTriggerEngagementMessage,
             webchatRootProps,
             webchatToggleProps,
@@ -546,8 +546,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             hasGivenRating,
             onShowRatingDialog,
             messages,
-            forceScrolling,
-            onToggleForceScrolling
+            forceScrollingTo,
+            onSetForceScrollingTo
         } = this.props;
 
         const { enableRating } = config.settings;
@@ -569,8 +569,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                 />
                 <HistoryWrapper
                     disableBranding={config.settings.disableBranding}
-                    forceScrolling={forceScrolling}
-                    toggleForceScrolling={() => onToggleForceScrolling()}
+                    forceScrollingTo={forceScrollingTo}
+                    setForceScrollingTo={(offsetTop: number) => onSetForceScrollingTo(offsetTop)}
                     ref={this.history as any}
                     className="webchat-chat-history"
                     tabIndex={messages?.length === 0 ? -1 : 0} // When no messages, remove chat history from tab order
@@ -621,14 +621,14 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                         key={index}
                         message={message}
                         onSendMessage={this.sendMessage}
-                        afterRenderCallback={() => this.props.onToggleForceScrolling()}
+                        setForceScrollingTo={offsetTop => this.props.onSetForceScrollingTo(offsetTop)}
                         onSetFullscreen={() => this.props.onSetFullscreenMessage(message)}
                         onDismissFullscreen={() => { }}
                         config={config}
                         plugins={messagePlugins}
                         webchatTheme={this.state.theme}
                         onEmitAnalytics={onEmitAnalytics}
-                    />
+                    />  
                 ))}
                 {enableTypingIndicator && (
                     <TypingIndicator active={isTyping} />

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -570,7 +570,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                 <HistoryWrapper
                     disableBranding={config.settings.disableBranding}
                     forceScrolling={forceScrolling}
-                    onToggleForceScrolling={() => onToggleForceScrolling()}
+                    toggleForceScrolling={() => onToggleForceScrolling()}
                     ref={this.history as any}
                     className="webchat-chat-history"
                     tabIndex={messages?.length === 0 ? -1 : 0} // When no messages, remove chat history from tab order

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -376,7 +376,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
 
     handleSendRating = ({ rating, comment }) => {
         if (this.history.current) {
-            this.history.current.scrollToBottom();
+            this.history.current.handleScrollTo();
         }
 
         this.props.onSendMessage(

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -313,7 +313,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
 
     sendMessage: MessageSender = (...args) => {
         if (this.history.current) {
-            this.history.current.scrollToBottom();
+            this.history.current.handleScrollTo();
         }
 
         this.props.onSendMessage(...args);

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -57,6 +57,8 @@ export interface WebchatUIProps {
     onClose: () => void;
     onConnect: () => void;
     onToggle: () => void;
+    onToggleForceScrolling: () => void;
+    forceScrolling: boolean;
 
     onEmitAnalytics: (event: string, payload?: any) => void;
     onTriggerEngagementMessage: () => void;
@@ -415,6 +417,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             onDismissFullscreenMessage,
             onClose,
             onToggle,
+            onToggleForceScrolling,
+            forceScrolling,
             onTriggerEngagementMessage,
             webchatRootProps,
             webchatToggleProps,
@@ -541,7 +545,9 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             config,
             hasGivenRating,
             onShowRatingDialog,
-            messages
+            messages,
+            forceScrolling,
+            onToggleForceScrolling
         } = this.props;
 
         const { enableRating } = config.settings;
@@ -563,6 +569,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                 />
                 <HistoryWrapper
                     disableBranding={config.settings.disableBranding}
+                    forceScrolling={forceScrolling}
+                    onToggleForceScrolling={() => onToggleForceScrolling()}
                     ref={this.history as any}
                     className="webchat-chat-history"
                     tabIndex={messages?.length === 0 ? -1 : 0} // When no messages, remove chat history from tab order
@@ -613,6 +621,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                         key={index}
                         message={message}
                         onSendMessage={this.sendMessage}
+                        afterRenderCallback={() => this.props.onToggleForceScrolling()}
                         onSetFullscreen={() => this.props.onSetFullscreenMessage(message)}
                         onDismissFullscreen={() => { }}
                         config={config}

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -7,8 +7,8 @@ const CLIENT_HEIGHT_OFFSET = 16 + 70; // banner + typing indicator
 export interface OuterProps extends React.HTMLProps<HTMLDivElement> {
     disableBranding: boolean;
     showFocusOutline: boolean;
-    forceScrollingTo: number;
-    setForceScrollingTo?: (offsetTop: number) => void;
+    scrollToPosition: number;
+    setScrollToPosition?: (position: number) => void;
     tabIndex: 0 | -1;
  }
 
@@ -91,10 +91,10 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
     }
 
     componentDidUpdate(prevProps: InnerProps, prevState: IState, wasScrolledToBottom: boolean) {
-        const { setForceScrollingTo, forceScrollingTo } = this.props;
-        if(forceScrollingTo && setForceScrollingTo) {
-            this.scrollToPosition(forceScrollingTo);
-            setForceScrollingTo(0);
+        const { setScrollToPosition, scrollToPosition } = this.props;
+        if(scrollToPosition && setScrollToPosition) {
+            this.scrollToPosition(scrollToPosition);
+            setScrollToPosition(0);
         } else if (wasScrolledToBottom) {
             this.scrollToBottom();
         }

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -7,8 +7,8 @@ const CLIENT_HEIGHT_OFFSET = 16 + 70; // banner + typing indicator
 export interface OuterProps extends React.HTMLProps<HTMLDivElement> {
     disableBranding: boolean;
     showFocusOutline: boolean;
-    forceScrolling: boolean;
-    toggleForceScrolling?: () => void;
+    forceScrollingTo: number;
+    setForceScrollingTo?: (offsetTop: number) => void;
     tabIndex: 0 | -1;
  }
 
@@ -64,6 +64,22 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
         }
     }
 
+    scrollToPosition = (position: number) => {
+        const root = this.rootRef.current;
+
+        // we need the container reference to perform a scroll on it
+        if (!root)
+            return;
+
+        try {
+            root.scroll({
+                top: position - 70
+            });
+        } catch (e) {
+            root.scrollTop = position;
+        }
+    }
+
     getSnapshotBeforeUpdate() {
         const root = this.rootRef.current;
         if (!root)
@@ -75,12 +91,11 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
     }
 
     componentDidUpdate(prevProps: InnerProps, prevState: IState, wasScrolledToBottom: boolean) {
-        const { toggleForceScrolling, forceScrolling } = this.props;
-        if(forceScrolling && toggleForceScrolling) {
-            this.scrollToBottom();
-            toggleForceScrolling();
-        }
-        if (wasScrolledToBottom) {
+        const { setForceScrollingTo, forceScrollingTo } = this.props;
+        if(forceScrollingTo && setForceScrollingTo) {
+            this.scrollToPosition(forceScrollingTo);
+            setForceScrollingTo(0);
+        } else if (wasScrolledToBottom) {
             this.scrollToBottom();
         }
     }

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -8,7 +8,7 @@ export interface OuterProps extends React.HTMLProps<HTMLDivElement> {
     disableBranding: boolean;
     showFocusOutline: boolean;
     forceScrolling: boolean;
-    onToggleForceScrolling?: () => void;
+    toggleForceScrolling?: () => void;
     tabIndex: 0 | -1;
  }
 
@@ -75,10 +75,10 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
     }
 
     componentDidUpdate(prevProps: InnerProps, prevState: IState, wasScrolledToBottom: boolean) {
-        const { onToggleForceScrolling, forceScrolling } = this.props;
-        if(forceScrolling && onToggleForceScrolling) {
+        const { toggleForceScrolling, forceScrolling } = this.props;
+        if(forceScrolling && toggleForceScrolling) {
             this.scrollToBottom();
-            onToggleForceScrolling();
+            toggleForceScrolling();
         }
         if (wasScrolledToBottom) {
             this.scrollToBottom();

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -46,38 +46,26 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
         this.innerRef = React.createRef();
     }
 
-    scrollToBottom = () => {
+    handleScrollTo = (position?: number) => {
         const root = this.rootRef.current;
 
         // we need the container reference to perform a scroll on it
         if (!root)
             return;
 
-        const scrollTop = root.scrollHeight - root.clientHeight;
+        const scrollTo = position ? position - 70  : root.scrollHeight - root.clientHeight;
 
         try {
             root.scroll({
-                top: scrollTop
+                top: scrollTo
             });
         } catch (e) {
-            root.scrollTop = scrollTop;
+            root.scrollTop = scrollTo;
         }
     }
 
-    scrollToPosition = (position: number) => {
-        const root = this.rootRef.current;
-
-        // we need the container reference to perform a scroll on it
-        if (!root)
-            return;
-
-        try {
-            root.scroll({
-                top: position - 70
-            });
-        } catch (e) {
-            root.scrollTop = position;
-        }
+    scrollToBottom = () => {
+        return this.handleScrollTo();
     }
 
     getSnapshotBeforeUpdate() {
@@ -93,15 +81,15 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
     componentDidUpdate(prevProps: InnerProps, prevState: IState, wasScrolledToBottom: boolean) {
         const { setScrollToPosition, scrollToPosition } = this.props;
         if(scrollToPosition && setScrollToPosition) {
-            this.scrollToPosition(scrollToPosition);
+            this.handleScrollTo(scrollToPosition);
             setScrollToPosition(0);
         } else if (wasScrolledToBottom) {
-            this.scrollToBottom();
+            this.handleScrollTo();
         }
     }
 
     componentDidMount() {
-        this.scrollToBottom();
+        this.handleScrollTo();
     }
 
     // Add outline to the parent element when Chat log receives focus

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -77,11 +77,12 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
         if (!root)
             return;
 
-        const scrollTo = position ? position - 70  : root.scrollHeight - root.clientHeight;
+        const scrollTo = position ? position - 70 : root.scrollHeight - root.clientHeight;
 
         try {
             root.scroll({
-                top: scrollTo
+                top: scrollTo,
+                behavior: "smooth",
             });
         } catch (e) {
             root.scrollTop = scrollTo;

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -7,6 +7,8 @@ const CLIENT_HEIGHT_OFFSET = 16 + 70; // banner + typing indicator
 export interface OuterProps extends React.HTMLProps<HTMLDivElement> {
     disableBranding: boolean;
     showFocusOutline: boolean;
+    forceScrolling: boolean;
+    onToggleForceScrolling?: () => void;
     tabIndex: 0 | -1;
  }
 
@@ -73,6 +75,11 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
     }
 
     componentDidUpdate(prevProps: InnerProps, prevState: IState, wasScrolledToBottom: boolean) {
+        const { onToggleForceScrolling, forceScrolling } = this.props;
+        if(forceScrolling && onToggleForceScrolling) {
+            this.scrollToBottom();
+            onToggleForceScrolling();
+        }
         if (wasScrolledToBottom) {
             this.scrollToBottom();
         }

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -46,28 +46,6 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
         this.innerRef = React.createRef();
     }
 
-    handleScrollTo = (position?: number) => {
-        const root = this.rootRef.current;
-
-        // we need the container reference to perform a scroll on it
-        if (!root)
-            return;
-
-        const scrollTo = position ? position - 70  : root.scrollHeight - root.clientHeight;
-
-        try {
-            root.scroll({
-                top: scrollTo
-            });
-        } catch (e) {
-            root.scrollTop = scrollTo;
-        }
-    }
-
-    scrollToBottom = () => {
-        return this.handleScrollTo();
-    }
-
     getSnapshotBeforeUpdate() {
         const root = this.rootRef.current;
         if (!root)
@@ -90,6 +68,24 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
 
     componentDidMount() {
         this.handleScrollTo();
+    }
+
+    handleScrollTo = (position?: number) => {
+        const root = this.rootRef.current;
+
+        // we need the container reference to perform a scroll on it
+        if (!root)
+            return;
+
+        const scrollTo = position ? position - 70  : root.scrollHeight - root.clientHeight;
+
+        try {
+            root.scroll({
+                top: scrollTo
+            });
+        } catch (e) {
+            root.scrollTop = scrollTo;
+        }
     }
 
     // Add outline to the parent element when Chat log receives focus

--- a/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
@@ -19,6 +19,7 @@ export interface MessageProps extends React.HTMLProps<HTMLDivElement> {
   onSendMessage: MessageSender;
   onSetFullscreen?: () => void;
   onDismissFullscreen?: () => void;
+  afterRenderCallback?: () => void;
   onEmitAnalytics: (name: string, payload?: any) => void;
   plugins: MessagePlugin[];
   isFullscreen?: boolean;
@@ -42,6 +43,7 @@ export default ({
   isFullscreen,
   onSetFullscreen,
   onDismissFullscreen,
+  afterRenderCallback,
   webchatTheme,
   onEmitAnalytics,
   hideAvatar,
@@ -146,6 +148,7 @@ export default ({
               onSendMessage={onSendMessage}
               onSetFullscreen={onSetFullscreen}
               onDismissFullscreen={onDismissFullscreen}
+              afterRenderCallback={afterRenderCallback}
               attributes={attributes}
               isFullscreen={isFullscreen}
               theme={webchatTheme}

--- a/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
@@ -19,7 +19,7 @@ export interface MessageProps extends React.HTMLProps<HTMLDivElement> {
   onSendMessage: MessageSender;
   onSetFullscreen?: () => void;
   onDismissFullscreen?: () => void;
-  setForceScrollingTo?: (offsetTop: number) => void;
+  setScrollToPosition?: (position: number) => void;
   onEmitAnalytics: (name: string, payload?: any) => void;
   plugins: MessagePlugin[];
   isFullscreen?: boolean;
@@ -43,7 +43,7 @@ export default ({
   isFullscreen,
   onSetFullscreen,
   onDismissFullscreen,
-  setForceScrollingTo,
+  setScrollToPosition,
   webchatTheme,
   onEmitAnalytics,
   hideAvatar,
@@ -148,7 +148,7 @@ export default ({
               onSendMessage={onSendMessage}
               onSetFullscreen={onSetFullscreen}
               onDismissFullscreen={onDismissFullscreen}
-              setForceScrollingTo={setForceScrollingTo}
+              setCardOffsetTop={setScrollToPosition}
               attributes={attributes}
               isFullscreen={isFullscreen}
               theme={webchatTheme}

--- a/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/MessagePluginRenderer.tsx
@@ -19,7 +19,7 @@ export interface MessageProps extends React.HTMLProps<HTMLDivElement> {
   onSendMessage: MessageSender;
   onSetFullscreen?: () => void;
   onDismissFullscreen?: () => void;
-  afterRenderCallback?: () => void;
+  setForceScrollingTo?: (offsetTop: number) => void;
   onEmitAnalytics: (name: string, payload?: any) => void;
   plugins: MessagePlugin[];
   isFullscreen?: boolean;
@@ -43,7 +43,7 @@ export default ({
   isFullscreen,
   onSetFullscreen,
   onDismissFullscreen,
-  afterRenderCallback,
+  setForceScrollingTo,
   webchatTheme,
   onEmitAnalytics,
   hideAvatar,
@@ -148,7 +148,7 @@ export default ({
               onSendMessage={onSendMessage}
               onSetFullscreen={onSetFullscreen}
               onDismissFullscreen={onDismissFullscreen}
-              afterRenderCallback={afterRenderCallback}
+              setForceScrollingTo={setForceScrollingTo}
               attributes={attributes}
               isFullscreen={isFullscreen}
               theme={webchatTheme}

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -2,13 +2,13 @@ import { WebchatUI, WebchatUIProps } from "../../webchat-ui";
 import { connect } from "react-redux";
 import { StoreState } from "../store/store";
 import { sendMessage, triggerEngagementMessage } from '../store/messages/message-middleware';
-import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, setForceScrollingTo } from '../store/ui/ui-reducer';
+import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, setScrollToPosition } from '../store/ui/ui-reducer';
 import { getPluginsForMessage, isFullscreenPlugin } from '../../plugins/helper';
 import { connect as doConnect } from "../store/connection/connection-middleware";
 import { setHasGivenRating, showRatingDialog } from "../store/rating/rating-reducer";
 
-type FromState = Pick<WebchatUIProps, 'messages' | 'unseenMessages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config' | 'connected' | 'reconnectionLimit' | 'forceScrollingTo'>;
-type FromDispatch = Pick<WebchatUIProps, 'onSendMessage' | 'onSetInputMode' | 'onSetFullscreenMessage' | 'onDismissFullscreenMessage' | 'onClose' | 'onToggle' | 'onSetForceScrollingTo' | 'onTriggerEngagementMessage'>;
+type FromState = Pick<WebchatUIProps, 'messages' | 'unseenMessages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config' | 'connected' | 'reconnectionLimit' | 'scrollToPosition'>;
+type FromDispatch = Pick<WebchatUIProps, 'onSendMessage' | 'onSetInputMode' | 'onSetFullscreenMessage' | 'onDismissFullscreenMessage' | 'onClose' | 'onToggle' | 'onSetScrollToPosition' | 'onTriggerEngagementMessage'>;
 export type FromProps = Pick<WebchatUIProps, 'messagePlugins' | 'inputPlugins' | 'webchatRootProps' | 'webchatToggleProps'>;
 type Merge = FromState & FromDispatch & FromProps & Pick<WebchatUIProps, 'fullscreenMessage'>;
 
@@ -17,7 +17,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         messages,
         unseenMessages,
         connection: { connected, reconnectionLimit },
-        ui: { open, typing, inputMode, fullscreenMessage, forceScrollingTo },
+        ui: { open, typing, inputMode, fullscreenMessage, scrollToPosition },
         config,
         rating: { showRatingDialog, hasGivenRating, customRatingTitle, customRatingCommentText },
     }) => ({
@@ -25,7 +25,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         unseenMessages,
         open,
         typingIndicator: typing,
-        forceScrollingTo,
+        scrollToPosition,
         inputMode,
         fullscreenMessage,
         config,
@@ -43,7 +43,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         onDismissFullscreenMessage: () => dispatch(setFullscreenMessage(undefined)),
         onClose: () => dispatch(setOpen(false)),
         onToggle: () => dispatch(toggleOpen()),
-        onSetForceScrollingTo: (offsetTop: number) => dispatch(setForceScrollingTo(offsetTop)),
+        onSetScrollToPosition: (position: number) => dispatch(setScrollToPosition(position)),
         onTriggerEngagementMessage: () => dispatch(triggerEngagementMessage()),
         onConnect: () => dispatch(doConnect()),
         onShowRatingDialog: (show: boolean) => dispatch(showRatingDialog(show)),

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -2,13 +2,13 @@ import { WebchatUI, WebchatUIProps } from "../../webchat-ui";
 import { connect } from "react-redux";
 import { StoreState } from "../store/store";
 import { sendMessage, triggerEngagementMessage } from '../store/messages/message-middleware';
-import { setInputMode, setFullscreenMessage, setOpen, toggleOpen } from '../store/ui/ui-reducer';
+import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, toggleForceScrolling } from '../store/ui/ui-reducer';
 import { getPluginsForMessage, isFullscreenPlugin } from '../../plugins/helper';
 import { connect as doConnect } from "../store/connection/connection-middleware";
 import { setHasGivenRating, showRatingDialog } from "../store/rating/rating-reducer";
 
-type FromState = Pick<WebchatUIProps, 'messages' | 'unseenMessages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config' | 'connected' | 'reconnectionLimit'>;
-type FromDispatch = Pick<WebchatUIProps, 'onSendMessage' | 'onSetInputMode' | 'onSetFullscreenMessage' | 'onDismissFullscreenMessage' | 'onClose' | 'onToggle' | 'onTriggerEngagementMessage'>;
+type FromState = Pick<WebchatUIProps, 'messages' | 'unseenMessages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config' | 'connected' | 'reconnectionLimit' | 'forceScrolling'>;
+type FromDispatch = Pick<WebchatUIProps, 'onSendMessage' | 'onSetInputMode' | 'onSetFullscreenMessage' | 'onDismissFullscreenMessage' | 'onClose' | 'onToggle' | 'onToggleForceScrolling' | 'onTriggerEngagementMessage'>;
 export type FromProps = Pick<WebchatUIProps, 'messagePlugins' | 'inputPlugins' | 'webchatRootProps' | 'webchatToggleProps'>;
 type Merge = FromState & FromDispatch & FromProps & Pick<WebchatUIProps, 'fullscreenMessage'>;
 
@@ -17,7 +17,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         messages,
         unseenMessages,
         connection: { connected, reconnectionLimit },
-        ui: { open, typing, inputMode, fullscreenMessage },
+        ui: { open, typing, inputMode, fullscreenMessage, forceScrolling },
         config,
         rating: { showRatingDialog, hasGivenRating, customRatingTitle, customRatingCommentText },
     }) => ({
@@ -25,6 +25,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         unseenMessages,
         open,
         typingIndicator: typing,
+        forceScrolling,
         inputMode,
         fullscreenMessage,
         config,
@@ -42,6 +43,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         onDismissFullscreenMessage: () => dispatch(setFullscreenMessage(undefined)),
         onClose: () => dispatch(setOpen(false)),
         onToggle: () => dispatch(toggleOpen()),
+        onToggleForceScrolling: () => dispatch(toggleForceScrolling()),
         onTriggerEngagementMessage: () => dispatch(triggerEngagementMessage()),
         onConnect: () => dispatch(doConnect()),
         onShowRatingDialog: (show: boolean) => dispatch(showRatingDialog(show)),

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -2,13 +2,13 @@ import { WebchatUI, WebchatUIProps } from "../../webchat-ui";
 import { connect } from "react-redux";
 import { StoreState } from "../store/store";
 import { sendMessage, triggerEngagementMessage } from '../store/messages/message-middleware';
-import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, toggleForceScrolling } from '../store/ui/ui-reducer';
+import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, setForceScrollingTo } from '../store/ui/ui-reducer';
 import { getPluginsForMessage, isFullscreenPlugin } from '../../plugins/helper';
 import { connect as doConnect } from "../store/connection/connection-middleware";
 import { setHasGivenRating, showRatingDialog } from "../store/rating/rating-reducer";
 
-type FromState = Pick<WebchatUIProps, 'messages' | 'unseenMessages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config' | 'connected' | 'reconnectionLimit' | 'forceScrolling'>;
-type FromDispatch = Pick<WebchatUIProps, 'onSendMessage' | 'onSetInputMode' | 'onSetFullscreenMessage' | 'onDismissFullscreenMessage' | 'onClose' | 'onToggle' | 'onToggleForceScrolling' | 'onTriggerEngagementMessage'>;
+type FromState = Pick<WebchatUIProps, 'messages' | 'unseenMessages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config' | 'connected' | 'reconnectionLimit' | 'forceScrollingTo'>;
+type FromDispatch = Pick<WebchatUIProps, 'onSendMessage' | 'onSetInputMode' | 'onSetFullscreenMessage' | 'onDismissFullscreenMessage' | 'onClose' | 'onToggle' | 'onSetForceScrollingTo' | 'onTriggerEngagementMessage'>;
 export type FromProps = Pick<WebchatUIProps, 'messagePlugins' | 'inputPlugins' | 'webchatRootProps' | 'webchatToggleProps'>;
 type Merge = FromState & FromDispatch & FromProps & Pick<WebchatUIProps, 'fullscreenMessage'>;
 
@@ -17,7 +17,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         messages,
         unseenMessages,
         connection: { connected, reconnectionLimit },
-        ui: { open, typing, inputMode, fullscreenMessage, forceScrolling },
+        ui: { open, typing, inputMode, fullscreenMessage, forceScrollingTo },
         config,
         rating: { showRatingDialog, hasGivenRating, customRatingTitle, customRatingCommentText },
     }) => ({
@@ -25,7 +25,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         unseenMessages,
         open,
         typingIndicator: typing,
-        forceScrolling,
+        forceScrollingTo,
         inputMode,
         fullscreenMessage,
         config,
@@ -43,7 +43,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         onDismissFullscreenMessage: () => dispatch(setFullscreenMessage(undefined)),
         onClose: () => dispatch(setOpen(false)),
         onToggle: () => dispatch(toggleOpen()),
-        onToggleForceScrolling: () => dispatch(toggleForceScrolling()),
+        onSetForceScrollingTo: (offsetTop: number) => dispatch(setForceScrollingTo(offsetTop)),
         onTriggerEngagementMessage: () => dispatch(triggerEngagementMessage()),
         onConnect: () => dispatch(doConnect()),
         onShowRatingDialog: (show: boolean) => dispatch(showRatingDialog(show)),

--- a/src/webchat/store/ui/ui-reducer.ts
+++ b/src/webchat/store/ui/ui-reducer.ts
@@ -12,7 +12,7 @@ export interface UIState {
     botAvatarOverrideUrl?: string;
     userAvatarOverrideUrl?: string;
     isPageVisible: boolean;
-    forceScrollingTo: number;
+    scrollToPosition: number;
 }
 
 export const SET_OPEN = 'SET_OPEN';
@@ -28,12 +28,12 @@ export const toggleOpen = () => ({
 });
 export type ToggleOpenAction = ReturnType<typeof toggleOpen>;
 
-const SET_FORCE_SCROLLING_TO = 'SET_FORCE_SCROLLING_TO';
-export const setForceScrollingTo = (offsetTop: number) => ({
-    type: SET_FORCE_SCROLLING_TO as 'SET_FORCE_SCROLLING_TO',
-    offsetTop
+const SET_SCROLL_TO_POSITION = 'SET_SCROLL_TO_POSITION';
+export const setScrollToPosition = (position: number) => ({
+    type: SET_SCROLL_TO_POSITION as 'SET_SCROLL_TO_POSITION',
+    position
 });
-export type SetForceScrollingTo = ReturnType<typeof setForceScrollingTo>;
+export type SetScrollToPosition = ReturnType<typeof setScrollToPosition>;
 
 
 const SET_TYPING = 'SET_TYPING';
@@ -95,7 +95,7 @@ const getInitialState = (): UIState => ({
     botAvatarOverrideUrl: undefined,
     userAvatarOverrideUrl: undefined,
     isPageVisible: isPageVisible(),
-    forceScrollingTo: 0
+    scrollToPosition: 0
 });
 
 type UIAction = SetOpenAction 
@@ -106,7 +106,7 @@ type UIAction = SetOpenAction
     | SetBotAvatarOverrideUrlAction 
     | SetUserAvatarOverrideUrlAction
     | SetPageVisibleAction
-    | SetForceScrollingTo;
+    | SetScrollToPosition;
 
 
 export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action) => {
@@ -125,10 +125,10 @@ export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action
             }
         }
 
-        case SET_FORCE_SCROLLING_TO: {
+        case SET_SCROLL_TO_POSITION: {
             return {
                 ...state,
-                forceScrollingTo: action.offsetTop
+                scrollToPosition: action.position
             }
         }
 

--- a/src/webchat/store/ui/ui-reducer.ts
+++ b/src/webchat/store/ui/ui-reducer.ts
@@ -12,6 +12,7 @@ export interface UIState {
     botAvatarOverrideUrl?: string;
     userAvatarOverrideUrl?: string;
     isPageVisible: boolean;
+    forceScrolling: boolean;
 }
 
 export const SET_OPEN = 'SET_OPEN';
@@ -26,6 +27,13 @@ export const toggleOpen = () => ({
     type: TOGGLE_OPEN as 'TOGGLE_OPEN'
 });
 export type ToggleOpenAction = ReturnType<typeof toggleOpen>;
+
+const TOOGLE_FORCE_SCROLLING = 'TOOGLE_FORCE_SCROLLING';
+export const toggleForceScrolling = () => ({
+    type: TOOGLE_FORCE_SCROLLING as 'TOOGLE_FORCE_SCROLLING'
+});
+export type ToggleForceScrolling = ReturnType<typeof toggleForceScrolling>;
+
 
 const SET_TYPING = 'SET_TYPING';
 export const setTyping = (typing: TTyping) => ({
@@ -85,7 +93,8 @@ const getInitialState = (): UIState => ({
     agentAvatarOverrideUrl: undefined,
     botAvatarOverrideUrl: undefined,
     userAvatarOverrideUrl: undefined,
-    isPageVisible: isPageVisible()
+    isPageVisible: isPageVisible(),
+    forceScrolling: false
 });
 
 type UIAction = SetOpenAction 
@@ -95,7 +104,8 @@ type UIAction = SetOpenAction
     | SetAgentAvatarOverrideUrlAction
     | SetBotAvatarOverrideUrlAction 
     | SetUserAvatarOverrideUrlAction
-    | SetPageVisibleAction;
+    | SetPageVisibleAction
+    | ToggleForceScrolling;
 
 
 export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action) => {
@@ -111,6 +121,13 @@ export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action
             return {
                 ...state,
                 typing: action.typing
+            }
+        }
+
+        case TOOGLE_FORCE_SCROLLING: {
+            return {
+                ...state,
+                forceScrolling: !state.forceScrolling
             }
         }
 

--- a/src/webchat/store/ui/ui-reducer.ts
+++ b/src/webchat/store/ui/ui-reducer.ts
@@ -12,7 +12,7 @@ export interface UIState {
     botAvatarOverrideUrl?: string;
     userAvatarOverrideUrl?: string;
     isPageVisible: boolean;
-    forceScrolling: boolean;
+    forceScrollingTo: number;
 }
 
 export const SET_OPEN = 'SET_OPEN';
@@ -28,11 +28,12 @@ export const toggleOpen = () => ({
 });
 export type ToggleOpenAction = ReturnType<typeof toggleOpen>;
 
-const TOOGLE_FORCE_SCROLLING = 'TOOGLE_FORCE_SCROLLING';
-export const toggleForceScrolling = () => ({
-    type: TOOGLE_FORCE_SCROLLING as 'TOOGLE_FORCE_SCROLLING'
+const SET_FORCE_SCROLLING_TO = 'SET_FORCE_SCROLLING_TO';
+export const setForceScrollingTo = (offsetTop: number) => ({
+    type: SET_FORCE_SCROLLING_TO as 'SET_FORCE_SCROLLING_TO',
+    offsetTop
 });
-export type ToggleForceScrolling = ReturnType<typeof toggleForceScrolling>;
+export type SetForceScrollingTo = ReturnType<typeof setForceScrollingTo>;
 
 
 const SET_TYPING = 'SET_TYPING';
@@ -94,7 +95,7 @@ const getInitialState = (): UIState => ({
     botAvatarOverrideUrl: undefined,
     userAvatarOverrideUrl: undefined,
     isPageVisible: isPageVisible(),
-    forceScrolling: false
+    forceScrollingTo: 0
 });
 
 type UIAction = SetOpenAction 
@@ -105,7 +106,7 @@ type UIAction = SetOpenAction
     | SetBotAvatarOverrideUrlAction 
     | SetUserAvatarOverrideUrlAction
     | SetPageVisibleAction
-    | ToggleForceScrolling;
+    | SetForceScrollingTo;
 
 
 export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action) => {
@@ -124,10 +125,10 @@ export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action
             }
         }
 
-        case TOOGLE_FORCE_SCROLLING: {
+        case SET_FORCE_SCROLLING_TO: {
             return {
                 ...state,
-                forceScrolling: !state.forceScrolling
+                forceScrollingTo: action.offsetTop
             }
         }
 


### PR DESCRIPTION
**This PR fix the scrollTo bug for Adaptive Cards and adds the option to scroll to a specific position. In case of Adaptive Card plugin it is the offsetTop.**

- After rendering a message of type Adaptive Card the scrollTo functionality should work as expected.
- The ChatScroller Component now accepts a optional callback called "setScrollToPosition" and a numeric value. If both are defined it scrolls to the defined value and then reset to 0, otherwise scroll to bottom by default.
- The AdaptiveCard plugin component now accepts a optional callback called "setCardOffsetTop". If the callback is defined, it's invoked passing the offsetTop value of card for custom usage (ex.: global state). This can be useful if the adaptive card is expected to be higher then the clientHeight, and is preferable to scroll to the top of the card.

**How to test:**

- Create a Flow and add a Say node of output type Adaptive Card.
- Create a webchat endpoint and use this to test the above success criteria.