### PR TITLE
Bug/61761 fix file attachment re select

### DIFF
--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -378,6 +378,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 		const files = event.target.files;
 		const newFilesArray = Array.prototype.slice.call(files);
 		this.props.onAddFilesToList(newFilesArray);
+		event.target.value = "";
 	};
 
 	handleUploadFile = event => {


### PR DESCRIPTION
Added a fix to reset the file upload so that the same file can be uploaded multiple times in a row
(see https://cognigy.visualstudio.com/Cognigy.AI/_workitems/edit/61761)

To test this behavior:
1. Attach a file in a v3 webchat by clicking the file icon (don't use drag&drop)
2. remove the file
3. Attach again like in 1.