### PR TITLE
Maintenance mode

### DIFF
--- a/src/webchat-ui/assets/infoMessageIcon.svg
+++ b/src/webchat-ui/assets/infoMessageIcon.svg
@@ -1,0 +1,10 @@
+<svg width="111" height="82" viewBox="0 0 111 82" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g>
+<path d="M0.5 27C0.5 18.7157 7.21573 12 15.5 12H95.5C103.784 12 110.5 18.7157 110.5 27V67C110.5 75.2843 103.784 82 95.5 82H0.5V27Z" fill="#F2F2F2"/>
+<g>
+<path d="M29.4796 18H42.0858C42.9767 18 43.4229 19.0771 42.7929 19.7071L30.2071 32.2929C29.5771 32.9229 30.0233 34 30.9142 34H44.5" stroke="#999999" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M52.5 41H62.0858C62.9767 41 63.4229 42.0771 62.7929 42.7071L54.2071 51.2929C53.5771 51.9229 54.0233 53 54.9142 53H64.5" stroke="#999999" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M58.5 2H80.0858C80.9767 2 81.4229 3.07714 80.7929 3.70711L60.2071 24.2929C59.5771 24.9229 60.0233 26 60.9142 26H82.5" stroke="#999999" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+</svg>

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -698,6 +698,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         }
         const showInformationMessage = isInforming && informMessage;
 
+        // TODO: implement better navigation history and currentPage string property on redux
         const isSecondaryView = showInformationMessage;
         
         if (showHomeScreen && !isSecondaryView) return (

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -46,6 +46,7 @@ import { PrevConversationsState } from '../../webchat/store/previous-conversatio
 import Notifications from './presentational/Notifications';
 import Chip from './presentational/Chip';
 import { isConversationEnded } from './presentational/previous-conversations/helpers';
+import { InformationMessage } from './presentational/InformationMessage';
 
 export interface WebchatUIProps {
     currentSession: string;
@@ -556,6 +557,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                 return this.props.config.settings.connectivity.text || "This chat is disabled due to connectivity issues";
             }
         }
+
         return (
             <>
                 <ThemeProvider theme={theme}>
@@ -582,9 +584,9 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                                             id="webchatWindow"
                                             ref={this.webchatWindowRef}
                                         >
-                                            {!fullscreenMessage && !isInforming
-                                                ? this.renderRegularLayout()
-                                                : this.renderFullscreenMessageLayout()
+                                            {fullscreenMessage
+                                                ? this.renderFullscreenMessageLayout()
+                                                : this.renderRegularLayout(isInforming)
                                             }
                                             {
                                                 showRatingDialog &&
@@ -662,7 +664,7 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         )
     }
 
-    renderRegularLayout() {
+    renderRegularLayout(isInforming: boolean) {
         const {
             currentSession,
             config,
@@ -685,8 +687,20 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         const { enableRating } = config.settings;
 
         const showRatingButton = enableRating && (enableRating === "always" || (enableRating === "once" && hasGivenRating === false));
+
+        let informMessage = "";
+        if (config.settings.maintenance.enabled && config.settings.maintenance.mode === "inform") {
+            informMessage = config.settings.maintenance.text || "This Webchat is disabled due to maintenance";
+        } else if (config.settings.connectivity.enabled && config.settings.connectivity.mode === "inform") {
+            informMessage = config.settings.connectivity.text || "This Webchat is disabled due to connectivity issues";
+        } else if (config.settings.businessHours.enabled && config.settings.businessHours.mode === "inform") {
+            informMessage = config.settings.businessHours.text || "This Webchat is disabled out of business hours";
+        }
+        const showInformationMessage = isInforming && informMessage;
+
+        const isSecondaryView = showInformationMessage;
         
-        if (showHomeScreen) return (
+        if (showHomeScreen && !isSecondaryView) return (
             <HomeScreen
                 showHomeScreen={showHomeScreen}
                 onSetShowHomeScreen={onSetShowHomeScreen}
@@ -700,9 +714,13 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
         );
 
         const handleOnClose = () => {
-            onSetShowPrevConversations(false);
-            onSetShowHomeScreen(true);
-        }
+            if (showInformationMessage) {
+                onClose();
+            } else {
+                onSetShowPrevConversations(false);
+                onSetShowHomeScreen(true);
+            }
+        };
 
         return (
             <>
@@ -718,7 +736,9 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                     showCloseButton={true}
                     onRatingButtonClick={() => onShowRatingDialog(true)}
                 />
-                {showPrevConversations ? (
+                {showInformationMessage ? (
+                    <InformationMessage message={informMessage} />
+                ) : showPrevConversations ? (
                     <PrevConversationsList
                         conversations={this.props.prevConversations}
                         onSetShowPrevConversations={onSetShowPrevConversations}
@@ -727,9 +747,8 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
                     />
                 ) : (
                     <>
-                {/* When we have common Header implemented, 
-                we should move notifications container there  */}
-                <Notifications />
+                        {/* When we have common Header implemented, we should move notifications container there  */}
+                        <Notifications />
                         <HistoryWrapper
                             disableBranding={config.settings.disableBranding}
                             scrollToPosition={scrollToPosition}
@@ -760,66 +779,14 @@ export class WebchatUI extends React.PureComponent<React.HTMLProps<HTMLDivElemen
             onEmitAnalytics
         } = this.props;
 
-        const { messagePlugins } = this.state;
-
-        let message = fullscreenMessage as IMessage;
-
-        if (config.settings.maintenance.enabled && config.settings.maintenance.mode === "inform") {
-            message = {
-                text: config.settings.maintenance.text || "This Webchat is disabled due to maintenance",
-                data: {
-                    _plugin: {
-                        type: "full-screen-notification",
-                        text: config.settings.maintenance.text,
-                        data: {
-                            title: config.settings.maintenance.title || "",
-                            disableHtmlContentSanitization: config.settings.disableHtmlContentSanitization
-                        }
-                    }
-                },
-                source: "bot",
-                traceId: ""
-            }
-        } else if (config.settings.connectivity.enabled && config.settings.connectivity.mode === "inform") {
-            message = {
-                text: config.settings.connectivity.text || "This Webchat is disabled due to connectivity issues",
-                data: {
-                    _plugin: {
-                        type: "full-screen-notification",
-                        text: config.settings.connectivity.text,
-                        data: {
-                            title: config.settings.connectivity.title || ""
-                        }
-                    }
-                },
-                source: "bot",
-                traceId: ""
-            }
-        } else if (config.settings.businessHours.enabled && config.settings.businessHours.mode === "inform") {
-            message = {
-                text: config.settings.businessHours.text || "This Webchat is disabled out of business hours",
-                data: {
-                    _plugin: {
-                        type: "full-screen-notification",
-                        text: config.settings.businessHours.text,
-                        data: {
-                            title: config.settings.businessHours.title || ""
-                        }
-                    }
-                },
-                source: "bot",
-                traceId: ""
-            }
-        }
-
         return (
             <FullScreenMessage
                 onSendMessage={this.sendMessage}
                 config={config}
-                plugins={messagePlugins}
+                plugins={this.state.messagePlugins}
                 onSetFullscreen={() => { }}
                 onDismissFullscreen={onDismissFullscreenMessage}
-                message={message}
+                message={fullscreenMessage as IMessage}
                 webchatTheme={this.state.theme}
                 onEmitAnalytics={onEmitAnalytics}
             />

--- a/src/webchat-ui/components/presentational/InformationMessage.tsx
+++ b/src/webchat-ui/components/presentational/InformationMessage.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { Typography } from "@cognigy/chat-components";
+import InfoMessageSVG from "../../assets/infoMessageIcon.svg";
+
+const MessageRoot = styled.div(({ theme }) => ({
+	height: "100%",
+	width: "100%",
+	backgroundColor: theme.white,
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+}));
+
+const Message = styled.div(() => ({
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	flexDirection: "column",
+	gap: "24px",
+	maxWidth: "295px",
+	textAlign: "center",
+}));
+
+interface IInformationMessageProps {
+	message: string;
+}
+
+export const InformationMessage = (props: IInformationMessageProps) => {
+	const { message } = props;
+
+	return (
+		<MessageRoot className="webchat-information-message-root">
+			<Message className="webchat-information-message-content">
+				<InfoMessageSVG />
+				<Typography variant="title1-regular">
+					{message}
+				</Typography>
+			</Message>
+		</MessageRoot>
+	);
+};

--- a/src/webchat-ui/components/presentational/InformationMessage.tsx
+++ b/src/webchat-ui/components/presentational/InformationMessage.tsx
@@ -33,7 +33,7 @@ export const InformationMessage = (props: IInformationMessageProps) => {
 		<MessageRoot className="webchat-information-message-root">
 			<Message className="webchat-information-message-content">
 				<InfoMessageSVG />
-				<Typography variant="title1-regular">
+				<Typography variant="title1-regular" style={{margin: 0}}>
 					{message}
 				</Typography>
 			</Message>

--- a/src/webchat/store/options/options-middleware.ts
+++ b/src/webchat/store/options/options-middleware.ts
@@ -5,8 +5,11 @@ import { SetOptionsAction } from "./options-reducer";
 import { resetState } from "../reducer";
 import { getAllConversations, getStorage } from "../../helper/storage";
 import { setConversations } from "../previous-conversations/previous-conversations-reducer";
+import { SendMessageAction, TriggerEngagementMessageAction } from "../messages/message-middleware";
+import { ReceiveMessageAction } from "../messages/message-handler";
+import { RatingAction } from "../rating/rating-reducer";
 
-type Actions = SetOptionsAction;
+type Actions = SetOptionsAction | SendMessageAction | ReceiveMessageAction | TriggerEngagementMessageAction | RatingAction;
 
 export const optionsMiddleware: Middleware<object, StoreState> = store => next => (action: Actions) => {
 	const key = getOptionsKey(store.getState().options, store.getState().config);
@@ -43,19 +46,25 @@ export const optionsMiddleware: Middleware<object, StoreState> = store => next =
 			}
 			break;
 		}
-	}
-
-	// TODO: this block get excuted on every action dispached.
-	// It would be anyway better to restrict only to the actions regarding messages and rating
-	if (browserStorage && active && userId && !disablePersistentHistory) {
-		const { messages, rating } = store.getState();
-		browserStorage.setItem(
-			key,
-			JSON.stringify({
-				messages,
-				rating,
-			}),
-		);
+		case "SEND_MESSAGE":
+		case "RECEIVE_MESSAGE":
+		case "TRIGGER_ENGAGEMENT_MESSAGE":
+		case "SHOW_RATING_DIALOG":
+		case "SET_HAS_GIVEN_RATING":
+		case "SET_CUSTOM_RATING_TITLE":
+		case "SET_CUSTOM_RATING_COMMENT_TEXT": {
+			if (browserStorage && active && userId && !disablePersistentHistory) {
+				const { messages, rating } = store.getState();
+				browserStorage.setItem(
+					key,
+					JSON.stringify({
+						messages,
+						rating,
+					}),
+				);
+			}
+			break;
+		}
 	}
 
 	return next(action);


### PR DESCRIPTION
This PR includes the InformationMessage component used for maintenance mode, Connectivity issue and Out of business hours views.
When enabled, is expected to have the information screen on chat open. HomeScreen will never be shown.

**How to test**
Append the following on settings object on your index.html
```
awaitEndpointConfig: true,
maintenance: {
    enabled: true,
    mode: "inform",
    text:" ",
    title: "",
}
```

US reference 55720