### PR TITLE
Fix dplicate messgaes in history after re-connecting

### DIFF
--- a/src/webchat/store/reducer.ts
+++ b/src/webchat/store/reducer.ts
@@ -36,7 +36,7 @@ export const reducer = (state = rootReducer(undefined, { type: '' }), action) =>
             return rootReducer({
                 ...state,
                 messages: [
-                    // To avaoid duplicate messages in chat history during re-connection, we only restore messages if the current message history is empty
+                    // To avoid duplicate messages in chat history during re-connection, we only restore messages if the current message history is empty
                     ...state.messages.length === 0 && action.state.messages,
                     ...state.messages,
                 ],

--- a/src/webchat/store/reducer.ts
+++ b/src/webchat/store/reducer.ts
@@ -33,11 +33,13 @@ export const reducer = (state = rootReducer(undefined, { type: '' }), action) =>
     switch (action.type) {
         case 'RESET_STATE': {
             // We only restore messages and prepend them to the current message history
+            console.log(action.state.messages);
+
             return rootReducer({
                 ...state,
                 messages: [
-                    // TODO: Prepending messages causes duplicates in the message history. Find out why messages are prepended in the first place.
-                    // ...action.state.messages,
+                    // To avaoid duplicate messages in chat history during re-connection, we only restore messages if the current message history is empty
+                    ...state.messages.length === 0 && action.state.messages,
                     ...state.messages,
                 ],
                 rating: {

--- a/src/webchat/store/reducer.ts
+++ b/src/webchat/store/reducer.ts
@@ -33,8 +33,6 @@ export const reducer = (state = rootReducer(undefined, { type: '' }), action) =>
     switch (action.type) {
         case 'RESET_STATE': {
             // We only restore messages and prepend them to the current message history
-            console.log(action.state.messages);
-
             return rootReducer({
                 ...state,
                 messages: [

--- a/src/webchat/store/reducer.ts
+++ b/src/webchat/store/reducer.ts
@@ -36,7 +36,8 @@ export const reducer = (state = rootReducer(undefined, { type: '' }), action) =>
             return rootReducer({
                 ...state,
                 messages: [
-                    ...action.state.messages,
+                    // TODO: Prepending messages causes duplicates in the message history. Find out why messages are prepended in the first place.
+                    // ...action.state.messages,
                     ...state.messages,
                 ],
                 rating: {


### PR DESCRIPTION
This PR prevents duplicate messages in chat history by not prepending messages to the message history on re-connect.

Success Criteria:
- Reconnecting behaviour should remain unaffected. Reconnect screen should appear, chat history should not disappear
- In chat history, redunant messages should not appear on re-connecting
- please do a thorough testing to avoid regression

How to test:
- Send a message to the bot and wait for a response.
- Now, in browser console, select network to 'Offline' or simply disconnect your PC's wifi
- After few minutes, put your network to 'No throttling' or connect the wifi back. 
- Check SC