### PR TITLE
Use settings related to names & avatars in msg header

### DIFF
--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -37,25 +37,25 @@ export type TriggerEngagementMessageAction = ReturnType<typeof triggerEngagement
 export const getAvatarForMessage = (message: IMessage, state: StoreState) => {
     switch (message.source) {
         case 'agent':
-			return state.ui.agentAvatarOverrideUrl || (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.agentLogoUrl) || state.config.settings.layout.logoUrl || defaultAgentAvatar;
+            return state.ui.agentAvatarOverrideUrl || (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.agentLogoUrl) || state.config.settings.layout.logoUrl || defaultAgentAvatar;
         case 'bot':
         case 'engagement':
-			return state.ui.botAvatarOverrideUrl || (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.botLogoUrl) || state.config.settings.layout.logoUrl || undefined;
-		case 'user':
-			return;
-	}
+            return state.ui.botAvatarOverrideUrl || (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.botLogoUrl) || state.config.settings.layout.logoUrl || undefined;
+        case 'user':
+            return;
+    }
 }
 
 export const getAvatarNameForMessage = (message: IMessage, state: StoreState) => {
-	switch (message.source) {
-		case 'agent':
-			return (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.agentAvatarName) || state.config.settings.layout.title || undefined;
-		case 'bot':
-		case 'engagement':
-			return (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.botAvatarName) || state.config.settings.layout.title || undefined;
-		case 'user':
-			return;
-	}
+    switch (message.source) {
+        case 'agent':
+            return (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.agentAvatarName) || state.config.settings.layout.title || undefined;
+        case 'bot':
+        case 'engagement':
+            return (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.botAvatarName) || state.config.settings.layout.title || undefined;
+        case 'user':
+            return;
+    }
 }
 
 // forwards messages to the socket
@@ -65,11 +65,11 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<object
             const { message, options } = action;
             let { text, data } = message;
 
-			if (!store.getState().config.settings.widgetSettings.disableTextInputSanitization) {
+            if (!store.getState().config.settings.widgetSettings.disableTextInputSanitization) {
                 text = sanitizeHTML(text || '');
             }
 
-			if (store.getState().config.settings.widgetSettings.disableHtmlInput) {
+            if (store.getState().config.settings.widgetSettings.disableHtmlInput) {
                 text = new DOMParser()
                     .parseFromString(text || '', 'text/html')
                     .body
@@ -97,7 +97,7 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<object
             next(addMessage({
                 ...displayMessage,
                 avatarUrl: getAvatarForMessage(displayMessage, store.getState()),
-				avatarName: getAvatarNameForMessage(displayMessage, store.getState()),
+                avatarName: getAvatarNameForMessage(displayMessage, store.getState()),
                 timestamp: Date.now(),
             }));
 
@@ -108,7 +108,7 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<object
             const state = store.getState();
             const { message } = action;
             const avatarUrl = getAvatarForMessage(message, state);
-			const avatarName = getAvatarNameForMessage(message, state);
+            const avatarName = getAvatarNameForMessage(message, state);
 
             const isWebchatActive = state.ui.open && state.ui.isPageVisible;
             const isMessageEmpty = !(message.text || message.data?._cognigy?._webchat);
@@ -118,15 +118,15 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<object
                 ...message,
                 source: message.source || 'bot',
                 timestamp: Date.now(),
-				avatarUrl,
-				avatarName,
+                avatarUrl,
+                avatarName,
             } as IBotMessage, isUnseen));
 
             break;
         }
 
         case 'TRIGGER_ENGAGEMENT_MESSAGE': {
-			const text = store.getState().config.settings.teaserMessage.text;
+            const text = store.getState().config.settings.teaserMessage.text;
 
             if (text) {
                 store.dispatch(receiveMessage({

--- a/src/webchat/store/messages/message-middleware.ts
+++ b/src/webchat/store/messages/message-middleware.ts
@@ -12,9 +12,6 @@ import { SocketClient } from "@cognigy/socket-client";
 // a "person" icon
 const defaultAgentAvatar = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAQAAABIkb+zAAACOklEQVR4Ae3ZA2ydURwF8P9s2+bjPSdGo0aN08V+URtbL+a8BbO9xfZs2zaCuW7vbDx8uLfp/3dinw+XopRSSimllFJhYm9TjV08wwdoYB0f8ix2mDkTe0p7YIZxDeto/5I6rjHDxGtdkcc72n8H75CXruKn1CAcpi0cHE4NEv9kp+EubXHB3ew08QuH4hFt8cGj5Ajxx9hePE1bYi6k+4gvMJ+29GCe+CEzhvW0ZaQ+PVZ8wDW0ZWatuJfozrqyC9Qluotr2Sra8pOtEtewMkgBrBLXsC9QgX3iGm4EKnBDXOP7QAXeiWt4G6jAW3ENNwMVuCmu4UCgAgc6/DCqE1miO9+7X0oEgtVlF1gjPkiOKHs5Pbx9b2jme7SlxPmSC5we20v8kRjJh6Vt6jlU/JKZztsBj1XcH2zxGG3h4ERqkPgp0R35AhvMOuQT3cVnyRH/O9wt4zjLzaj00/F6/dfj9WrPj9eVUkqpRPeMMTnMxxbu4fWf5uP3uME93IZ5JpcxHi4lzGjWYgPPsom2cNDIs9jAWjNaXJvaw1RyES/SlpmLXGQqHb0Rgsv5hjaEvOJyIt6lWg4nacMNTppcHMu9LqYGL2ijCZ6bGuki0TEVuEIbbXDFVEgU2JsbaWPKRvYOf6C8SBtjLoY6yKbH4h5tvMHd5DgJR6Ivb9E6yK1EX6c3AMGDlRIcZtG6i5ktQWGpywJYKkHxgtMC5yUo1tM6TL0ERes2WkALaAEtEEm0gFJKKaWUUkp9ABvn3SEbw3cFAAAAAElFTkSuQmCC";
 
-// "white-label friendly" grey background
-const defaultBotAvatar = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKIAAACiCAYAAADC8hYbAAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAclJREFUeJzt0jEBwDAMwLCs/FGGyAqjPiQEPvzt7j/w2HkdADNGJMKIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIglGJMGIJBiRBCOSYEQSjEiCEUkwIgkXp8oE6Yb9phEAAAAASUVORK5CYII="
-
 export interface ISendMessageOptions {
     /** overrides the displayed text within a chat bubble. useful for e.g. buttons */
     label: string;
@@ -40,13 +37,25 @@ export type TriggerEngagementMessageAction = ReturnType<typeof triggerEngagement
 export const getAvatarForMessage = (message: IMessage, state: StoreState) => {
     switch (message.source) {
         case 'agent':
-			return state.ui.agentAvatarOverrideUrl || state.config.settings.layout.agentLogoUrl || defaultAgentAvatar;
+			return state.ui.agentAvatarOverrideUrl || (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.agentLogoUrl) || state.config.settings.layout.logoUrl || defaultAgentAvatar;
         case 'bot':
         case 'engagement':
-			return state.ui.botAvatarOverrideUrl || state.config.settings.layout.botLogoUrl || defaultBotAvatar;
-        case 'user':
+			return state.ui.botAvatarOverrideUrl || (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.botLogoUrl) || state.config.settings.layout.logoUrl || undefined;
+		case 'user':
 			return;
-    }
+	}
+}
+
+export const getAvatarNameForMessage = (message: IMessage, state: StoreState) => {
+	switch (message.source) {
+		case 'agent':
+			return (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.agentAvatarName) || state.config.settings.layout.title || undefined;
+		case 'bot':
+		case 'engagement':
+			return (state.config.settings.layout.useOtherAgentLogo && state.config.settings.layout.botAvatarName) || state.config.settings.layout.title || undefined;
+		case 'user':
+			return;
+	}
 }
 
 // forwards messages to the socket
@@ -88,6 +97,7 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<object
             next(addMessage({
                 ...displayMessage,
                 avatarUrl: getAvatarForMessage(displayMessage, store.getState()),
+				avatarName: getAvatarNameForMessage(displayMessage, store.getState()),
                 timestamp: Date.now(),
             }));
 
@@ -98,6 +108,7 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<object
             const state = store.getState();
             const { message } = action;
             const avatarUrl = getAvatarForMessage(message, state);
+			const avatarName = getAvatarNameForMessage(message, state);
 
             const isWebchatActive = state.ui.open && state.ui.isPageVisible;
             const isMessageEmpty = !(message.text || message.data?._cognigy?._webchat);
@@ -107,7 +118,8 @@ export const createMessageMiddleware = (client: SocketClient): Middleware<object
                 ...message,
                 source: message.source || 'bot',
                 timestamp: Date.now(),
-                avatarUrl
+				avatarUrl,
+				avatarName,
             } as IBotMessage, isUnseen));
 
             break;


### PR DESCRIPTION
This PR implements use of the `useOtherAgentLogo` setting and related other settings. please have a look at the spec or the embedding section for any open technicalities.

The basic idea is:
- the title & logoUrl are used for avatar headers as default
- if useOtherAgentLogo is true, the other variables can be used to have a more granular approach.
 
Best to test it directly with https://cognigy.visualstudio.com/Cognigy.AI/_git/cognigy/pullrequest/27838 for the endpoint settings.
Please test various combinations with the values being set or not.

I also removed the old "botAvatar" base64 image, as that was just a grey circle and we already have a AI-Logo fallback in the chat-components.

See here for the settings you can use in your index.html to configure this
```
settings: {
		layout: {
			title: "",
			logoUrl: "",
			useOtherAgentLogo: false,
			botAvatarName: "",
			botLogoUrl: "",
			agentAvatarName: "",
			agentLogoUrl: "",
                },
}
```