### PR TITLE
Fixed teaser message not using configured logo

### DIFF
--- a/src/webchat-ui/components/presentational/TeaserMessage.tsx
+++ b/src/webchat-ui/components/presentational/TeaserMessage.tsx
@@ -10,6 +10,7 @@ import { WebchatUIProps } from "../WebchatUI";
 import { IWebchatConfig } from "../../../common/interfaces/webchat-config";
 import { ISendMessageOptions } from "../../../webchat/store/messages/message-middleware";
 import { useMediaQuery } from "react-responsive";
+import { Logo } from "./Header";
 
 const TeaserMessageRoot = styled.div(() => ({
 	position: "fixed",
@@ -60,6 +61,10 @@ const ButtonContainer = styled.div(() => ({
 		gap: "8px",
 		flexWrap: "wrap",
 	},
+}));
+
+const HeaderLogo = styled(Logo)(() => ({
+	marginInline: 0,
 }));
 
 interface ITeaserMessageProps {
@@ -114,7 +119,15 @@ export const TeaserMessage = (props: ITeaserMessageProps) => {
 				aria-live="polite"
 			>
 				<TeaserMessageHeader>
-					<CognigyAIAvatar />
+					{config?.settings?.layout?.logoUrl ? (
+						<HeaderLogo
+							src={config?.settings?.layout?.logoUrl}
+							className={"webchat-teaser-message-header-logo"}
+							alt="Chat logo"
+						/>
+					) : (
+						<CognigyAIAvatar alt="Chat logo" />
+					)}
 					<TeaserMessageHeaderContent>
 						<Typography
 							variant="title2-regular"


### PR DESCRIPTION
Fixed bug https://cognigy.visualstudio.com/Cognigy.AI/_workitems/edit/67960

to test:
1. configure webchat with teaser message and custom logo url
2. verify that teaser message now uses the custom logo