### PR TITLE
Added webpack limitchunkcount plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const TerserPlugin = require("terser-webpack-plugin");
 const zlib = require("zlib");
 const CompressionPlugin = require("compression-webpack-plugin");
+const webpack = require('webpack');
 
 module.exports = {
     mode: 'development',
@@ -70,6 +71,9 @@ module.exports = {
 			},
 			threshold: 10240,
 			minRatio: 0.8,
+		}),
+		new webpack.optimize.LimitChunkCountPlugin({
+			maxChunks: 1
 		}),
     ],
     devServer: {


### PR DESCRIPTION
to reduce the chunks created from the webpack build (with the odd names like 11.webchat.js, see here in assets https://github.com/Cognigy/WebchatWidget/releases/tag/v3.0.0-beta.18), I added the webchat chunk limit plugin.
to test, checkout and run the build, the oddly named chunks should disappear, as they will be bundled into the same chunk, e.g. webchat.js.