### PR TITLE
Bug/48743 Minimizing issues with adaptive cards

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -62,7 +62,9 @@ export interface WebchatUIProps {
     onConnect: () => void;
     onToggle: () => void;
     onSetScrollToPosition: (position: number) => void;
+    onSetLastScrolledPosition: (position: number | null) => void;
     scrollToPosition: number;
+    lastScrolledPosition: number | null;
 
     onEmitAnalytics: (event: string, payload?: any) => void;
     onTriggerEngagementMessage: () => void;
@@ -352,6 +354,11 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         }
 
         this.props.onSendMessage(...args);
+
+        // we activate scrollToPosition functionality on first message
+        if (this.props.lastScrolledPosition === null) {
+            this.props.onSetLastScrolledPosition(0);
+        }
     }
 
     renderInput = () => {
@@ -453,7 +460,9 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             onClose,
             onToggle,
             onSetScrollToPosition,
+            onSetLastScrolledPosition,
             scrollToPosition,
+            lastScrolledPosition,
             onTriggerEngagementMessage,
             webchatRootProps,
             webchatToggleProps,
@@ -631,7 +640,9 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             onShowRatingDialog,
             messages,
             scrollToPosition,
-            onSetScrollToPosition
+            lastScrolledPosition,
+            onSetScrollToPosition,
+            onSetLastScrolledPosition
         } = this.props;
 
         const { enableRating } = config.settings;
@@ -656,6 +667,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                     disableBranding={config.settings.disableBranding}
                     scrollToPosition={scrollToPosition}
                     setScrollToPosition={onSetScrollToPosition}
+                    lastScrolledPosition={lastScrolledPosition}
+                    setLastScrolledPosition={onSetLastScrolledPosition}
                     ref={this.history as any}
                     className="webchat-chat-history"
                     tabIndex={messages?.length === 0 ? -1 : 0} // When no messages, remove chat history from tab order

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -8,7 +8,9 @@ export interface OuterProps extends React.HTMLProps<HTMLDivElement> {
     disableBranding: boolean;
     showFocusOutline: boolean;
     scrollToPosition: number;
+    lastScrolledPosition: number | null;
     setScrollToPosition?: (position: number) => void;
+    setLastScrolledPosition?: (position: number | null) => void;
     tabIndex: 0 | -1;
  }
 
@@ -57,17 +59,31 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
     }
 
     componentDidUpdate(prevProps: InnerProps, prevState: IState, wasScrolledToBottom: boolean) {
-        const { setScrollToPosition, scrollToPosition } = this.props;
-        if(scrollToPosition && setScrollToPosition) {
-            this.handleScrollTo(scrollToPosition);
+        const { setScrollToPosition, scrollToPosition, lastScrolledPosition, setLastScrolledPosition } = this.props;
+        if (scrollToPosition && setScrollToPosition) {
+            // we skip scrollToPosition on first render and re-renders
+            if (lastScrolledPosition === null && setLastScrolledPosition) {
+                setTimeout(() => { this.handleScrollTo() }, 100);
+                setLastScrolledPosition(0);
+            } else if (typeof lastScrolledPosition === "number" && scrollToPosition > lastScrolledPosition) {
+                setTimeout(() => { this.handleScrollTo(scrollToPosition) }, 10);
+                setLastScrolledPosition && setLastScrolledPosition(scrollToPosition);
+            } else if (wasScrolledToBottom) {
+                this.handleScrollTo();
+            }
             setScrollToPosition(0);
         } else if (wasScrolledToBottom) {
             this.handleScrollTo();
-        }
+        }  
     }
 
     componentDidMount() {
         this.handleScrollTo();
+    }
+
+    componentWillUnmount() {
+        const { setLastScrolledPosition } = this.props;
+        setLastScrolledPosition && setLastScrolledPosition(null);
     }
 
     handleScrollTo = (position?: number) => {
@@ -93,7 +109,7 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
     handleFocus = () => {
         if(this.innerRef.current === document.activeElement) {
             this.setState({isChatLogFocused: true});
-        }        
+        }
     }
 
     // Remove outline from the parent element when Chat log loses focus 

--- a/src/webchat-ui/components/history/ChatScroller.tsx
+++ b/src/webchat-ui/components/history/ChatScroller.tsx
@@ -63,22 +63,22 @@ export class ChatScroller extends React.Component<InnerProps, IState> {
         if (scrollToPosition && setScrollToPosition) {
             // we skip scrollToPosition on first render and re-renders
             if (lastScrolledPosition === null && setLastScrolledPosition) {
-                setTimeout(() => { this.handleScrollTo() }, 100);
+                setTimeout(() => { this.handleScrollTo() }, 1000);
                 setLastScrolledPosition(0);
             } else if (typeof lastScrolledPosition === "number" && scrollToPosition > lastScrolledPosition) {
-                setTimeout(() => { this.handleScrollTo(scrollToPosition) }, 10);
+                setTimeout(() => { this.handleScrollTo(scrollToPosition) }, 0);
                 setLastScrolledPosition && setLastScrolledPosition(scrollToPosition);
             } else if (wasScrolledToBottom) {
-                this.handleScrollTo();
+                setTimeout(() => { this.handleScrollTo() }, 0);
             }
             setScrollToPosition(0);
         } else if (wasScrolledToBottom) {
-            this.handleScrollTo();
+            setTimeout(() => { this.handleScrollTo() }, 0);
         }  
     }
 
     componentDidMount() {
-        this.handleScrollTo();
+        setTimeout(() => { this.handleScrollTo() }, 0);
     }
 
     componentWillUnmount() {

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -2,13 +2,13 @@ import { WebchatUI, WebchatUIProps } from "../../webchat-ui";
 import { connect } from "react-redux";
 import { StoreState } from "../store/store";
 import { sendMessage, triggerEngagementMessage } from '../store/messages/message-middleware';
-import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, setScrollToPosition } from '../store/ui/ui-reducer';
+import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, setScrollToPosition, setLastScrolledPosition } from '../store/ui/ui-reducer';
 import { getPluginsForMessage, isFullscreenPlugin } from '../../plugins/helper';
 import { connect as doConnect } from "../store/connection/connection-middleware";
 import { setHasGivenRating, showRatingDialog } from "../store/rating/rating-reducer";
 
-type FromState = Pick<WebchatUIProps, 'messages' | 'unseenMessages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config' | 'connected' | 'reconnectionLimit' | 'scrollToPosition'>;
-type FromDispatch = Pick<WebchatUIProps, 'onSendMessage' | 'onSetInputMode' | 'onSetFullscreenMessage' | 'onDismissFullscreenMessage' | 'onClose' | 'onToggle' | 'onSetScrollToPosition' | 'onTriggerEngagementMessage'>;
+type FromState = Pick<WebchatUIProps, 'messages' | 'unseenMessages' | 'open' | 'typingIndicator' | 'inputMode' | 'fullscreenMessage' | 'config' | 'connected' | 'reconnectionLimit' | 'scrollToPosition'| 'lastScrolledPosition'>;
+type FromDispatch = Pick<WebchatUIProps, 'onSendMessage' | 'onSetInputMode' | 'onSetFullscreenMessage' | 'onDismissFullscreenMessage' | 'onClose' | 'onToggle' | 'onSetScrollToPosition' | 'onSetLastScrolledPosition' | 'onTriggerEngagementMessage'>;
 export type FromProps = Pick<WebchatUIProps, 'messagePlugins' | 'inputPlugins' | 'webchatRootProps' | 'webchatToggleProps'>;
 type Merge = FromState & FromDispatch & FromProps & Pick<WebchatUIProps, 'fullscreenMessage'>;
 
@@ -17,7 +17,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         messages,
         unseenMessages,
         connection: { connected, reconnectionLimit },
-        ui: { open, typing, inputMode, fullscreenMessage, scrollToPosition },
+        ui: { open, typing, inputMode, fullscreenMessage, scrollToPosition, lastScrolledPosition },
         config,
         rating: { showRatingDialog, hasGivenRating, customRatingTitle, customRatingCommentText },
     }) => ({
@@ -26,6 +26,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         open,
         typingIndicator: typing,
         scrollToPosition,
+        lastScrolledPosition,
         inputMode,
         fullscreenMessage,
         config,
@@ -44,6 +45,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         onClose: () => dispatch(setOpen(false)),
         onToggle: () => dispatch(toggleOpen()),
         onSetScrollToPosition: (position: number) => dispatch(setScrollToPosition(position)),
+        onSetLastScrolledPosition: (position: number | null) => dispatch(setLastScrolledPosition(position)),
         onTriggerEngagementMessage: () => dispatch(triggerEngagementMessage()),
         onConnect: () => dispatch(doConnect()),
         onShowRatingDialog: (show: boolean) => dispatch(showRatingDialog(show)),

--- a/src/webchat/store/ui/ui-reducer.ts
+++ b/src/webchat/store/ui/ui-reducer.ts
@@ -13,6 +13,7 @@ export interface UIState {
     userAvatarOverrideUrl?: string;
     isPageVisible: boolean;
     scrollToPosition: number;
+    lastScrolledPosition: number | null;
 }
 
 export const SET_OPEN = 'SET_OPEN';
@@ -34,6 +35,13 @@ export const setScrollToPosition = (position: number) => ({
     position
 });
 export type SetScrollToPosition = ReturnType<typeof setScrollToPosition>;
+
+const SET_LAST_SCROLLED_POSITION = 'SET_LAST_SCROLLED_POSITION';
+export const setLastScrolledPosition = (position: number | null) => ({
+    type: SET_LAST_SCROLLED_POSITION as 'SET_LAST_SCROLLED_POSITION',
+    position
+});
+export type SetLastScrolledPosition = ReturnType<typeof setLastScrolledPosition>;
 
 
 const SET_TYPING = 'SET_TYPING';
@@ -95,18 +103,20 @@ const getInitialState = (): UIState => ({
     botAvatarOverrideUrl: undefined,
     userAvatarOverrideUrl: undefined,
     isPageVisible: isPageVisible(),
-    scrollToPosition: 0
+    scrollToPosition: 0,
+    lastScrolledPosition: null
 });
 
-type UIAction = SetOpenAction 
-    | SetTypingAction 
-    | SetInputModeAction 
-    | SetFullscreenMessageAction 
+type UIAction = SetOpenAction
+    | SetTypingAction
+    | SetInputModeAction
+    | SetFullscreenMessageAction
     | SetAgentAvatarOverrideUrlAction
-    | SetBotAvatarOverrideUrlAction 
+    | SetBotAvatarOverrideUrlAction
     | SetUserAvatarOverrideUrlAction
     | SetPageVisibleAction
-    | SetScrollToPosition;
+    | SetScrollToPosition
+    | SetLastScrolledPosition;
 
 
 export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action) => {
@@ -129,6 +139,13 @@ export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action
             return {
                 ...state,
                 scrollToPosition: action.position
+            }
+        }
+            
+        case SET_LAST_SCROLLED_POSITION: {
+            return {
+                ...state,
+                lastScrolledPosition: action.position
             }
         }
 


### PR DESCRIPTION
**This PR fix the scrollToPosition bug for Adaptive Cards on minimizing the chat or on first render**

- After rendering a history chat with at least a message of type Adaptive Card, the chat should scroll to bottom, not to last Adaptive Card message.
- On minimizing a chat and expand again, the chat should scroll to bottom, not to last Adaptive Card message.

**How to test:**

- Create a Flow and add a Say node of output type Adaptive Card.
- Add some say node of type Text after the Adaptive Card
- Create a webchat endpoint and use this to test the above success criteria.

**NOTE**: It's important to test for new/empty chat session, and also with long chat session. Testing also page refresh and minimizing action.