### PR TITLE
changed minimize icon

### DIFF
--- a/src/webchat-ui/assets/minimize-16px.svg
+++ b/src/webchat-ui/assets/minimize-16px.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 -960 960 960" width="16" fill="none">
-<path d="M288-144v-72h384v72H288Z"/>
+	<path d="M180.78-427v-106h598.44v106H180.78Z"/>
 </svg>


### PR DESCRIPTION
Following the accpetance meeting, we agreed to increase the size of the minimize icon and to move it to the vertical center. This was achieved by switching to the material icon known as "Remove".

for testing just deploy and go to the chat window.

see below images for comparison:

Before
![Screenshot from 2024-06-05 15-54-38](https://github.com/Cognigy/WebchatWidget/assets/30043753/c745e6c4-d4bb-4dde-85e0-174dbab2f6e8)

After
![Screenshot from 2024-06-05 15-54-43](https://github.com/Cognigy/WebchatWidget/assets/30043753/0a0b4149-1b59-4dca-9085-eb3056443469)
