### PR TITLE
Add class names to rating dialog elements

### DIFF
--- a/docs/css-customization.md
+++ b/docs/css-customization.md
@@ -14,6 +14,7 @@ There are several classes that you need to take in consideration if you want to 
 * *webchat-header-logo*
 * *webchat-header-title*
 * *webchat-header-close-button*
+* *webchat-header-rating-button*
 * *webchat-chat-history*
 * *webchat-message-row*
 * *regular-message*
@@ -36,6 +37,19 @@ There are several classes that you need to take in consideration if you want to 
 * *webchat-toggle-button*
 * *webchat-unread-message-preview*
 * *webchat-unread-message-badge*
+* *webchat-rating-dialog-wrapper*
+* *webchat-rating-dialog-root*
+* *webchat-rating-dialog-header*
+* *webchat-rating-dialog-title*
+* *webchat-rating-dialog-header-close-button*
+* *webchat-rating-dialog-main-content*
+* *webchat-rating-dialog-content-container*
+* *webchat-rating-dialog-thumbs-up-button*
+* *webchat-rating-dialog-thumbs-down-button*
+* *webchat-rating-dialog-comment-input-label*
+* *webchat-rating-dialog-toolbar*
+* *webchat-rating-dialog-comment-input-field*
+* *webchat-rating-dialog-send-button*
 
 If you want to be sure that the custom CSS that you apply will be shown, you will have to add some other selectors to those classes, for the Webchat we will use the attribute selectors:
 ```CSS

--- a/src/webchat-ui/components/presentational/Header.tsx
+++ b/src/webchat-ui/components/presentational/Header.tsx
@@ -55,10 +55,11 @@ export default ({ logoUrl, connected, title, showRatingButton, onRatingButtonCli
             {showRatingButton &&
                 <HeaderIconButton
                     onClick={onRatingButtonClick}
+                    className="webchat-header-rating-button"
                     aria-label="Rate your chat"
                     id="webchatHeaderOpenRatingDialogButton"
                     ref={ratingButtonRef}
-                    >
+                >
                     <ThumbsUpDownIcon />
                 </HeaderIconButton>
             }

--- a/src/webchat-ui/components/presentational/RatingDialog.tsx
+++ b/src/webchat-ui/components/presentational/RatingDialog.tsx
@@ -240,37 +240,71 @@ class RatingDialog extends React.PureComponent<React.HTMLProps<HTMLDivElement> &
         const webchatRatingCommentLabelId = `webchatRatingCommentLabelId-${uuid.v4()}`;
 
         return (
-            <Wrapper>
-                <RatingDialogRoot role="dialog" aria-modal="true" aria-labelledby={webchatRatingDialogTitleId} onKeyDown={this.handleKeydown}>
-                    <RatingDialogHeader>
-                        <span id={webchatRatingDialogTitleId} role="heading" aria-level={2}>{ratingTitleText}</span>
-                        <HeaderIconButton onClick={this.handleCloseRatingClick} aria-label="Close Rating dialog" ref={this.closeButtonInHeaderRef}>
+            <Wrapper className="webchat-rating-dialog-wrapper">
+                <RatingDialogRoot
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby={webchatRatingDialogTitleId}
+                    onKeyDown={this.handleKeydown}
+                    className="webchat-rating-dialog-root"
+                >
+                    <RatingDialogHeader className="webchat-rating-dialog-header">
+                        <span
+                            id={webchatRatingDialogTitleId}
+                            role="heading"
+                            aria-level={2}
+                            className="webchat-rating-dialog-title"
+                        >
+                            {ratingTitleText}
+                        </span>
+                        <HeaderIconButton
+                            onClick={this.handleCloseRatingClick}
+                            className="webchat-rating-dialog-header-close-button"
+                            aria-label="Close Rating dialog"
+                            ref={this.closeButtonInHeaderRef}
+                        >
                             <CloseIcon />
                         </HeaderIconButton>
                     </RatingDialogHeader>
-                    <RatingDialogMain>
-                        <RatingButtonContainer>
+                    <RatingDialogMain className="webchat-rating-dialog-main-content">
+                        <RatingButtonContainer className="webchat-rating-dialog-content-container">
                             <div>
-                                <RatingIconButton onClick={() => this.handleSetRatingValue(1)} selected={ratingValue === 1} aria-label="Thumbs Up">
+                                <RatingIconButton
+                                    onClick={() => this.handleSetRatingValue(1)}
+                                    className="webchat-rating-dialog-thumbs-up-button"
+                                    selected={ratingValue === 1}
+                                    aria-label="Thumbs Up"
+                                >
                                     <ThumbIcon />
                                 </RatingIconButton>
                             </div>
                             <div>
-                                <RatingIconButton onClick={() => this.handleSetRatingValue(-1)} selected={ratingValue === -1} aria-label="Thumbs Down">
+                                <RatingIconButton
+                                    onClick={() => this.handleSetRatingValue(-1)}
+                                    className="webchat-rating-dialog-thumbs-down-button"
+                                    selected={ratingValue === -1}
+                                    aria-label="Thumbs Down"
+                                >
                                     <ThumbDownIcon />
                                 </RatingIconButton>
                             </div>
                         </RatingButtonContainer>
                         <div>
-                            <div id={webchatRatingCommentLabelId}>{ratingCommentText}</div>
+                            <div 
+                                id={webchatRatingCommentLabelId}
+                                className="webchat-rating-dialog-comment-input-label"
+                            >
+                                {ratingCommentText}
+                            </div>
                         </div>
                     </RatingDialogMain>
-                    <RatingToolbar>
+                    <RatingToolbar className="webchat-rating-dialog-toolbar">
                         <RatingInput
                             data-test="rating-input"
                             type="text"
                             value={ratingText}
                             onChange={this.handleSetRatingText}
+                            className="webchat-rating-dialog-comment-input-field"
                             autoFocus
                             maxlength={500}
                             rows={3}
@@ -278,7 +312,7 @@ class RatingDialog extends React.PureComponent<React.HTMLProps<HTMLDivElement> &
                             ref={this.commentTextAreaRef}
                         />
                         <SendIconButton
-                            className={disableSendButton ? "disabled" : "active"}
+                            className={`webchat-rating-dialog-send-button ${disableSendButton ? "disabled" : "active"}`}
                             disabled={disableSendButton}
                             onClick={this.handleSendRatingClick}
                             ref={this.sendRatingButtonRef}


### PR DESCRIPTION
Add class names to rating dialog elements to make it more customizable by the user.

Success Criteria:
- All essential elements in the Rating dialog now have a class name
- Added classnames are documented in the mark down file