### PR TITLE
Add support for color selection through settings

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -247,20 +247,57 @@ export class WebchatUI extends React.PureComponent<
 		props: WebchatUIProps,
 		state: WebchatUIState,
 	): WebchatUIState | null {
-		const color = props?.config?.settings?.colors?.primaryColor;
+		const primaryColor = props?.config?.settings?.colors?.primaryColor;
+		const secondaryColor = props?.config?.settings?.colors?.secondaryColor;
+		const chatInterfaceColor = props?.config?.settings?.colors?.chatInterfaceColor;
+		const botMessageColor = props?.config?.settings?.colors?.botMessageColor;
+		const userMessageColor = props?.config?.settings?.colors?.userMessageColor;
+		const textLinkColor = props?.config?.settings?.colors?.textLinkColor;
 
-		if (!!color && color !== state.theme.primaryColor) {
+		let isThemeChanged = false;
+
+		if (!!primaryColor && primaryColor !== state.theme.primaryColor) {
 			// We will integrate this into the theme object in the future
 			// This is a demo of injecting a custom color scheme
-			document.documentElement.style.setProperty("--webchat-primary-color", color);
+			document.documentElement.style.setProperty("--webchat-primary-color", primaryColor);
 			// This is example of how a new theme properties can be added
 			// document.documentElement.style.setProperty('--webchat-background-bot-message', color);
 
-			return {
-				...state,
-				theme: createWebchatTheme({ primaryColor: color }),
-			};
+			isThemeChanged = true;
 		}
+
+		if (!!secondaryColor && secondaryColor !== state.theme.secondaryColor) {
+			document.documentElement.style.setProperty("--webchat-secondary-color", secondaryColor);
+			isThemeChanged = true;
+		}
+		if (!!chatInterfaceColor && chatInterfaceColor !== state.theme.backgroundWebchat) {
+			document.documentElement.style.setProperty("--webchat-background-webchat", chatInterfaceColor);
+			isThemeChanged = true;
+		}
+		if (!!botMessageColor && botMessageColor !== state.theme.backgroundBotMessage) {
+			document.documentElement.style.setProperty("--webchat-background-bot-message", botMessageColor);
+			isThemeChanged = true;
+		}
+		if (!!userMessageColor && userMessageColor !== state.theme.backgroundUserMessage) {
+			document.documentElement.style.setProperty("--webchat-background-user-message", userMessageColor);
+			isThemeChanged = true;
+		}
+		if (!!textLinkColor && textLinkColor !== state.theme.textLink) {
+			document.documentElement.style.setProperty("--webchat-text-link", textLinkColor);
+			isThemeChanged = true;
+		}
+
+		if (isThemeChanged) return {
+			...state,
+			theme: createWebchatTheme({
+				primaryColor,
+				secondaryColor,
+				backgroundWebchat: chatInterfaceColor,
+				backgroundBotMessage: botMessageColor,
+				backgroundUserMessage: userMessageColor,
+				textLink: textLinkColor,
+			}),
+		};
 
 		return null;
 	}
@@ -305,9 +342,21 @@ export class WebchatUI extends React.PureComponent<
 	}
 
 	async componentDidUpdate(prevProps: WebchatUIProps, prevState: WebchatUIState) {
-		if (this.props.config.settings.colors.primaryColor !== prevProps.config.settings.colors.primaryColor) {
+		if (this?.props?.config?.settings?.colors?.primaryColor !== prevProps?.config?.settings?.colors?.primaryColor ||
+			this?.props?.config?.settings?.colors?.secondaryColor !== prevProps?.config?.settings?.colors?.secondaryColor ||
+			this?.props?.config?.settings?.colors?.chatInterfaceColor !== prevProps?.config?.settings?.colors?.chatInterfaceColor ||
+			this?.props?.config?.settings?.colors?.botMessageColor !== prevProps?.config?.settings?.colors?.botMessageColor ||
+			this?.props?.config?.settings?.colors?.userMessageColor !== prevProps?.config?.settings?.colors?.userMessageColor ||
+			this?.props?.config?.settings?.colors?.textLinkColor !== prevProps?.config?.settings?.colors?.textLinkColor) {
 			this.setState({
-				theme: createWebchatTheme({ primaryColor: this.props.config.settings.colors.primaryColor }),
+				theme: createWebchatTheme({
+					primaryColor: this?.props?.config?.settings?.colors?.primaryColor,
+					secondaryColor: this?.props?.config?.settings?.colors?.secondaryColor,
+					backgroundWebchat: this?.props?.config?.settings?.colors?.chatInterfaceColor,
+					backgroundBotMessage: this?.props?.config?.settings?.colors?.botMessageColor,
+					backgroundUserMessage: this?.props?.config?.settings?.colors?.userMessageColor,
+					textLink: this?.props?.config?.settings?.colors?.textLinkColor,
+				}),
 			});
 		}
 

--- a/src/webchat-ui/components/presentational/HomeScreen.tsx
+++ b/src/webchat-ui/components/presentational/HomeScreen.tsx
@@ -125,7 +125,7 @@ const HomeScreenActions = styled.div(({ theme }) => ({
 	justifyContent: "center",
 	width: "100%",
 	padding: "20px 20px 12px 20px",
-	backgroundColor: theme.backgroundWebchat,
+	backgroundColor: theme.white,
 }));
 
 const StartButton = styled(PrimaryButton)(() => ({

--- a/src/webchat-ui/components/presentational/chat-options/ChatOptionsFooter.tsx
+++ b/src/webchat-ui/components/presentational/chat-options/ChatOptionsFooter.tsx
@@ -10,7 +10,7 @@ const Footer = styled.div(({ theme }) => ({
 	gap: 24,
 	width: "100%",
 	display: "flex",
-	backgroundColor: theme.backgroundWebchat,
+	backgroundColor: theme.white,
 	borderTop: `1px solid var(--basics-black-80, ${theme.black80})`,
 }));
 

--- a/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
+++ b/src/webchat-ui/components/presentational/previous-conversations/ConversationsList.tsx
@@ -13,7 +13,7 @@ const ConversationsListRoot = styled.div(({ theme }) => ({
 	fontSize: 16,
 	fontWeight: 700,
 	boxSizing: "border-box",
-	backgroundColor: theme.backgroundWebchat,
+	backgroundColor: theme.white,
 	display: "flex",
 	flexDirection: "column",
 	"& *": {
@@ -43,7 +43,7 @@ const ConversationsListActions = styled.div(({ theme }) => ({
 	justifyContent: "center",
 	width: "100%",
 	padding: "20px 20px 12px 20px",
-	backgroundColor: theme.backgroundWebchat,
+	backgroundColor: theme.white,
 	borderTop: `1px solid var(--basics-black-80, ${theme.black80})`,
 }));
 


### PR DESCRIPTION
This PR adds the option to use all colors configurable in the settings in the webchat. the variable colors are used according to the Figma designs.

Test together with:
https://github.com/Cognigy/chat-components/pull/41 to enable the color settings for text-links