### PR TITLE
Feature/61647 use new fields from request rating node

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -8,20 +8,27 @@
 <body>
     <script src="./webchat.js"></script>
     <script>
-                    initWebchat('https://endpoint-dev.cognigy.ai/14c8e0ab190c22ec8121cbd7d1cef945727844f7d41aad21cae33654806bacbd', {
+            initWebchat('https://endpoint-dev.cognigy.ai/14c8e0ab190c22ec8121cbd7d1cef945727844f7d41aad21cae33654806bacbd', {
             userId: "user1",
             sessionId: "session1",
             settings: {
-                // colorScheme: '#FAB',
-                enableUnreadMessageSound: true,
-                enableUnreadMessageBadge: true,
-                enableUnreadMessagePreview: true,
-                enableUnreadMessageTitleIndicator: true,
-                showEngagementMessagesInChat: true,
-                getStartedText: "",
-                engagementMessageText: "Hi there!",
-                engagementMessageDelay: 5000,
-            }
+                unreadMessages: {
+                    enableIndicator: true,
+                    enableBadge: true,  
+                    enablePreview: true,
+                    enableSound: true
+                },
+                teaserMessage:{
+                    showInChat: true,
+                    text: "Hi there!"
+                },
+                widgetSettings: {
+                    teaserMessageDelay: 5000,
+                },
+                startBehavior: {
+                    getStartedText: ""
+                },
+            },
         }).then(function (webchat) {
             window.cognigyWebchat = webchat;
             // webchat.open();

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -243,7 +243,6 @@ export interface IWebchatSettings {
 			commentPlaceholder: string;
 			submitButtonText: string;
 			eventBannerText: string;
-			chatStatusMessage: string;
 		};
 		footer: {
 			enabled: boolean;

--- a/src/plugins/rating/RatingConfirmation.tsx
+++ b/src/plugins/rating/RatingConfirmation.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 import { ChatEvent } from "@cognigy/chat-components";
+import { useSelector } from "react-redux";
+import { StoreState } from "../../webchat/store/store";
 
 const RatingConfirmation = () => {
-	return <ChatEvent text="Feedback submitted" />;
+	const requestRatingChatStatusBadgeText = useSelector(
+		(state: StoreState) => state.rating.requestRatingChatStatusBadgeText,
+	);
+
+	return <ChatEvent text={requestRatingChatStatusBadgeText || "Feedback submitted"} />;
 };
 
 export default RatingConfirmation;

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -108,6 +108,9 @@ export interface WebchatUIProps {
 	onSetHasGivenRating: () => void;
 	customRatingTitle: string;
 	customRatingCommentText: string;
+	requestRatingSubmitButtonText: string;
+	requestRatingEventBannerText: string;
+	requestRatingChatStatusBadgeText: string;
 
 	showHomeScreen: boolean;
 	onSetShowHomeScreen: (show: boolean) => void;
@@ -603,6 +606,9 @@ export class WebchatUI extends React.PureComponent<
 			onSwitchSession,
 			customRatingTitle,
 			customRatingCommentText,
+			requestRatingSubmitButtonText,
+			requestRatingEventBannerText,
+			requestRatingChatStatusBadgeText,
 			onAcceptTerms,
 			onSetStoredMessage,
 			onSetFileList,
@@ -807,6 +813,8 @@ export class WebchatUI extends React.PureComponent<
 			onSetShowChatOptionsScreen,
 			customRatingTitle,
 			customRatingCommentText,
+			requestRatingSubmitButtonText,
+			requestRatingEventBannerText,
 			showRatingScreen,
 			onShowRatingScreen,
 			onSwitchSession,
@@ -918,6 +926,8 @@ export class WebchatUI extends React.PureComponent<
 					config={config}
 					ratingTitleText={customRatingTitle || config.settings.chatOptions.rating.title}
 					ratingCommentText={customRatingCommentText || config.settings.chatOptions.rating.commentPlaceholder}
+					ratingSubmitButtonText={requestRatingSubmitButtonText || config.settings.chatOptions.rating.submitButtonText}
+					ratingEventBannerText={requestRatingEventBannerText || config.settings.chatOptions.rating.eventBannerText}
 					showOnlyRating={showRatingScreen}
 					hasGivenRating={this.props.hasGivenRating}
 					onSendRating={this.handleSendRating}

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -106,6 +106,7 @@ export interface WebchatUIProps {
 	showRatingScreen: boolean;
 	onShowRatingScreen: (show: boolean) => void;
 	onSetHasGivenRating: () => void;
+	requestRatingScreenTitle: string;
 	customRatingTitle: string;
 	customRatingCommentText: string;
 	requestRatingSubmitButtonText: string;
@@ -604,6 +605,7 @@ export class WebchatUI extends React.PureComponent<
 			onSetShowPrevConversations,
 			onSetShowChatOptionsScreen,
 			onSwitchSession,
+			requestRatingScreenTitle,
 			customRatingTitle,
 			customRatingCommentText,
 			requestRatingSubmitButtonText,
@@ -811,6 +813,7 @@ export class WebchatUI extends React.PureComponent<
 			onSetShowPrevConversations,
 			showChatOptionsScreen,
 			onSetShowChatOptionsScreen,
+			requestRatingScreenTitle,
 			customRatingTitle,
 			customRatingCommentText,
 			requestRatingSubmitButtonText,
@@ -980,7 +983,7 @@ export class WebchatUI extends React.PureComponent<
 				return config.settings.chatOptions.title || "Chat options";
 			}
 			if (showRatingScreen) {
-				return config.settings.chatOptions.rating.title || "Conversation rating";
+				return requestRatingScreenTitle || "Conversation rating";
 			}
 			if (config.settings.layout.title) {
 				return config.settings.layout.title;

--- a/src/webchat-ui/components/presentational/chat-options/ChatOptions.tsx
+++ b/src/webchat-ui/components/presentational/chat-options/ChatOptions.tsx
@@ -41,6 +41,8 @@ interface IChatOptionsProps {
 	config: IWebchatConfig;
 	ratingTitleText: string;
 	ratingCommentText: string;
+	ratingSubmitButtonText: string;
+	ratingEventBannerText: string;
 	showOnlyRating: boolean;
 	hasGivenRating: boolean;
 	onSendRating: (props: IOnSendRatingProps) => void;
@@ -54,6 +56,8 @@ export const ChatOptions = (props: IChatOptionsProps) => {
 		showOnlyRating,
 		ratingTitleText,
 		ratingCommentText,
+		ratingSubmitButtonText,
+		ratingEventBannerText,
 		hasGivenRating,
 		onSendRating,
 		onEmitAnalytics,
@@ -61,10 +65,6 @@ export const ChatOptions = (props: IChatOptionsProps) => {
 	} = props;
 	const { settings } = config;
 	const { chatOptions } = settings;
-	const { rating: chatOptionsRating } = chatOptions;
-
-	const ratingEventBannerText = chatOptionsRating.eventBannerText;
-	const submitRatingButtonText = chatOptionsRating.submitButtonText;
 
 	const ratingEnabled = chatOptions.rating.enabled;
 	const showRating = ratingEnabled === "always" || (ratingEnabled === "once" && !hasGivenRating) || showOnlyRating;
@@ -94,7 +94,7 @@ export const ChatOptions = (props: IChatOptionsProps) => {
 						onSendRating={onSendRating}
 						showRatingStatus={showOnlyRating}
 						ratingEventBannerText={ratingEventBannerText}
-						buttonText={submitRatingButtonText}
+						buttonText={ratingSubmitButtonText}
 					/>
 				}
 			</ChatOptionsContainer>

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -24,7 +24,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         ui: { open, typing, inputMode, fullscreenMessage, scrollToPosition, lastScrolledPosition, showHomeScreen, showPrevConversations, showChatOptionsScreen, hasAcceptedTerms },
         config,
         options: { sessionId },
-        rating: { showRatingScreen, hasGivenRating, customRatingTitle, customRatingCommentText, requestRatingSubmitButtonText, requestRatingEventBannerText, requestRatingChatStatusBadgeText },
+        rating: { showRatingScreen, hasGivenRating, requestRatingScreenTitle, customRatingTitle, customRatingCommentText, requestRatingSubmitButtonText, requestRatingEventBannerText, requestRatingChatStatusBadgeText },
         input: { sttActive, isDropZoneVisible, fileList, fileUploadError },
     }) => ({
         currentSession: sessionId,
@@ -42,6 +42,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         reconnectionLimit,
         showRatingScreen,
         hasGivenRating,
+        requestRatingScreenTitle,
         customRatingTitle,
         customRatingCommentText,
         requestRatingSubmitButtonText,

--- a/src/webchat/components/ConnectedWebchatUI.tsx
+++ b/src/webchat/components/ConnectedWebchatUI.tsx
@@ -24,7 +24,7 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         ui: { open, typing, inputMode, fullscreenMessage, scrollToPosition, lastScrolledPosition, showHomeScreen, showPrevConversations, showChatOptionsScreen, hasAcceptedTerms },
         config,
         options: { sessionId },
-        rating: { showRatingScreen, hasGivenRating, customRatingTitle, customRatingCommentText },
+        rating: { showRatingScreen, hasGivenRating, customRatingTitle, customRatingCommentText, requestRatingSubmitButtonText, requestRatingEventBannerText, requestRatingChatStatusBadgeText },
         input: { sttActive, isDropZoneVisible, fileList, fileUploadError },
     }) => ({
         currentSession: sessionId,
@@ -44,6 +44,9 @@ export const ConnectedWebchatUI = connect<FromState, FromDispatch, FromProps, Me
         hasGivenRating,
         customRatingTitle,
         customRatingCommentText,
+        requestRatingSubmitButtonText,
+        requestRatingEventBannerText,
+        requestRatingChatStatusBadgeText,
         showHomeScreen,
         sttActive,
         isDropZoneVisible,

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -120,7 +120,7 @@ export const getInitialState = (): ConfigState => ({
 
 				submitButtonText: "Send feedback",
 				eventBannerText: "Your feedback was submitted",
-				chatStatusMessage: "Feedback submitted",
+				chatStatusMessage: "Feedback submitted", // Not used anywhere. Please see spec and remove if not needed
 			},
 			footer: {
 				enabled: false,

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -116,7 +116,7 @@ export const getInitialState = (): ConfigState => ({
 			rating: {
 				enabled: "once",
 				title: "Please rate your chat experience",
-				commentPlaceholder: "Type something here",
+				commentPlaceholder: "Type something here...",
 
 				submitButtonText: "Send feedback",
 				eventBannerText: "Your feedback was submitted",

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -120,7 +120,6 @@ export const getInitialState = (): ConfigState => ({
 
 				submitButtonText: "Send feedback",
 				eventBannerText: "Your feedback was submitted",
-				chatStatusMessage: "Feedback submitted", // Not used anywhere. Please see spec and remove if not needed
 			},
 			footer: {
 				enabled: false,

--- a/src/webchat/store/messages/message-handler.ts
+++ b/src/webchat/store/messages/message-handler.ts
@@ -52,8 +52,8 @@ export const createOutputHandler = (store: Store) => (output) => {
                 store.dispatch(setRequestRatingEventBannerText(data.ratingEventBannerText));
             }
 
-            if (data && data.ratingChatStatusBadgeText) {
-                store.dispatch(setRequestRatingChatStatusText(data.ratingChatStatusBadgeText));
+            if (data && data.ratingChatStatusMessage) {
+                store.dispatch(setRequestRatingChatStatusText(data.ratingChatStatusMessage));
             }
 
             store.dispatch(showRatingScreen(true));

--- a/src/webchat/store/messages/message-handler.ts
+++ b/src/webchat/store/messages/message-handler.ts
@@ -2,7 +2,7 @@ import { Store } from "redux";
 import { IMessage } from "../../../common/interfaces/message";
 import { ISendMessageOptions } from "./message-middleware";
 import { setBotAvatarOverrideUrl, setUserAvatarOverrideUrl, setAgentAvatarOverrideUrl, setTyping } from "../ui/ui-reducer";
-import { setCustomRatingCommentText, setCustomRatingTitle, showRatingScreen } from "../rating/rating-reducer";
+import { setCustomRatingCommentText, setCustomRatingTitle, setRequestRatingSubmitButtonText, setRequestRatingEventBannerText, setRequestRatingChatStatusText, showRatingScreen } from "../rating/rating-reducer";
 import { SocketClient } from "@cognigy/socket-client";
 
 const RECEIVE_MESSAGE = 'RECEIVE_MESSAGE';
@@ -42,6 +42,18 @@ export const createOutputHandler = (store: Store) => (output) => {
 
             if (data && data.ratingTitleText) {
                 store.dispatch(setCustomRatingTitle(data.ratingTitleText));
+            }
+
+            if (data && data.ratingSubmitButtonText) {
+                store.dispatch(setRequestRatingSubmitButtonText(data.ratingSubmitButtonText));
+            }
+
+            if (data && data.ratingEventBannerText) {
+                store.dispatch(setRequestRatingEventBannerText(data.ratingEventBannerText));
+            }
+
+            if (data && data.ratingChatStatusBadgeText) {
+                store.dispatch(setRequestRatingChatStatusText(data.ratingChatStatusBadgeText));
             }
 
             store.dispatch(showRatingScreen(true));

--- a/src/webchat/store/messages/message-handler.ts
+++ b/src/webchat/store/messages/message-handler.ts
@@ -1,69 +1,87 @@
 import { Store } from "redux";
 import { IMessage } from "../../../common/interfaces/message";
 import { ISendMessageOptions } from "./message-middleware";
-import { setBotAvatarOverrideUrl, setUserAvatarOverrideUrl, setAgentAvatarOverrideUrl, setTyping } from "../ui/ui-reducer";
-import { setCustomRatingCommentText, setCustomRatingTitle, setRequestRatingSubmitButtonText, setRequestRatingEventBannerText, setRequestRatingChatStatusText, showRatingScreen } from "../rating/rating-reducer";
+import {
+	setBotAvatarOverrideUrl,
+	setUserAvatarOverrideUrl,
+	setAgentAvatarOverrideUrl,
+	setTyping,
+} from "../ui/ui-reducer";
+import {
+	setCustomRatingCommentText,
+	setCustomRatingTitle,
+	setRequestRatingSubmitButtonText,
+	setRequestRatingEventBannerText,
+	setRequestRatingChatStatusText,
+	showRatingScreen,
+	setRequestRatingScreenTitle,
+} from "../rating/rating-reducer";
 import { SocketClient } from "@cognigy/socket-client";
 
-const RECEIVE_MESSAGE = 'RECEIVE_MESSAGE';
+const RECEIVE_MESSAGE = "RECEIVE_MESSAGE";
 export const receiveMessage = (message: IMessage, options: Partial<ISendMessageOptions> = {}) => ({
-    type: RECEIVE_MESSAGE as 'RECEIVE_MESSAGE',
-    message: { ...message } as IMessage,
-    options
+	type: RECEIVE_MESSAGE as "RECEIVE_MESSAGE",
+	message: { ...message } as IMessage,
+	options,
 });
 export type ReceiveMessageAction = ReturnType<typeof receiveMessage>;
 
-export const createOutputHandler = (store: Store) => (output) => {
-    // handle custom webchat actions
-    if (output.data && output.data._webchat) {
-        const { agentAvatarOverrideUrl, botAvatarOverrideUrl, userAvatarOverrideUrl } = output.data._webchat;
+export const createOutputHandler = (store: Store) => output => {
+	// handle custom webchat actions
+	if (output.data && output.data._webchat) {
+		const { agentAvatarOverrideUrl, botAvatarOverrideUrl, userAvatarOverrideUrl } =
+			output.data._webchat;
 
-        if (agentAvatarOverrideUrl !== undefined) {
-            store.dispatch(setAgentAvatarOverrideUrl(agentAvatarOverrideUrl));
-        }
+		if (agentAvatarOverrideUrl !== undefined) {
+			store.dispatch(setAgentAvatarOverrideUrl(agentAvatarOverrideUrl));
+		}
 
-        if (botAvatarOverrideUrl !== undefined) {
-            store.dispatch(setBotAvatarOverrideUrl(botAvatarOverrideUrl));
-        }
+		if (botAvatarOverrideUrl !== undefined) {
+			store.dispatch(setBotAvatarOverrideUrl(botAvatarOverrideUrl));
+		}
 
-        if (userAvatarOverrideUrl !== undefined) {
-            store.dispatch(setUserAvatarOverrideUrl(userAvatarOverrideUrl))
-        }
-    }
+		if (userAvatarOverrideUrl !== undefined) {
+			store.dispatch(setUserAvatarOverrideUrl(userAvatarOverrideUrl));
+		}
+	}
 
-    // handle custom plugin actions
-    if (output.data && output.data._plugin) {
-        const { type, data } = output.data._plugin;
+	// handle custom plugin actions
+	if (output.data && output.data._plugin) {
+		const { type, data } = output.data._plugin;
 
-        if (type === "request-rating") {
-            if (data && data.ratingCommentText) {
-                store.dispatch(setCustomRatingCommentText(data.ratingCommentText));
-            }
+		if (type === "request-rating") {
+			if (data && data.ratingCommentText) {
+				store.dispatch(setCustomRatingCommentText(data.ratingCommentText));
+			}
 
-            if (data && data.ratingTitleText) {
-                store.dispatch(setCustomRatingTitle(data.ratingTitleText));
-            }
+			if (data && data.ratingTitleText) {
+				store.dispatch(setCustomRatingTitle(data.ratingTitleText));
+			}
 
-            if (data && data.ratingSubmitButtonText) {
-                store.dispatch(setRequestRatingSubmitButtonText(data.ratingSubmitButtonText));
-            }
+			if (data && data.ratingSubmitButtonText) {
+				store.dispatch(setRequestRatingSubmitButtonText(data.ratingSubmitButtonText));
+			}
 
-            if (data && data.ratingEventBannerText) {
-                store.dispatch(setRequestRatingEventBannerText(data.ratingEventBannerText));
-            }
+			if (data && data.ratingEventBannerText) {
+				store.dispatch(setRequestRatingEventBannerText(data.ratingEventBannerText));
+			}
 
-            if (data && data.ratingChatStatusMessage) {
-                store.dispatch(setRequestRatingChatStatusText(data.ratingChatStatusMessage));
-            }
+			if (data && data.ratingChatStatusMessage) {
+				store.dispatch(setRequestRatingChatStatusText(data.ratingChatStatusMessage));
+			}
 
-            store.dispatch(showRatingScreen(true));
-        }
-    }
+			if (data && data.ratingScreenTitleText) {
+				store.dispatch(setRequestRatingScreenTitle(data.ratingScreenTitleText));
+			}
 
-    store.dispatch(setTyping("remove"));
-    store.dispatch(receiveMessage(output));
-} 
+			store.dispatch(showRatingScreen(true));
+		}
+	}
+
+	store.dispatch(setTyping("remove"));
+	store.dispatch(receiveMessage(output));
+};
 
 export const registerMessageHandler = (store: Store, client: SocketClient) => {
-    client.on('output', createOutputHandler(store));
-}
+	client.on("output", createOutputHandler(store));
+};

--- a/src/webchat/store/rating/rating-reducer.ts
+++ b/src/webchat/store/rating/rating-reducer.ts
@@ -5,6 +5,9 @@ export interface RatingState {
     showRatingScreen: boolean;
     customRatingTitle: string;
     customRatingCommentText: string;
+    requestRatingSubmitButtonText?: string;
+    requestRatingEventBannerText?: string;
+    requestRatingChatStatusBadgeText?: string;
 }
 
 const SHOW_RATING_SCREEN = "SHOW_RATING_SCREEN";
@@ -34,11 +37,35 @@ export const setCustomRatingCommentText = (text: string) => ({
 });
 type SetCustomRatingCommentText = ReturnType<typeof setCustomRatingCommentText>;
 
+const SET_REQUEST_RATING_SUBMIT_BUTTON_TEXT = "SET_REQUEST_RATING_SUBMIT_BUTTON_TEXT";
+export const setRequestRatingSubmitButtonText = (text: string) => ({
+    type: SET_REQUEST_RATING_SUBMIT_BUTTON_TEXT as "SET_REQUEST_RATING_SUBMIT_BUTTON_TEXT",
+    requestRatingSubmitButtonText: text,
+});
+type SetRequestRatingSubmitButtonText = ReturnType<typeof setRequestRatingSubmitButtonText>;
+
+const SET_REQUEST_RATING_EVENT_BANNER_TEXT = "SET_REQUEST_RATING_EVENT_BANNER_TEXT";
+export const setRequestRatingEventBannerText = (text: string) => ({
+    type: SET_REQUEST_RATING_EVENT_BANNER_TEXT as "SET_REQUEST_RATING_EVENT_BANNER_TEXT",
+    requestRatingEventBannerText: text,
+});
+type SetRequestRatingEventBannerText = ReturnType<typeof setRequestRatingEventBannerText>;
+
+const SET_REQUEST_RATING_CHAT_STATUS_BADGE_TEXT = "SET_REQUEST_RATING_CHAT_STATUS_BADGE_TEXT";
+export const setRequestRatingChatStatusText = (text: string) => ({
+    type: SET_REQUEST_RATING_CHAT_STATUS_BADGE_TEXT as "SET_REQUEST_RATING_CHAT_STATUS_BADGE_TEXT",
+    requestRatingChatStatusBadgeText: text,
+});
+type SetRequestRatingChatStatusText = ReturnType<typeof setRequestRatingChatStatusText>;
+
 const getInitialState = (): RatingState => ({
     hasGivenRating: false,
     showRatingScreen: false,
     customRatingTitle: "",
     customRatingCommentText: "",
+    requestRatingSubmitButtonText: "",
+    requestRatingEventBannerText: "",
+    requestRatingChatStatusBadgeText: "",
 });
 
 export const ratingInitialState = getInitialState();
@@ -46,7 +73,10 @@ export const ratingInitialState = getInitialState();
 export type RatingAction = ShowRatingScreenAction
     | SetHasGivenRating
     | SetCustomRatingTitle
-    | SetCustomRatingCommentText;
+    | SetCustomRatingCommentText
+    | SetRequestRatingSubmitButtonText
+    | SetRequestRatingEventBannerText
+    | SetRequestRatingChatStatusText;
 
 
 export const rating: Reducer<RatingState, RatingAction> = (state = getInitialState(), action) => {
@@ -60,6 +90,9 @@ export const rating: Reducer<RatingState, RatingAction> = (state = getInitialSta
                     showRatingScreen: action.show,
                     customRatingTitle: "",
                     customRatingCommentText: "",
+                    requestRatingSubmitButtonText: "",
+                    requestRatingEventBannerText: "",
+                    requestRatingChatStatusBadgeText: "",
                 }
 
             } else {
@@ -91,6 +124,28 @@ export const rating: Reducer<RatingState, RatingAction> = (state = getInitialSta
                 customRatingCommentText: action.text,
             }
         }
+
+        case SET_REQUEST_RATING_SUBMIT_BUTTON_TEXT: {
+            return {
+                ...state,
+                requestRatingSubmitButtonText: action.requestRatingSubmitButtonText,
+            }
+        }
+
+        case SET_REQUEST_RATING_EVENT_BANNER_TEXT: {
+            return {
+                ...state,
+                requestRatingEventBannerText: action.requestRatingEventBannerText,
+            }
+        }
+
+        case SET_REQUEST_RATING_CHAT_STATUS_BADGE_TEXT: {
+            return {
+                ...state,
+                requestRatingChatStatusBadgeText: action.requestRatingChatStatusBadgeText,
+            }
+        }
+
     }
 
     return state;

--- a/src/webchat/store/rating/rating-reducer.ts
+++ b/src/webchat/store/rating/rating-reducer.ts
@@ -92,7 +92,6 @@ export const rating: Reducer<RatingState, RatingAction> = (state = getInitialSta
                     customRatingCommentText: "",
                     requestRatingSubmitButtonText: "",
                     requestRatingEventBannerText: "",
-                    requestRatingChatStatusBadgeText: "",
                 }
 
             } else {

--- a/src/webchat/store/rating/rating-reducer.ts
+++ b/src/webchat/store/rating/rating-reducer.ts
@@ -3,6 +3,7 @@ import { Reducer } from "redux";
 export interface RatingState {
     hasGivenRating: boolean;
     showRatingScreen: boolean;
+    requestRatingScreenTitle?: string;
     customRatingTitle: string;
     customRatingCommentText: string;
     requestRatingSubmitButtonText?: string;
@@ -23,6 +24,13 @@ export const setHasGivenRating = () => ({
 });
 type SetHasGivenRating = ReturnType<typeof setHasGivenRating>;
 
+const SET_REQUEST_RATING_SCREEN_TITLE = "SET_REQUEST_RATING_SCREEN_TITLE";
+export const setRequestRatingScreenTitle = (text: string) => ({
+    type: SET_REQUEST_RATING_SCREEN_TITLE as "SET_REQUEST_RATING_SCREEN_TITLE",
+    text,
+});
+type SetRequestRatingScreenTitle = ReturnType<typeof setRequestRatingScreenTitle>;
+
 const SET_CUSTOM_RATING_TITLE = "SET_CUSTOM_RATING_TITLE";
 export const setCustomRatingTitle = (text: string) => ({
     type: SET_CUSTOM_RATING_TITLE as "SET_CUSTOM_RATING_TITLE",
@@ -40,27 +48,28 @@ type SetCustomRatingCommentText = ReturnType<typeof setCustomRatingCommentText>;
 const SET_REQUEST_RATING_SUBMIT_BUTTON_TEXT = "SET_REQUEST_RATING_SUBMIT_BUTTON_TEXT";
 export const setRequestRatingSubmitButtonText = (text: string) => ({
     type: SET_REQUEST_RATING_SUBMIT_BUTTON_TEXT as "SET_REQUEST_RATING_SUBMIT_BUTTON_TEXT",
-    requestRatingSubmitButtonText: text,
+    text,
 });
 type SetRequestRatingSubmitButtonText = ReturnType<typeof setRequestRatingSubmitButtonText>;
 
 const SET_REQUEST_RATING_EVENT_BANNER_TEXT = "SET_REQUEST_RATING_EVENT_BANNER_TEXT";
 export const setRequestRatingEventBannerText = (text: string) => ({
     type: SET_REQUEST_RATING_EVENT_BANNER_TEXT as "SET_REQUEST_RATING_EVENT_BANNER_TEXT",
-    requestRatingEventBannerText: text,
+    text,
 });
 type SetRequestRatingEventBannerText = ReturnType<typeof setRequestRatingEventBannerText>;
 
 const SET_REQUEST_RATING_CHAT_STATUS_BADGE_TEXT = "SET_REQUEST_RATING_CHAT_STATUS_BADGE_TEXT";
 export const setRequestRatingChatStatusText = (text: string) => ({
     type: SET_REQUEST_RATING_CHAT_STATUS_BADGE_TEXT as "SET_REQUEST_RATING_CHAT_STATUS_BADGE_TEXT",
-    requestRatingChatStatusBadgeText: text,
+    text,
 });
 type SetRequestRatingChatStatusText = ReturnType<typeof setRequestRatingChatStatusText>;
 
 const getInitialState = (): RatingState => ({
     hasGivenRating: false,
     showRatingScreen: false,
+    requestRatingScreenTitle: "",
     customRatingTitle: "",
     customRatingCommentText: "",
     requestRatingSubmitButtonText: "",
@@ -72,6 +81,7 @@ export const ratingInitialState = getInitialState();
 
 export type RatingAction = ShowRatingScreenAction
     | SetHasGivenRating
+    | SetRequestRatingScreenTitle
     | SetCustomRatingTitle
     | SetCustomRatingCommentText
     | SetRequestRatingSubmitButtonText
@@ -88,6 +98,7 @@ export const rating: Reducer<RatingState, RatingAction> = (state = getInitialSta
                 return {
                     ...state,
                     showRatingScreen: action.show,
+                    requestRatingScreenTitle: "",
                     customRatingTitle: "",
                     customRatingCommentText: "",
                     requestRatingSubmitButtonText: "",
@@ -110,6 +121,13 @@ export const rating: Reducer<RatingState, RatingAction> = (state = getInitialSta
             }
         }
 
+        case SET_REQUEST_RATING_SCREEN_TITLE: {
+            return {
+                ...state,
+                requestRatingScreenTitle: action.text,
+            }
+        }
+
         case SET_CUSTOM_RATING_TITLE: {
             return {
                 ...state,
@@ -127,21 +145,21 @@ export const rating: Reducer<RatingState, RatingAction> = (state = getInitialSta
         case SET_REQUEST_RATING_SUBMIT_BUTTON_TEXT: {
             return {
                 ...state,
-                requestRatingSubmitButtonText: action.requestRatingSubmitButtonText,
+                requestRatingSubmitButtonText: action.text,
             }
         }
 
         case SET_REQUEST_RATING_EVENT_BANNER_TEXT: {
             return {
                 ...state,
-                requestRatingEventBannerText: action.requestRatingEventBannerText,
+                requestRatingEventBannerText: action.text,
             }
         }
 
         case SET_REQUEST_RATING_CHAT_STATUS_BADGE_TEXT: {
             return {
                 ...state,
-                requestRatingChatStatusBadgeText: action.requestRatingChatStatusBadgeText,
+                requestRatingChatStatusBadgeText: action.text,
             }
         }
 


### PR DESCRIPTION
Please test this PR together with https://cognigy.visualstudio.com/Cognigy.AI/_git/cognigy/pullrequest/27397 

- When Request Rating node is configured with rating screen title, custom submit text, event banner text and chat status message text, the webchat widget should use these values in Conversation Rating screen.
- If these values are not configured, the Webchat should use the default values.

How to test
- To test this, deploy the branch from the above mentioned PR.
- Create a flow with request rating node and customize it
- Create webchat 3 endpoint and select the flow with the rating node in the endpoint editor
- Save and copy the endpoint URL and use this URL to initialize the webchat