### PR TITLE
Browser APIs in xApp Overlay

### DIFF
--- a/src/webchat-ui/components/functional/xapp-overlay/XAppOverlay.tsx
+++ b/src/webchat-ui/components/functional/xapp-overlay/XAppOverlay.tsx
@@ -129,7 +129,18 @@ const xAppOverlay: FC = () => {
 					onClose={showCloseIcon ? handleCloseIconClick : undefined}
 				/>
 			)}
-			<Iframe src={url} />
+			<Iframe
+				src={url}
+				allow="
+  accelerometer; ambient-light-sensor; autoplay; battery; bluetooth; camera; 
+  cross-origin-isolated; display-capture; document-domain; encrypted-media; 
+  execution-while-not-rendered; execution-while-out-of-viewport; 
+  fullscreen; gamepad; geolocation; gyroscope; hid; idle-detection; 
+  interest-cohort; local-fonts; magnetometer; microphone; midi; 
+  otp-credentials; payment; picture-in-picture; publickey-credentials-get; 
+  screen-wake-lock; serial; speaker-selection; usb; web-share; 
+  xr-spatial-tracking"
+			/>
 		</Root>
 	);
 };


### PR DESCRIPTION
This PR fixes an issue, where Geolocation- and Camera- APIs were not available for the xApps displayed in the overlay.

To fix the issue, we declare all current stable “feature policies” as allowed on overlay's iframe.
Reference link: https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md

# How to test
- Use attached packages to this issue:
https://cognigy.visualstudio.com/Cognigy.AI/_workitems/edit/70615
- Talk to a bot, allow access to the location.

It should display a map with your position.