### PR TITLE
Prevent sending message on IME compositing

### DIFF
--- a/src/webchat-ui/components/plugins/input/text/TextInput.tsx
+++ b/src/webchat-ui/components/plugins/input/text/TextInput.tsx
@@ -313,7 +313,7 @@ export class TextInput extends React.PureComponent<InputComponentProps, TextInpu
      * Shift+Return should insert a "newline" (default)
      */
     handleInputKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = event => {
-        if (event.key === 'Enter' && !event.shiftKey) {
+        if (event.key === 'Enter' && !event.shiftKey && !event?.nativeEvent?.isComposing) {
             event.preventDefault();
             event.stopPropagation();
 


### PR DESCRIPTION
This PR fixes an issue where choosing an input suggestion in, e.g. Japanese IME with enter key, would send the message.

To test you need an MacOS. Add Japanese language, switch to it and start typing into main input field. Press arrow-down key. The suggestions should popup, press enter to choose one of it.

The suggestion should be applied to input, but the message should not be sent to chat.