### PR TITLE
Add handler to change input text from outside

### DIFF
--- a/src/webchat-ui/components/plugins/input/text/TextInput.tsx
+++ b/src/webchat-ui/components/plugins/input/text/TextInput.tsx
@@ -181,6 +181,12 @@ export interface TextInputState {
     fileUploadError: boolean;
 }
 
+declare global {
+        interface Window {
+        WebChatInputTextCallback: (text: string) => void;
+    }
+}
+
 export class TextInput extends React.PureComponent<InputComponentProps, TextInputState> {
     state = {
         text: '',
@@ -194,6 +200,13 @@ export class TextInput extends React.PureComponent<InputComponentProps, TextInpu
     inputRef = React.createRef<HTMLTextAreaElement | HTMLInputElement>();
     menuRef = React.createRef<HTMLDivElement>();
     fileInputRef = React.createRef<HTMLInputElement>();
+
+    componentDidMount(): void {
+        // Global handler to modify the input text
+        window.WebChatInputTextCallback = (text: string) => {
+            this.setState({ text });
+        }
+    }
 
     handleChangeState = (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
         this.setState({


### PR DESCRIPTION
- Should be possible to modify the input text from developer console like `WebChatInputTextCallback("test")`. 
- Rest of the webchat functionality should remain unaltered

How to test:
1. Open webchat and type something in the input field. For example, 'Hi'
2. Open the developer console and write WebChatInputTextCallback("test") and hit enter
3. Now the text in input field you entered in step 1 should be replaced by the string 'test' from step 2
4. Click the input field, the text should still be 'test'
