### PR TITLE
Fix file upload autoscrolling issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.0",
-				"@cognigy/chat-components": "0.19.0",
+				"@cognigy/chat-components": "0.19.1",
 				"@cognigy/socket-client": "5.0.0-beta.10",
 				"@emotion/cache": "^10.0.29",
 				"@emotion/react": "^11.7.1",
@@ -2181,9 +2181,9 @@
 			}
 		},
 		"node_modules/@cognigy/chat-components": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/@cognigy/chat-components/-/chat-components-0.19.0.tgz",
-			"integrity": "sha512-tLtggyj/WZxURX6l+PbmGFEZ2QmAb6tD2L3/b5NHixv0h4wztPOJ0QpXOqbu6+EJHRMxcZOSEidmuYkN5hb56g==",
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@cognigy/chat-components/-/chat-components-0.19.1.tgz",
+			"integrity": "sha512-eXpHM0NQ3XyZv53yoT8hQ1ZuCdFZW+ItWfTXjFiJFdDmPbi7ZYmeub5cnCNhb6XAjN+4ZYLszNjvKRJwtIpHdg==",
 			"dependencies": {
 				"@braintree/sanitize-url": "^6.0.4",
 				"@fontsource/figtree": "5.0.18",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	},
 	"dependencies": {
 		"@braintree/sanitize-url": "^6.0.0",
-		"@cognigy/chat-components": "0.19.0",
+		"@cognigy/chat-components": "0.19.1",
 		"@cognigy/socket-client": "5.0.0-beta.10",
 		"@emotion/cache": "^10.0.29",
 		"@emotion/react": "^11.7.1",

--- a/src/webchat-ui/components/plugins/input/file/PreviewUploadedFiles.tsx
+++ b/src/webchat-ui/components/plugins/input/file/PreviewUploadedFiles.tsx
@@ -100,10 +100,13 @@ const PreviewUploadedFiles: FC = () => {
 						<RemoveFileButton
 							onClick={() => onRemoveFileButtonClick(index)}
 							onFocus={() => {
-								removeFileButtonRefs.current[index].scrollIntoView({
-									behavior: "smooth",
-									inline: "center",
-								});
+								if (removeFileButtonRefs.current[index]) {
+									removeFileButtonRefs.current[index].scrollIntoView({
+										behavior: "smooth",
+										inline: "center",
+										block: "nearest",
+									});
+								}
 							}}
 							aria-label={`Remove File Attachment ${index + 1}`}
 							ref={ref => {


### PR DESCRIPTION

The auto scroll behavior from the onFocus event on the attachment items made them scroll to the top, force breaking the layout. This PR fixes that behavior.

### To reproduce:
Please follow repro steps from ticket with attached package (https://cognigy.visualstudio.com/Cognigy.AI/_workitems/edit/63272)


