### PR TITLE
Fix session issue on teaser and preview messages

### DIFF
--- a/src/webchat-ui/components/WebchatUI.tsx
+++ b/src/webchat-ui/components/WebchatUI.tsx
@@ -744,6 +744,13 @@ export class WebchatUI extends React.PureComponent<
 		this.props.onSetShowChatOptionsScreen(false);
 	};
 
+	openConversationFromTeaser = () => {
+		// in this case we always open to current session
+		this.props.onToggle();
+		this.props.onSetShowHomeScreen(false);
+		this.props.onSetShowChatOptionsScreen(false);
+	};
+
 	render() {
 		const { props, state } = this;
 		const {
@@ -919,7 +926,7 @@ export class WebchatUI extends React.PureComponent<
 											lastUnseenMessageText && (
 												<TeaserMessage
 													messageText={lastUnseenMessageText}
-													onClick={this.handleStartConversation}
+													onClick={this.openConversationFromTeaser}
 													config={config}
 													onEmitAnalytics={onEmitAnalytics}
 													onSendActionButtonMessage={


### PR DESCRIPTION
This PR fixes a bug where we open a new session when user clicks on teaser or preview messages, if chat is closed. We now open to the current session.

Bug item related to this PR: [#65649](https://cognigy.visualstudio.com/Cognigy.AI/_workitems/edit/65649)

This PR will probably solves also [this issue](https://cognigy.visualstudio.com/Cognigy.AI/_workitems/edit/71613), need to verify separately.