### PR TITLE
Bug/37877 typeguard the url recognition against wrong types of text

### DIFF
--- a/src/webchat/helper/url-links.ts
+++ b/src/webchat/helper/url-links.ts
@@ -11,6 +11,8 @@ const urlMatcherRegex = /(^|\s)(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\
  */
 export const replaceUrlsWithHTMLanchorElem = (text: string) => {
 
+	if (typeof text !== "string") return text;
+
     const enhancedText = text.replace(urlMatcherRegex, (url, leadingSymbol) => {
         const trimmedUrl = url.trim();
 


### PR DESCRIPTION
https://cognigy.visualstudio.com/Cognigy.AI/_workitems/edit/37877

Webchat can break if you send a bot output with a different type than text.

To recreate the issue, connect to a bot that has a code node. In the code node, write something like api.say(123) (or send an object etc.) Then connect to a webchat endpoint and talk to the bot through webchat.