### PR TITLE
Bug/65529 nonclickable postback buttons

### DIFF
--- a/cypress/integration/regressions/65529-unclickable-action-button.spec.ts
+++ b/cypress/integration/regressions/65529-unclickable-action-button.spec.ts
@@ -1,0 +1,16 @@
+describe("When Input is Focused", () => {
+	it("Sends postback on click", () => {
+		cy.visitWebchat();
+		cy.initMockWebchat();
+		cy.openWebchat();
+		cy.startConversation();
+
+		cy.fixture("messages/buttons.json").then(({ text, data, source }) => {
+			cy.receiveMessage(text, data, source);
+		});
+
+		cy.focusInput();
+		cy.contains("foobar005b1").click();
+		cy.get(".webchat-message-row.user").contains("foobar005b1").should("be.visible");
+	});
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -229,3 +229,9 @@ Cypress.Commands.add('updateSettings', (settings: Partial<IWebchatSettings>) => 
 
     return cy.then(() => { });
 });
+
+Cypress.Commands.add("focusInput", () => {
+	cy.get(".webchat-input-message-input").focus();
+
+	return cy.then(() => {});
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -75,5 +75,7 @@ declare namespace Cypress {
        * @param settings - The partial settings object to update.
        */
       updateSettings(settings: any): Chainable<any>;
+
+      focusInput(): Chainable<any>;
     }
   }

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -50,7 +50,6 @@ const TextArea = styled(TextareaAutosize)(({ theme }) => ({
 	"::-webkit-scrollbar-thumb": {
 		backgroundColor: theme.black60,
 	},
-
 }));
 
 const Button = styled.button(({ theme }) => ({
@@ -392,6 +391,18 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 		this.fileInputRef.current?.click();
 	};
 
+	handleFocus = () => {
+		setTimeout(() => {
+			this.props.onSetTextActive(true);
+		}, 200);
+	};
+
+	handleBlur = () => {
+		setTimeout(() => {
+			this.props.onSetTextActive(false);
+		}, 200);
+	};
+
 	render() {
 		const { props, state } = this;
 
@@ -412,7 +423,7 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 		return (
 			<>
 				<InputWrapper data-active={textActive && isFileListEmpty}>
-					<InputForm						
+					<InputForm
 						onSubmit={this.handleSubmit}
 						className={classnames("webchat-input-menu-form")}
 					>
@@ -443,8 +454,8 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 									autoFocus={!disableInputAutofocus}
 									value={combineStrings(text, speechInterim)}
 									onChange={this.handleChangeTextValue}
-									onFocus={() => this.props.onSetTextActive(true)}
-									onBlur={() => this.props.onSetTextActive(false)}
+									onFocus={this.handleFocus}
+									onBlur={this.handleBlur}
 									onKeyDown={this.handleInputKeyDown}
 									placeholder={props.config.settings.behavior.inputPlaceholder}
 									className="webchat-input-message-input"

--- a/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
+++ b/src/webchat-ui/components/plugins/input/base/BaseInput.tsx
@@ -207,6 +207,11 @@ export class BaseInput extends React.PureComponent<IBaseInputProps, IBaseInputSt
 		window.WebChatInputTextCallback = (text: string) => {
 			this.setState({ text });
 		};
+		setTimeout(() => {
+			if (!this.props.config.settings.widgetSettings.disableInputAutofocus) {
+				this.inputRef.current?.focus?.();
+			}
+		}, 200);
 	}
 
 	componentDidUpdate() {


### PR DESCRIPTION
This PR fixes an issue where postback buttons were only active if clicking on them twice. Besides that, I have found an issue with text input not being autofocused. This is also fixed.

Also added a regression test for the case.

# How to test

- Add some flow outputting Buttons / QRs.
- Receive message
- Click text input
- Try to click a postback button
It should work.