### PR TITLE
add homescreen button functionality

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -57,6 +57,7 @@ import { PrevConversationsList } from "./presentational/previous-conversations/C
 import { PrevConversationsState } from "../../webchat/store/previous-conversations/previous-conversations-reducer";
 import Chip from "./presentational/Chip";
 import { isConversationEnded } from "./presentational/previous-conversations/helpers";
+import { ISendMessageOptions } from '../../webchat/store/messages/message-middleware';
 
 export interface WebchatUIProps {
 	currentSession: string;
@@ -738,7 +739,13 @@ export class WebchatUI extends React.PureComponent<
 			onSwitchSession,
 			onClose,
 			onEmitAnalytics,
+			onSendMessage,
 		} = this.props;
+
+		const onSendActionButtonMessage = (text?: string, data?: any, options?: Partial<ISendMessageOptions>) => {
+			onSetShowHomeScreen(false);
+			onSendMessage(text, data, options);
+		};
 
 		if (showHomeScreen)
 			return (
@@ -751,6 +758,7 @@ export class WebchatUI extends React.PureComponent<
 					onClose={onClose}
 					config={config}
 					onEmitAnalytics={onEmitAnalytics}
+					onSendActionButtonMessage={onSendActionButtonMessage}
 				/>
 			);
 

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -57,11 +57,8 @@ import { PrevConversationsList } from "./presentational/previous-conversations/C
 import { PrevConversationsState } from "../../webchat/store/previous-conversations/previous-conversations-reducer";
 import Chip from "./presentational/Chip";
 import { isConversationEnded } from "./presentational/previous-conversations/helpers";
-<<<<<<< HEAD
 import { ISendMessageOptions } from '../../webchat/store/messages/message-middleware';
-=======
 import { InformationMessage } from "./presentational/InformationMessage";
->>>>>>> v3
 
 export interface WebchatUIProps {
 	currentSession: string;

--- a/src/webchat-ui/components/presentational/HomeScreen.tsx
+++ b/src/webchat-ui/components/presentational/HomeScreen.tsx
@@ -119,6 +119,7 @@ interface IHomeScreenProps {
 	onSwitchSession: (sessionId?: string, conversation?: PrevConversationsState[string]) => void;
 	onClose: () => void;
 	onEmitAnalytics: WebchatUIProps["onEmitAnalytics"];
+	onSendActionButtonMessage: WebchatUIProps["onSendMessage"];
 }
 
 export const HomeScreen: React.FC<IHomeScreenProps> = props => {
@@ -130,7 +131,32 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 		onSwitchSession,
 		onClose,
 		onEmitAnalytics,
+		onSendActionButtonMessage,
 	} = props;
+
+	// TODO: Load buttons from new endpoint config
+	const buttons = [
+		{
+			title: "Cognigy Homepage",
+			type: "web_url",
+			url: "https://www.cognigy.com/",
+		},
+		{
+			title: "How are you?",
+			type: "postback",
+			payload: "How are you?",
+		},
+		{
+			title: "What is your name?",
+			type: "postback",
+			payload: "What is your name?",
+		},
+		{
+			title: "What is your favorite color?",
+			type: "postback",
+			payload: "What is your favorite color?",
+		},
+	]
 
 	const disableBranding = config?.settings?.disableBranding;
 
@@ -182,32 +208,11 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 					<ActionButtons
 						size="large"
 						showUrlIcon
-						action={() => {}}
 						buttonClassName="webchat-homescreen-button"
 						containerClassName="webchat-homescreen-button-container"
-						payload={[
-							{
-								title: "Cognigy Homepage",
-								type: "web_url",
-								url: "https://www.cognigy.com/",
-							},
-							{
-								title: "How are you?",
-								type: "postback",
-								payload: "How are you?",
-							},
-							{
-								title: "What is your name?",
-								type: "postback",
-								payload: "What is your name?",
-							},
-							{
-								title: "What is your favorite color?",
-								type: "postback",
-								payload: "What is your favorite color?",
-							},
-						]}
+						payload={buttons}
 						config={config}
+						action={onSendActionButtonMessage}
 						onEmitAnalytics={onEmitAnalytics}
 					/>
 				</HomeScreenButtons>


### PR DESCRIPTION
This PR adds the necessary changes to make the homescreen buttons usable. they are still mocked as we don't have the endpoint settings yet, but fully usable as link and postback message.

To test, just deploy a webchat and check the two button types 