### PR TITLE
added logic to display custom watermark

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -8,10 +8,14 @@
 <body>
     <script src="./webchat.js"></script>
     <script>
-            initWebchat('https://endpoint-dev.cognigy.ai/14c8e0ab190c22ec8121cbd7d1cef945727844f7d41aad21cae33654806bacbd', {
+			initWebchat('https://endpoint-dev.cognigy.ai/50ea4877c2d4c0aadd1067fb6391bdda4207399f9d813dbf43cd9d3cf1e23e90', {
             userId: "user1",
             sessionId: "session1",
             settings: {
+				layout: {
+					watermark: "default",
+					watermarkText: "Some Random Watermark"
+				},
                 unreadMessages: {
                     enableIndicator: true,
                     enableBadge: true,  

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -942,7 +942,7 @@ export class WebchatUI extends React.PureComponent<
 			if (isDropZoneVisible)
 				return (
 					<DropZone
-						disableBranding={config.settings.layout.watermark !== "default"}
+						layoutSettings={config.settings.layout}
 						dropzoneText={config.settings.fileStorageSettings?.dropzoneText}
 					/>
 				);

--- a/src/webchat-ui/components/branding/Branding.tsx
+++ b/src/webchat-ui/components/branding/Branding.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from "react";
 import styled from "@emotion/styled";
 import { Typography } from "@cognigy/chat-components";
+import { IWebchatSettings } from "../../../common/interfaces/webchat-config";
 
 const Link = styled.a(({ theme }) => ({
 	display: "flex",
@@ -23,23 +24,40 @@ const Link = styled.a(({ theme }) => ({
 	},
 }));
 
+const Placeholder = styled.div(() => ({
+}));
+
 const URL = `https://www.cognigy.com/?utm_campaign=CognigyWebchatEmbedded&utm_medium=webchat&utm_term=webchat&utm_content=webchat&utm_source=${window.location.hostname}`;
 
 interface IBrandingProps {
 	id?: string;
+	watermark?: IWebchatSettings["layout"]["watermark"];
+	watermarkText?: string;
 }
 
-const Branding: FC<IBrandingProps> = (props) => (
-	<Link
-		href={URL}
-		target="_blank"
-		aria-label="Powered by Cognigy. Opens in new tab"
-		id={props.id ?? "cognigyBrandingLink"}
-	>
-		<Typography variant="copy-medium" component="span" fontSize={10} lineHeight="120%">
-			Powered by Cognigy.AI
-		</Typography>
-	</Link>
-);
+const Branding: FC<IBrandingProps> = (props) => {
+	const { id, watermark, watermarkText } = props;
+
+	if (watermark === "none") return (
+		<Placeholder />
+	);
+
+	return (
+		<Link
+			href={URL}
+			target="_blank"
+			aria-label="Powered by Cognigy. Opens in new tab"
+			id={id ?? "cognigyBrandingLink"}
+		>
+			<Typography variant="copy-medium" component="span" fontSize={10} lineHeight="120%">
+				{(watermark === "custom" && watermarkText) ?
+					watermarkText
+					:
+					"Powered by Cognigy.AI"
+				}
+			</Typography>
+		</Link>
+	);
+}
 
 export default memo(Branding, () => true);

--- a/src/webchat-ui/components/plugins/InputPluginRenderer.tsx
+++ b/src/webchat-ui/components/plugins/InputPluginRenderer.tsx
@@ -107,7 +107,10 @@ const InputPluginRenderer = ({ messages, config, onSendMessage, plugins, inputMo
                 />
             )}
             {/* Branding Logo Link */}
-			{config.settings.layout.watermark === "default" && <Branding />}
+			<Branding
+				watermark={config.settings.layout.watermark}
+				watermarkText={config.settings.layout.watermarkText}
+			/>
         </InputRoot>
     )
 }

--- a/src/webchat-ui/components/plugins/input/file/DropZone.tsx
+++ b/src/webchat-ui/components/plugins/input/file/DropZone.tsx
@@ -6,6 +6,7 @@ import { Typography } from "@cognigy/chat-components";
 import Branding from "../../../branding/Branding";
 import { setDropZoneVisible } from "../../../../../webchat/store/input/input-reducer";
 import { addFilesToList } from "../../../../../webchat/store/input/file-input-middleware";
+import { IWebchatSettings } from "../../../../../common/interfaces/webchat-config";
 
 const componentStyles = () => ({
 	width: "100%",
@@ -40,13 +41,14 @@ const DragDropTypography = styled(Typography)(({ theme }) => ({
 interface IDropZoneProps {
 	disableBranding?: boolean;
 	dropzoneText?: string;
+	layoutSettings?: IWebchatSettings["layout"];
 }
 
 const DropZone: FC<IDropZoneProps> = props => {
 	const dropRef = useRef<HTMLInputElement>(null);
 	const dispatch = useDispatch();
 
-	const { disableBranding, dropzoneText } = props;
+	const { disableBranding, dropzoneText, layoutSettings } = props;
 
 	const handleDragOver = e => {
 		e.preventDefault();
@@ -80,7 +82,11 @@ const DropZone: FC<IDropZoneProps> = props => {
 						{dropzoneText || "Drop to attach"}
 					</DragDropTypography>
 				</DropZoneContent>
-				{!disableBranding && <Branding id="cognigyDropZoneLogo" />}
+				<Branding
+					id="cognigyDropZoneLogo"
+					watermark={layoutSettings?.watermark}
+					watermarkText={layoutSettings?.watermarkText}
+				/>
 			</DropZoneRoot>
 			<DropZoneContainer
 				ref={dropRef}

--- a/src/webchat-ui/components/presentational/HomeScreen.tsx
+++ b/src/webchat-ui/components/presentational/HomeScreen.tsx
@@ -164,8 +164,6 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 
 	const buttons: IWebchatButton[] = config.settings.homeScreen.conversationStarters.starters;
 
-	const disableBranding = config?.settings?.layout?.watermark !== "default";
-
 	const handleShowPrevConversations = () => {
 		onSetShowHomeScreen(false);
 		onSetShowPrevConversations(true);
@@ -235,7 +233,11 @@ export const HomeScreen: React.FC<IHomeScreenProps> = props => {
 						</PrevConversationsButton>
 				}
 				{/* Branding Logo Link */}
-				{!disableBranding && <Branding id="cognigyHomeScreenBranding" />}
+				<Branding
+					id="cognigyHomeScreenBranding"
+					watermark={config?.settings?.layout?.watermark}
+					watermarkText={config?.settings?.layout?.watermarkText}
+				/>
 			</HomeScreenActions>
 		</HomeScreenRoot>
 	);

--- a/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
+++ b/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
@@ -62,8 +62,6 @@ interface IPrevConversationsListProps {
 export const PrevConversationsList = (props: IPrevConversationsListProps) => {
 	const { conversations, config, onSetShowPrevConversations, onSwitchSession } = props;
 
-	const disableBranding = config.settings.layout.watermark !== "default";
-
 	// we sort the conversation based on last message timestamp
 	// result: the last updated conversation goes on top
 	const sortedConversations = sortConversationsByFreshness(conversations);
@@ -108,7 +106,11 @@ export const PrevConversationsList = (props: IPrevConversationsListProps) => {
 				>
 					Start new conversation
 				</StartButton>
-				{!disableBranding && <Branding id="cognigyConversationListBranding" />}
+				<Branding
+					id="cognigyConversationListBranding"
+					watermark={config?.settings?.layout?.watermark}
+					watermarkText={config?.settings?.layout?.watermarkText}
+				/>
 			</ConversationsListActions>
 		</ConversationsListRoot>
 	);


### PR DESCRIPTION
Added the logic to display custom watermark. 

To test, checkout and run dev. 
In the `index.html`, change the value for `watermark` to `custom` to display the value configured as `watermarkText`.
Change `watermark` to `none` to see the webchat without a watermark.

Can be tested with https://cognigy.visualstudio.com/Cognigy.AI/_git/cognigy/pullrequest/27609 for the respective endpoint settings