### PR TITLE
Resizing input font to 16px on mobile

### DIFF
--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -9,6 +9,7 @@ import TextareaAutosize from "react-textarea-autosize";
 import PreviewUploadedFiles from "../file/PreviewUploadedFiles";
 import { IUploadFileMetaData } from "../../../../../common/interfaces/file-upload";
 import { IFile } from "../../../../../webchat/store/input/input-reducer";
+import MediaQuery from "react-responsive";
 
 const InputWrapper = styled.div(() => ({
 	display: "flex",
@@ -425,23 +426,28 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 							</>
 						)}
 
-						<TextArea
-							ref={this.inputRef as React.Ref<HTMLTextAreaElement>}
-							autoFocus={!disableInputAutofocus}
-							value={combineStrings(text, speechInterim)}
-							onChange={this.handleChangeTextValue}
-							onFocus={() => this.setState({ textActive: true })}
-							onBlur={() => this.setState({ textActive: false })}
-							onKeyDown={this.handleInputKeyDown}
-							placeholder={props.config.settings.inputPlaceholder}
-							className="webchat-input-message-input"
-							aria-label="Message to send"
-							minRows={1}
-							maxRows={inputAutogrowMaxRows}
-							autoComplete={disableInputAutocomplete ? "off" : undefined}
-							spellCheck={false}
-							id="webchatInputMessageInputInTextMode"
-						/>
+						<MediaQuery maxWidth={575}>
+							{matches => (
+								<TextArea
+									ref={this.inputRef as React.Ref<HTMLTextAreaElement>}
+									autoFocus={!disableInputAutofocus}
+									value={combineStrings(text, speechInterim)}
+									onChange={this.handleChangeTextValue}
+									onFocus={() => this.setState({ textActive: true })}
+									onBlur={() => this.setState({ textActive: false })}
+									onKeyDown={this.handleInputKeyDown}
+									placeholder={props.config.settings.inputPlaceholder}
+									className="webchat-input-message-input"
+									aria-label="Message to send"
+									minRows={1}
+									maxRows={inputAutogrowMaxRows}
+									autoComplete={disableInputAutocomplete ? "off" : undefined}
+									spellCheck={false}
+									id="webchatInputMessageInputInTextMode"
+									style={matches ? { fontSize: "16px" } : undefined}
+								/>
+							)}
+						</MediaQuery>
 
 						<SpeechButton
 							className={classnames(

--- a/src/webchat-ui/components/presentational/MultilineInput.tsx
+++ b/src/webchat-ui/components/presentational/MultilineInput.tsx
@@ -1,10 +1,11 @@
 import React, { ComponentProps, forwardRef } from "react";
 import styled from "@emotion/styled";
+import MediaQuery from "react-responsive";
 
 const InputWrapper = styled.div(({ theme }) => ({
 	borderRadius: 10,
 	border: `1px solid var(--basics-black-60, ${theme.black60})`,
-	background: `var(--Basics-white, ${theme.white})`, 
+	background: `var(--Basics-white, ${theme.white})`,
 	width: "100%",
 	height: "100px",
 	padding: 12,
@@ -42,7 +43,6 @@ const Input = styled.textarea(({ theme }) => ({
 	"::-webkit-scrollbar": {
 		width: 2,
 		height: 2,
-		
 	},
 	"::-webkit-scrollbar-track": {
 		backgroundColor: theme.black95,
@@ -63,12 +63,17 @@ const MultilineInput = forwardRef<HTMLTextAreaElement, IMultilineInputProps>((pr
 
 	return (
 		<InputWrapper>
-			<Input
-				{...restProps}
-				data-test={dataTest}
-				ref={ref}
-				className={`${className} ${props.disabled ? "disabled" : ""}`.trim()}
-			/>
+			<MediaQuery maxWidth={575}>
+				{matches => (
+					<Input
+						{...restProps}
+						data-test={dataTest}
+						ref={ref}
+						className={`${className} ${props.disabled ? "disabled" : ""}`.trim()}
+						style={matches ? { fontSize: "16px" } : undefined}
+					/>
+				)}
+			</MediaQuery>
 		</InputWrapper>
 	);
 });


### PR DESCRIPTION
Implement a media query (maxWidth: 575) to conditionally set the font size in all input and textarea to 16px, in order to prevent autofocus on mobile devices.

**How to test:**
1. Deploy the Webchat widget locally using this endpoint: 
https://webchat-dev.cognigy.ai/v3/f8b7805b35c19db25c3840b586e2a26ad56b2c5bececf30e177eca2dab6f4841

2. Using a mobile device connected on same network as your cognigy machine, point the mobile browser to your cognigy machine IP like this (Example http://192.168.178.1:8787). It could be necessary to add a rule to the firewall in order to allow port 8787.

**Note**: this PR is going together with this one on chat-components
https://github.com/Cognigy/chat-components/pull/31