### PR TITLE
added MessageRenderer.isMessageSupported function

### DIFF
--- a/cypress/integration/message-renderer/isMessageSupported.spec.ts
+++ b/cypress/integration/message-renderer/isMessageSupported.spec.ts
@@ -1,0 +1,54 @@
+const supportedMessageFixtures = [
+	"adaptivecard",
+	"audio",
+	"buttons",
+	"downloadableImage",
+	"gallery",
+	"image",
+	"list",
+	"quick-replies-with-null-quick-replies",
+	"text",
+	"video",
+];
+
+describe("isMessageSupported", () => {
+	for (const message of supportedMessageFixtures) {
+		it(`returns true for a "${message}" message`, () => {
+			cy.visitMessageRenderer();
+
+			cy.fixture(`messages/${message}.json`).then(message => {
+				cy.window().then(window => {
+					expect(
+						// @ts-ignore
+						window.MessageRenderer.isMessageSupported(message),
+					).to.be.true;
+				});
+			});
+		});
+	}
+
+	it("returns false for an empty text message", () => {
+		cy.visitMessageRenderer();
+
+		cy.window().then(window => {
+			expect(
+				// @ts-ignore
+				window.MessageRenderer.isMessageSupported({ text: "" }),
+			).to.be.false;
+		});
+	});
+
+	it("returns false for an arbitrary data message", () => {
+		cy.visitMessageRenderer();
+
+		cy.window().then(window => {
+			expect(
+				// @ts-ignore
+				window.MessageRenderer.isMessageSupported({
+					text: "",
+					data: { something: "else" },
+				}),
+			).to.be.false;
+		});
+	});
+});

--- a/src/message-renderer/MessageRenderer.tsx
+++ b/src/message-renderer/MessageRenderer.tsx
@@ -10,7 +10,8 @@ import {
 import regularMessagePlugin from "../webchat-ui/components/plugins/message/regular";
 import MessagePluginRenderer from "../webchat-ui/components/plugins/MessagePluginRenderer";
 import { createWebchatTheme, styled } from "../webchat-ui/style";
-import { getInitialState } from "../webchat/store/config/config-reducer";
+import { getMessageRendererConfig } from "./getMessageRendererConfig";
+import { getMessageRendererPlugins } from "./getMessageRendererPlugins";
 
 interface IMessageRendererProps {
   message: IMessage;
@@ -20,18 +21,7 @@ interface IMessageRendererProps {
 const MessageRenderer: FC<IMessageRendererProps> = (props) => {
   const { message, config } = props;
 
-  const actualConfig = useMemo(() => {
-    const defaultConfig = getInitialState();
-
-    return {
-      ...defaultConfig,
-      ...config,
-      settings: {
-        ...defaultConfig.settings,
-        ...config?.settings
-      }
-    }
-  }, [config]);
+  const actualConfig = useMemo(() => getMessageRendererConfig(config), [config]);
 
   const onEmitAnalytics = useCallback(console.log.bind(console), []);
   const onSendMessage = useCallback(
@@ -39,14 +29,7 @@ const MessageRenderer: FC<IMessageRendererProps> = (props) => {
     []
   );
 
-  const plugins = useMemo(() => {
-    const plugins = prepareMessagePlugins(
-      [...getRegisteredMessagePlugins(), regularMessagePlugin],
-      { React, styled }
-    );
-
-    return plugins;
-  }, []);
+  const plugins = useMemo(() => getMessageRendererPlugins(), []);
 
   const theme = useMemo(() => createWebchatTheme({
     primaryColor: actualConfig.settings.colorScheme

--- a/src/message-renderer/getMessageRendererConfig.ts
+++ b/src/message-renderer/getMessageRendererConfig.ts
@@ -1,0 +1,22 @@
+import { IWebchatConfig } from "../common/interfaces/webchat-config";
+import { getInitialState } from "../webchat/store/config/config-reducer";
+
+/**
+ * returns a full webchat config based on a partial webchat config
+ * passed as options that's used for the message renderer
+ *
+ * @param options
+ * @returns
+ */
+export const getMessageRendererConfig = (options?: IWebchatConfig): IWebchatConfig => {
+	const defaultConfig = getInitialState();
+
+	return {
+		...defaultConfig,
+		...options,
+		settings: {
+			...defaultConfig.settings,
+			...options?.settings,
+		},
+	};
+};

--- a/src/message-renderer/getMessageRendererPlugins.ts
+++ b/src/message-renderer/getMessageRendererPlugins.ts
@@ -1,0 +1,13 @@
+import { getRegisteredMessagePlugins, prepareMessagePlugins } from "../plugins/helper";
+import regularMessagePlugin from "../webchat-ui/components/plugins/message/regular";
+import { styled } from "../webchat-ui/style";
+import * as React from "react";
+
+/**
+ * returns a list of ready-to-use message plugins for the message renderer
+ */
+export const getMessageRendererPlugins = () =>
+	prepareMessagePlugins([...getRegisteredMessagePlugins(), regularMessagePlugin], {
+		React,
+		styled,
+	});

--- a/src/message-renderer/message-renderer.tsx
+++ b/src/message-renderer/message-renderer.tsx
@@ -3,9 +3,20 @@ import * as ReactDOM from "react-dom";
 import { IMessage } from "../common/interfaces/message";
 import { IWebchatConfig } from "../common/interfaces/webchat-config";
 import MessageRendererComponent from "./MessageRenderer";
+import { getMessageRendererConfig } from "./getMessageRendererConfig";
+import { getMessageRendererPlugins } from "./getMessageRendererPlugins";
+import { getPluginsForMessage } from "../plugins/helper";
 
 export class MessageRenderer {
-  static renderMessage(message: IMessage, target: HTMLElement, config?: IWebchatConfig) {
-    ReactDOM.render(<MessageRendererComponent message={message} config={config} />, target);
-  }
+	static renderMessage(message: IMessage, target: HTMLElement, config?: IWebchatConfig) {
+		ReactDOM.render(<MessageRendererComponent message={message} config={config} />, target);
+	}
+	static isMessageSupported(message: IMessage, config?: IWebchatConfig) {
+		const fullConfig = getMessageRendererConfig(config);
+		const plugins = getMessageRendererPlugins();
+		const matcher = getPluginsForMessage(plugins, fullConfig);
+		const matchedPlugins = matcher(message);
+
+		return matchedPlugins.length > 0;
+	}
 }

--- a/src/message-renderer/message-renderer.tsx
+++ b/src/message-renderer/message-renderer.tsx
@@ -11,12 +11,15 @@ export class MessageRenderer {
 	static renderMessage(message: IMessage, target: HTMLElement, config?: IWebchatConfig) {
 		ReactDOM.render(<MessageRendererComponent message={message} config={config} />, target);
 	}
-	static isMessageSupported(message: IMessage, config?: IWebchatConfig) {
+	static getPluginsForMessage(message: IMessage, config?: IWebchatConfig) {
 		const fullConfig = getMessageRendererConfig(config);
 		const plugins = getMessageRendererPlugins();
 		const matcher = getPluginsForMessage(plugins, fullConfig);
 		const matchedPlugins = matcher(message);
 
-		return matchedPlugins.length > 0;
+		return matchedPlugins;
+	}
+	static isMessageSupported(message: IMessage, config?: IWebchatConfig) {
+		return MessageRenderer.getPluginsForMessage(message, config).length > 0;
 	}
 }


### PR DESCRIPTION
This PR adds a new functionality to the `message-renderer.js` bundle which allows its users to check whether a certain message can be rendered with it.

This allows consumers of the message renderer to conditionally use the renderer based on whether the message would be supported in the first place, improving usability.

As an example, I only want to render a "message row" with timestamp etc if the message turns out to be renderable in the end.


```js
MessageRenderer.isMessageSupported({ text: "hi" }); // => true, as the "regular message" plugin would be matched
MessageRenderer.isMessageSupported({ text: "" }); // => false, as no plugins would be matched
```