### PR TITLE
Avoid duplicate message in history on re-connect in (v3)

### DIFF
--- a/src/webchat/store/reducer.ts
+++ b/src/webchat/store/reducer.ts
@@ -48,11 +48,14 @@ export type SetPrevStateAction = ReturnType<typeof setPrevState>;
 export const reducer = (state = rootReducer(undefined, { type: "" }), action) => {
 	switch (action.type) {
 		case "RESET_STATE": {
-			// We only restore messages and prepend them to the current message history
 			return rootReducer(
 				{
 					...state,
-					messages: [...action.state.messages, ...state.messages],
+					messages: [
+						// To avoid duplicate messages in chat history during re-connection, we only restore messages and prepend them if the current message history is empty
+						...state.messages.length === 0 ? action.state.messages : [],
+						...state.messages
+					],
 					rating: {
 						...state.rating,
 						hasGivenRating: action.state.rating.hasGivenRating,


### PR DESCRIPTION
This PR prevents duplicate messages in chat history by not prepending messages to the message history on re-connect.

Success Criteria:

- Reconnecting behaviour should remain unaffected. Reconnect screen should appear, chat history should not disappear
- In chat history, redunant messages should not appear on re-connecting
- please do a thorough testing to avoid regression
- When a session id is defined in index.html, then the chat history should be restored even after page reload
- When session id is not defined in index.htm, then reloding the page should clear the chat history

How to test:

- Send a message to the bot and wait for a response.
- Now, in browser console, select network to 'Offline' or simply disconnect your PC's wifi
- After few minutes, put your network to 'No throttling' or connect the wifi back.
- Check SC