### PR TITLE
updated @cognigy/socket-client to 4.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@braintree/sanitize-url": "^6.0.0",
-        "@cognigy/socket-client": "4.6.3",
+        "@cognigy/socket-client": "4.7.1",
         "@emotion/cache": "^10.0.29",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -2002,9 +2002,9 @@
       }
     },
     "node_modules/@cognigy/socket-client": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.6.3.tgz",
-      "integrity": "sha512-lS2vcOpyrryIbRLttLmkYadYelmq6X61iz9NvemP/bGeMZdexViFGsw84/ObuDuOaOeXtIpjYF9Zg3zChDwhdQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.7.1.tgz",
+      "integrity": "sha512-UIBHSfUxfPMAd3sj4ln6bTiPreH4Stl+7T3CPRl8QQR1u5/MY1/nw2l8mpWydHoeG87fX1TfRKLMCAZnccBg1A==",
       "dependencies": {
         "detect-browser": "^4.8.0",
         "socket.io-client": "^2.4.0",
@@ -14574,9 +14574,9 @@
       }
     },
     "@cognigy/socket-client": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.6.3.tgz",
-      "integrity": "sha512-lS2vcOpyrryIbRLttLmkYadYelmq6X61iz9NvemP/bGeMZdexViFGsw84/ObuDuOaOeXtIpjYF9Zg3zChDwhdQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@cognigy/socket-client/-/socket-client-4.7.1.tgz",
+      "integrity": "sha512-UIBHSfUxfPMAd3sj4ln6bTiPreH4Stl+7T3CPRl8QQR1u5/MY1/nw2l8mpWydHoeG87fX1TfRKLMCAZnccBg1A==",
       "requires": {
         "detect-browser": "^4.8.0",
         "socket.io-client": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.0",
-    "@cognigy/socket-client": "4.6.3",
+    "@cognigy/socket-client": "4.7.1",
     "@emotion/cache": "^10.0.29",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",


### PR DESCRIPTION
this PR bumps the `@cognigy/socket-client` package from `v3.6.3` to `v3.7.1`

- `v4.7.0` added "test mode" capabilities to the socket client
- `v4.7.1` contains a security fix for the `socketio-parser` sub-dependency package