### PR TITLE
Prevent sending message on IME compositing (v3)

### DIFF
--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -133,7 +133,7 @@ interface ISpeechInputState {
 	isFinalResult: boolean;
 }
 
-interface IBaseInputState extends TextInputState, ISpeechInputState { }
+interface IBaseInputState extends TextInputState, ISpeechInputState {}
 
 interface IBaseInputProps extends InputComponentProps {
 	sttActive: boolean;
@@ -154,11 +154,11 @@ declare global {
 const getSpeechRecognition = (): SpeechRecognition | null => {
 	try {
 		return new SpeechRecognition();
-	} catch (e) { }
+	} catch (e) {}
 
 	try {
 		return new webkitSpeechRecognition() as SpeechRecognition;
-	} catch (e) { }
+	} catch (e) {}
 
 	return null;
 };
@@ -365,7 +365,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 	 * Shift+Return should insert a "newline" (default)
 	 */
 	handleInputKeyDown: React.KeyboardEventHandler<HTMLTextAreaElement> = event => {
-		if (event.key === "Enter" && !event.shiftKey) {
+		if (event.key === "Enter" && !event.shiftKey && !event?.nativeEvent?.isComposing) {
 			event.preventDefault();
 			event.stopPropagation();
 
@@ -392,20 +392,11 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 
 		const { text, textActive, speechResult: speechInterim } = state;
 
-		const {
-			layout,
-			fileStorageSettings,
-			widgetSettings,
-		} = props.config.settings;
+		const { layout, fileStorageSettings, widgetSettings } = props.config.settings;
 
-		const {
-			disableInputAutocomplete,
-			inputAutogrowMaxRows,
-		} = layout;
+		const { disableInputAutocomplete, inputAutogrowMaxRows } = layout;
 
-		const {
-			disableInputAutofocus,
-		} = widgetSettings;
+		const { disableInputAutofocus } = widgetSettings;
 
 		const isFileAttachmentEnabled = fileStorageSettings?.enabled;
 
@@ -461,8 +452,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 							)}
 						</MediaQuery>
 
-						{
-							props.config.settings.behavior.enableSTT &&
+						{props.config.settings.behavior.enableSTT && (
 							<SpeechButton
 								className={classnames(
 									"webchat-input-button-speech",
@@ -491,7 +481,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 								)}
 								<SpeechIcon />
 							</SpeechButton>
-						}
+						)}
 
 						<SubmitButton
 							disabled={


### PR DESCRIPTION
This PR fixes an issue where choosing an input suggestion in, e.g. Japanese IME with enter key, would send the message.

To test you need an MacOS. Add Japanese language, switch to it and start typing into main input field. Press arrow-down key. The suggestions should popup, press enter to choose one of it.

The suggestion should be applied to input, but the message should not be sent to chat.