### PR TITLE
Feature/55721 privacynotice

### DIFF
--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -27,7 +27,7 @@ export interface IWebchatSettings {
   disableHtmlContentSanitization: boolean;
   disableHtmlInput: boolean;
   disableInputAutocomplete: boolean;
-	disableInputAutofocus: boolean;
+  disableInputAutofocus: boolean;
   disableLocalStorage: boolean;
   disablePersistentHistory: boolean;
   disableRenderURLsAsLinks: boolean;
@@ -41,7 +41,7 @@ export interface IWebchatSettings {
   enableFocusTrap: boolean;
   enableGenericHTMLStyling: boolean;
   enableInjectionWithoutEmptyHistory: boolean;
-	enableInputCollation: boolean;
+  enableInputCollation: boolean;
   enableRating: "always" | "once" | "onRequest";
   enableStrictMessengerSync: boolean;
   enableSTT: boolean;
@@ -74,7 +74,7 @@ export interface IWebchatSettings {
   };
   messageDelay: number;
   /** TODO: this is the botAvatarUrl (rename for major) */
-	messageLogoUrl: string;
+  messageLogoUrl: string;
   ratingCommentText: string;
   ratingMessageHistoryCommentText: string;
   ratingMessageHistoryRatingText: string;
@@ -99,7 +99,9 @@ export interface IWebchatSettings {
     engagement: TSourceColor;
     user: TSourceColor;
   };
-_endpointTokenUrl: string;
+  _endpointTokenUrl: string;
+  privacyMessage: string;
+  privacyUrl: string;
 }
 
 export interface IWebchatConfig {

--- a/src/webchat-ui/components/presentational/HomeScreen.tsx
+++ b/src/webchat-ui/components/presentational/HomeScreen.tsx
@@ -9,7 +9,6 @@ import Branding from "../branding/Branding";
 import Notifications from "./Notifications";
 import { ActionButtons, Typography } from "@cognigy/chat-components";
 import { WebchatUIProps } from "../WebchatUI";
-import { PrevConversationsState } from "../../../webchat/store/previous-conversations/previous-conversations-reducer";
 
 const HomeScreenRoot = styled.div(({ theme }) => ({
 	display: "flex",
@@ -112,26 +111,24 @@ const PrevConversationsButton = styled(SecondaryButton)(() => ({
 
 interface IHomeScreenProps {
 	config: IWebchatConfig;
-	currentSession: string;
 	showHomeScreen: boolean;
 	onSetShowHomeScreen: (show: boolean) => void;
 	onSetShowPrevConversations: (show: boolean) => void;
-	onSwitchSession: (sessionId?: string, conversation?: PrevConversationsState[string]) => void;
 	onClose: () => void;
 	onEmitAnalytics: WebchatUIProps["onEmitAnalytics"];
 	onSendActionButtonMessage: WebchatUIProps["onSendMessage"];
+	onStartConversation: () => void;
 }
 
 export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 	const {
 		config,
-		currentSession,
 		onSetShowHomeScreen,
 		onSetShowPrevConversations,
-		onSwitchSession,
 		onClose,
 		onEmitAnalytics,
 		onSendActionButtonMessage,
+		onStartConversation,
 	} = props;
 
 	// TODO: Load buttons from new endpoint config
@@ -163,17 +160,6 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 	const handleShowPrevConversations = () => {
 		onSetShowHomeScreen(false);
 		onSetShowPrevConversations(true);
-	};
-
-	const handleStartConversation = () => {
-		const { initialSessionId } = config;
-		if (!initialSessionId) {
-			onSwitchSession();
-		}
-		if (initialSessionId && initialSessionId !== currentSession) {
-			onSwitchSession(initialSessionId);
-		}
-		onSetShowHomeScreen(false);
 	};
 
 	return (
@@ -219,7 +205,7 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 			</HomeScreenContent>
 			<HomeScreenActions className="webchat-homescreen-actions">
 				<StartButton
-					onClick={handleStartConversation}
+					onClick={onStartConversation}
 					className="webchat-homescreen-send-button"
 					aria-label="Start chat"
 				>

--- a/src/webchat-ui/components/presentational/PrivacyNotice.tsx
+++ b/src/webchat-ui/components/presentational/PrivacyNotice.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { Typography } from "@cognigy/chat-components";
+import PrimaryButton from "./PrimaryButton";
+import TertiaryButton from "./TertiaryButton";
+
+const PrivacyNoticeRoot = styled.div(({ theme }) => ({
+	height: "100%",
+	width: "100%",
+	backgroundColor: theme.white,
+	display: "flex",
+	flex: "1 0 0",
+	flexDirection: "column",
+	justifyContent: "space-between",
+	alignItems: "center",
+	padding: 20,
+}));
+
+const PrivacyMessage = styled.div(() => ({
+}));
+
+const PrivacyActions = styled.div(() => ({
+	display: "flex",
+	alignItems: "center",
+	flexDirection: "column",
+	gap: 16,
+}));
+
+const AcceptButton = styled(PrimaryButton)(() => ({
+	width: 303,
+}));
+
+const PolicyButton = styled(TertiaryButton)(() => ({
+
+}));
+
+interface IPrivacyNoticeProps {
+	privacyMessage: string;
+	privacyUrl: string;
+	onAcceptTerms: () => void;
+}
+
+export const PrivacyNotice = (props: IPrivacyNoticeProps) => {
+	const { privacyMessage, privacyUrl, onAcceptTerms } = props;
+
+	const handleLinkClick = () => {
+		window.open(privacyUrl, "_blank");
+	};
+
+	return (
+		<PrivacyNoticeRoot className="webchat-privacy-notice-root">
+			<PrivacyMessage className="webchat-privacy-notice-message">
+				<Typography
+					variant="body-regular"
+					style={{ whiteSpace: "pre-wrap" }}
+				>
+					{privacyMessage}
+				</Typography>
+			</PrivacyMessage>
+			<PrivacyActions className="webchat-privacy-notice-actions">
+				<AcceptButton
+					className="webchat-privacy-notice-accept-button"
+					onClick={onAcceptTerms}
+				>
+					Submit
+				</AcceptButton>
+				<PolicyButton onClick={handleLinkClick}>
+					Privacy policy
+				</PolicyButton>
+			</PrivacyActions>
+		</PrivacyNoticeRoot>
+	);
+};

--- a/src/webchat-ui/components/presentational/TertiaryButton.tsx
+++ b/src/webchat-ui/components/presentational/TertiaryButton.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import ArrowIcon from '../../assets/arrow-back-16px.svg';
+import styled from '@emotion/styled';
+import Button from './Button';
+import { Typography } from '@cognigy/chat-components';
+
+interface TertiaryButtonProps {
+	onClick: () => void;
+}
+
+const TertiaryButtonWrapper = styled(Button)(({ theme }) => ({
+	display: "inline-flex",
+	justifyContent: "center",
+	alignItems: "center",
+	gap: 8,
+	color: theme.black10,
+	backgroundColor: theme.white,
+	svg: {
+		transform: "rotate(180deg)",
+		fill: theme.black10,
+	},
+
+	'&:disabled': {
+		cursor: 'default',
+		color: theme.black60,
+		backgroundColor: theme.white,
+		svg: {
+			fill: theme.black60,
+		},
+	},
+
+	'&:hover:not(:disabled)': {
+		color: theme.black40,
+		backgroundColor: theme.white,
+		svg: {
+			fill: theme.black40,
+		},
+	},
+
+	'&:focus:not(:disabled)': {
+		color: theme.black40,
+		backgroundColor: theme.white,
+		svg: {
+			fill: theme.black40,
+		},
+	},
+
+	'&:active:not(:disabled)': {
+		color: theme.black40,
+		backgroundColor: theme.white,
+		svg: {
+			fill: theme.black40,
+		},
+	},
+}));
+
+const TertiaryButton: React.FC<TertiaryButtonProps> = ({ children, onClick }) => {
+	return (
+		<TertiaryButtonWrapper className="tertiary-button" onClick={onClick}>
+			<Typography variant="cta-semibold" >{children}</Typography>
+			<ArrowIcon />
+		</TertiaryButtonWrapper>
+	);
+};
+
+export default TertiaryButton;

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -2,7 +2,7 @@ import { WebchatUI, WebchatUIProps } from "../../webchat-ui";
 import { connect } from "react-redux";
 import { StoreState } from "../store/store";
 import { sendMessage, triggerEngagementMessage } from '../store/messages/message-middleware';
-import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, setScrollToPosition, setLastScrolledPosition, setShowHomeScreen, setShowPrevConversations } from '../store/ui/ui-reducer';
+import { setInputMode, setFullscreenMessage, setOpen, toggleOpen, setScrollToPosition, setLastScrolledPosition, setShowHomeScreen, setShowPrevConversations, setHasAcceptedTerms, UIState, setStoredMessage } from '../store/ui/ui-reducer';
 import { getPluginsForMessage, isFullscreenPlugin } from '../../plugins/helper';
 import { connect as doConnect } from "../store/connection/connection-middleware";
 import { setHasGivenRating, showRatingDialog } from "../store/rating/rating-reducer";
@@ -20,7 +20,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         unseenMessages,
         prevConversations,
         connection: { connected, reconnectionLimit },
-        ui: { open, typing, inputMode, fullscreenMessage, scrollToPosition, lastScrolledPosition, showHomeScreen, showPrevConversations },
+        ui: { open, typing, inputMode, fullscreenMessage, scrollToPosition, lastScrolledPosition, showHomeScreen, showPrevConversations, hasAcceptedTerms },
         config,
         options: { sessionId },
         rating: { showRatingDialog, hasGivenRating, customRatingTitle, customRatingCommentText },
@@ -46,6 +46,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         showHomeScreen,
         sttActive,
         showPrevConversations,
+        hasAcceptedTerms,
     }),
     dispatch => ({
         onSendMessage: (text, data, options) => dispatch(sendMessage({ text, data }, options)),
@@ -63,6 +64,8 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         onSetShowHomeScreen: (show: boolean) => dispatch(setShowHomeScreen(show)),
         onSetShowPrevConversations: (show: boolean) => dispatch(setShowPrevConversations(show)),
         onSwitchSession: (sessionId?: string, conversation?: PrevConversationsState[string]) => dispatch(switchSession(sessionId, conversation)),
+        onAcceptTerms: () => dispatch(setHasAcceptedTerms()),
+        onSetStoredMessage: (message: UIState['storedMessage']) => dispatch(setStoredMessage(message)),
     }),
     ({ fullscreenMessage, ...state }, dispatch, props) => {
         if (!fullscreenMessage) {

--- a/src/webchat/components/Webchat.tsx
+++ b/src/webchat/components/Webchat.tsx
@@ -6,7 +6,7 @@ import { ConnectedWebchatUI, FromProps } from './ConnectedWebchatUI';
 import { MessagePlugin } from '../../common/interfaces/message-plugin';
 import { sendMessage } from '../store/messages/message-middleware';
 import { MessageSender } from '../../webchat-ui/interfaces';
-import { setOpen, setShowHomeScreen, toggleOpen } from '../store/ui/ui-reducer';
+import { setHasAcceptedTerms, setOpen, setShowHomeScreen, toggleOpen } from '../store/ui/ui-reducer';
 import { loadConfig } from '../store/config/config-middleware';
 import { connect } from '../store/connection/connection-middleware';
 import { EventEmitter } from 'events';
@@ -20,6 +20,7 @@ import { isDisabledDueToMaintenance } from '../helper/maintenance';
 import { isDisabledOutOfBusinessHours } from '../helper/businessHours';
 import { isDisabledDueToConnectivity } from '../helper/connectivity';
 import { createNotification } from '../../webchat-ui/components/presentational/Notifications';
+import { getStorage } from '../helper/storage';
 
 export interface WebchatProps extends FromProps {
     url: string;
@@ -57,6 +58,15 @@ export class Webchat extends React.PureComponent<WebchatProps> {
     }
 
     componentWillMount() {
+		const { settings } = this.props;
+
+		const disableLocalStorage = settings?.disableLocalStorage ?? false;
+		const useSessionStorage = settings?.useSessionStorage ?? false;
+		const browserStorage = getStorage({ disableLocalStorage, useSessionStorage });
+		if (browserStorage?.getItem('hasAcceptedTerms') === 'true') {
+			this.store.dispatch(setHasAcceptedTerms());
+		}
+
         this.store.dispatch(loadConfig());
         if (this.props.options?.sessionId) {
             this.store.dispatch(setInitialSessionId(this.props.options.sessionId));

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -109,7 +109,11 @@ export const getInitialState = (): ConfigState => ({
       engagement: 'primary',
       user: 'neutral',
     },
-    _endpointTokenUrl: ""
+    _endpointTokenUrl: "",
+    privacyMessage: `Please accept our privacy policy to start your chats
+
+This website uses the messaging software Cognigy, which enables you to have conversations with us. Cognigy needs to save some cookies on your device. Your data is safe though and it will not be used to identify you personally. To learn more, please read our Privacy Policy.`,
+    privacyUrl: "https://www.cognigy.com/",
   },
 });
 

--- a/src/webchat/store/ui/ui-middleware.ts
+++ b/src/webchat/store/ui/ui-middleware.ts
@@ -1,9 +1,15 @@
 import { Middleware } from "redux";
 import { StoreState } from "../store";
 import { clearUnseenMessages } from "../unseen-messages/unseen-message-reducer";
-import { setOpen, ToggleOpenAction, SetOpenAction, SetPageVisibleAction } from "./ui-reducer";
+import { setOpen, ToggleOpenAction, SetOpenAction, SetPageVisibleAction, SetHasAcceptedTermsAction } from "./ui-reducer";
+import { getStorage } from "../../helper/storage";
 
-export const uiMiddleware: Middleware<{}, StoreState> = store => next => (action: ToggleOpenAction | SetOpenAction | SetPageVisibleAction) => {
+export const uiMiddleware: Middleware<{}, StoreState> = store => next => (action: ToggleOpenAction | SetOpenAction | SetPageVisibleAction | SetHasAcceptedTermsAction) => {
+
+    const { disableLocalStorage, useSessionStorage } =
+        store.getState().config.settings;
+    const browserStorage = getStorage({ useSessionStorage, disableLocalStorage });
+
     switch (action.type) {
         case 'TOGGLE_OPEN': {
             const open = store.getState().ui.open;
@@ -26,6 +32,15 @@ export const uiMiddleware: Middleware<{}, StoreState> = store => next => (action
         case 'SET_PAGE_VISIBLE': {
             if (action.visible && store.getState().ui.open) {
                 store.dispatch(clearUnseenMessages());
+            }
+
+            break;
+        }
+
+        // if the User accepts the privacy notice, we store it in local storage
+        case 'SET_HAS_ACCEPTED_TERMS': {
+            if (browserStorage) {
+                browserStorage.setItem('hasAcceptedTerms', 'true');
             }
 
             break;

--- a/src/webchat/store/ui/ui-reducer.ts
+++ b/src/webchat/store/ui/ui-reducer.ts
@@ -2,6 +2,7 @@ import { Reducer } from "redux";
 import { IMessage } from "../../../common/interfaces/message";
 import { TTyping } from "../../../common/interfaces/typing";
 import { isPageVisible } from '../../helper/page-visibility';
+import { ISendMessageOptions } from "../messages/message-middleware";
 
 export interface UIState {
     open: boolean;
@@ -16,6 +17,10 @@ export interface UIState {
     lastScrolledPosition: number | null;
     showHomeScreen: boolean;
     showPrevConversations: boolean;
+    hasAcceptedTerms: boolean;
+    storedMessage: {
+        text?: string, data?: any, options?: Partial<ISendMessageOptions>
+    } | null,
 }
 
 export const SET_OPEN = 'SET_OPEN';
@@ -47,15 +52,15 @@ export type SetLastScrolledPosition = ReturnType<typeof setLastScrolledPosition>
 
 export const SET_SHOW_HOME_SCREEN = 'SET_SHOW_HOME_SCREEN';
 export const setShowHomeScreen = (showHomeScreen: boolean) => ({
-	type: SET_SHOW_HOME_SCREEN as 'SET_SHOW_HOME_SCREEN',
-	showHomeScreen
+    type: SET_SHOW_HOME_SCREEN as 'SET_SHOW_HOME_SCREEN',
+    showHomeScreen
 });
 export type SetShowHomeScreenAction = ReturnType<typeof setShowHomeScreen>;
 
 export const SET_SHOW_PREV_CONVERSATIONS = 'SET_SHOW_PREV_CONVERSATIONS';
 export const setShowPrevConversations = (showPrevConversations: boolean) => ({
-	type: SET_SHOW_PREV_CONVERSATIONS as 'SET_SHOW_PREV_CONVERSATIONS',
-	showPrevConversations
+    type: SET_SHOW_PREV_CONVERSATIONS as 'SET_SHOW_PREV_CONVERSATIONS',
+    showPrevConversations
 });
 export type SetShowPrevConversationsAction = ReturnType<typeof setShowPrevConversations>;
 
@@ -108,6 +113,19 @@ export const setPageVisible = (visible: boolean) => ({
 });
 export type SetPageVisibleAction = ReturnType<typeof setPageVisible>;
 
+const SET_HAS_ACCEPTED_TERMS = 'SET_HAS_ACCEPTED_TERMS';
+export const setHasAcceptedTerms = () => ({
+    type: SET_HAS_ACCEPTED_TERMS as 'SET_HAS_ACCEPTED_TERMS',
+});
+export type SetHasAcceptedTermsAction = ReturnType<typeof setHasAcceptedTerms>;
+
+const SET_STORED_MESSAGE = 'SET_STORED_MESSAGE';
+export const setStoredMessage = (message: UIState['storedMessage']) => ({
+    type: SET_STORED_MESSAGE as 'SET_STORED_MESSAGE',
+    message
+});
+export type SetStoredMessageAction = ReturnType<typeof setStoredMessage>;
+
 
 const getInitialState = (): UIState => ({
     open: false,
@@ -119,9 +137,11 @@ const getInitialState = (): UIState => ({
     userAvatarOverrideUrl: undefined,
     isPageVisible: isPageVisible(),
     scrollToPosition: 0,
-	lastScrolledPosition: null,
+    lastScrolledPosition: null,
     showHomeScreen: true,
     showPrevConversations: false,
+    hasAcceptedTerms: false,
+    storedMessage: null,
 });
 
 type UIAction = SetOpenAction
@@ -133,9 +153,11 @@ type UIAction = SetOpenAction
     | SetUserAvatarOverrideUrlAction
     | SetPageVisibleAction
     | SetScrollToPosition
-	| SetLastScrolledPosition
+    | SetLastScrolledPosition
     | SetShowHomeScreenAction
-    | SetShowPrevConversationsAction;
+    | SetShowPrevConversationsAction
+    | SetHasAcceptedTermsAction
+    | SetStoredMessageAction;
 
 
 export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action) => {
@@ -168,19 +190,19 @@ export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action
             }
         }
 
-		case SET_SHOW_HOME_SCREEN: {
-			return {
-				...state,
-				showHomeScreen: action.showHomeScreen
-			}
+        case SET_SHOW_HOME_SCREEN: {
+            return {
+                ...state,
+                showHomeScreen: action.showHomeScreen
+            }
         }
             
         case SET_SHOW_PREV_CONVERSATIONS: {
-			return {
-				...state,
-				showPrevConversations: action.showPrevConversations
-			}
-		}
+            return {
+                ...state,
+                showPrevConversations: action.showPrevConversations
+            }
+        }
 
         case SET_INPUT_MODE: {
             return {
@@ -221,6 +243,20 @@ export const ui: Reducer<UIState, UIAction> = (state = getInitialState(), action
             return {
                 ...state,
                 isPageVisible: action.visible
+            }
+        }
+
+        case SET_HAS_ACCEPTED_TERMS: {
+            return {
+                ...state,
+                hasAcceptedTerms: true
+            }
+        }
+
+        case SET_STORED_MESSAGE: {
+            return {
+                ...state,
+                storedMessage: action.message
             }
         }
     }


### PR DESCRIPTION
Implements the Privacy Notice feature according to Figma pages and US 55721 (https://cognigy.visualstudio.com/Cognigy.AI/_workitems/edit/55721)

- adds the visual components to look & behave like the specs
- adds local storage logic so that you only have to accept once
- adds connection logic so that a user only connects to the endpoint after they have accepted
- adds logic that a message action button from home screen is stored and only sent after privacy notice was accepted