### PR TITLE
Bug/61922 implement source direction mapping v3

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -546,7 +546,6 @@ interface IWebchatSettings {
 		sourceDirectionMapping: {
 			agent: TSourceDirection;
 			bot: TSourceDirection;
-			engagement: TSourceDirection;
 			user: TSourceDirection;
 		};
 		sourceColorMapping: {

--- a/src/common/interfaces/webchat-config.ts
+++ b/src/common/interfaces/webchat-config.ts
@@ -315,7 +315,6 @@ export interface IWebchatSettings {
 		sourceDirectionMapping: {
 			agent: TSourceDirection;
 			bot: TSourceDirection;
-			engagement: TSourceDirection;
 			user: TSourceDirection;
 		};
 		sourceColorMapping: {

--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -1268,7 +1268,7 @@ export class WebchatUI extends React.PureComponent<
 					/>
 				)}
 				{enableTypingIndicator && (
-					<TypingIndicator active={isTyping} delay={messageDelay} />
+					<TypingIndicator active={isTyping} delay={messageDelay} direction={config?.settings?.widgetSettings?.sourceDirectionMapping?.bot || "incoming"}/>
 				)}
 			</>
 		);

--- a/src/webchat-ui/components/history/TypingIndicator.tsx
+++ b/src/webchat-ui/components/history/TypingIndicator.tsx
@@ -3,10 +3,12 @@ import styled from "@emotion/styled";
 import { TypingIndicator as ComponentsTypingIndicator } from "@cognigy/chat-components";
 
 import { useIsMounted } from "../../utils/is-mounted";
+import { TSourceDirection } from "../../../common/interfaces/webchat-config";
 
 interface ITypingIndicatorProps {
 	active: boolean;
 	delay?: number;
+	direction?: TSourceDirection;
 }
 
 const ChatTypingIndicator = styled(ComponentsTypingIndicator)({
@@ -18,7 +20,7 @@ const HiddenChatTypingIndicator = styled(ChatTypingIndicator)({
 });
 
 const TypingIndicator: FC<ITypingIndicatorProps> = props => {
-	const { active, delay } = props;
+	const { active, delay, direction } = props;
 
 	const isMounted = useIsMounted();
 
@@ -52,7 +54,7 @@ const TypingIndicator: FC<ITypingIndicatorProps> = props => {
 
 	if (!isVisible) return <HiddenChatTypingIndicator />;
 
-	return <ChatTypingIndicator />;
+	return <ChatTypingIndicator direction={direction} />;
 };
 
 export default TypingIndicator;

--- a/src/webchat/store/config/config-reducer.ts
+++ b/src/webchat/store/config/config-reducer.ts
@@ -191,7 +191,6 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 			sourceDirectionMapping: {
 				agent: 'incoming',
 				bot: 'incoming',
-				engagement: 'incoming',
 				user: 'outgoing',
 			},
 			sourceColorMapping: {


### PR DESCRIPTION
Test this along with https://github.com/Cognigy/chat-components/pull/60

- In index.html define the sourceDirectionMapping object.
- When a message source has the direction 'incoming', the bubble should be aligned to the left
- When a message source has the direction 'outcoming', the bubble should be aligned to the right
- Check the alignment of the typing indicator - should be aligned with the bot message direction